### PR TITLE
Add Trivy scan (NDISC-61)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -144,17 +144,31 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@2b6a709cf9c4025c5438138008beaddbb02086f0
         with:
           scan-type: 'fs'
-          ignore-unfixed: true
           format: 'sarif'
           output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH' #ignored by sarif report
-
+          severity: 'CRITICAL,HIGH' #ignored by sarif report 
+      - name: Check trivy results
+        run: |
+          if grep -qE 'HIGH|CRITICAL' trivy-results.sarif; then
+            echo "Vulnerabilities found"
+            exit 1
+          else
+            echo "No significant vulnerabilities found"
+            exit 0
+          fi
       - name: Upload Trivy scan results to GitHub Security tab
+        if: ${{ always() && github.ref == 'refs/heads/main' }} # Bypass non-zero exit code..
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
+      - name: Send status to Slack
+        # Third-party action, pin to commit SHA!
+        # See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
+        uses: digitalservicebund/notify-on-failure-gha@06092d732d0689b3593241ee64954f2ad29ed144 # v1.2.0
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+        with:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -152,7 +152,7 @@ jobs:
           ignore-unfixed: true
           format: 'sarif'
           output: 'trivy-results.sarif'
-          severity: 'CRITICAL'
+          severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [**]
+    branches: [*]
   # Allow to run this workflow manually
   workflow_dispatch:
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,7 +6,8 @@ name: Pipeline
 on:
   push:
     branches: [main]
-  pull_request: # all branches
+  pull_request: 
+    branches: [main]
   # Allow to run this workflow manually
   workflow_dispatch:
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [**]
   # Allow to run this workflow manually
   workflow_dispatch:
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,8 +6,7 @@ name: Pipeline
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [*]
+  pull_request: # all branches
   # Allow to run this workflow manually
   workflow_dispatch:
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -140,7 +140,7 @@ jobs:
 # by the documentation
 
   trivy-scan:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -136,3 +136,26 @@ jobs:
         if: ${{ failure() }}
         with:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+# by the documentation
+
+  trivy-scan:
+    name: Build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -146,7 +146,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@2b6a709cf9c4025c5438138008beaddbb02086f0
         with:
           scan-type: 'fs'
           ignore-unfixed: true

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -139,7 +139,6 @@ jobs:
 # by the documentation
 
   trivy-scan:
-    name: Build
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -152,7 +152,7 @@ jobs:
           ignore-unfixed: true
           format: 'sarif'
           output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
+          severity: 'CRITICAL,HIGH' #ignored by sarif report
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2


### PR DESCRIPTION
I did not use the template which scanned an image.
Instead I followed the docs: on [Git repository scanning](https://github.com/aquasecurity/trivy-action#using-trivy-to-scan-your-git-repo)

Here's how a scan looks like: https://github.com/digitalservicebund/ris-norms/actions/runs/7019008273/job/19095553247

It *does* add data to the "GitHub Security Tab"