### PR TITLE
Cache frontend npm cache (not node-modules)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -314,14 +314,14 @@ jobs:
           node-version-file: ./vscode-extension/package.json
           cache: npm
           cache-dependency-path: ./vscode-extension/package-lock.json
-      - name: Cache node_modules
+      - name: Cache npm cache
         uses: actions/cache@v4
-        id: node-modules-cache
+        id: cache-npm-cache
         with:
-          path: ./vscode-extension/node_modules
-          key: modules-${{ hashFiles('./vscode-extension/package-lock.json') }}
-      - name: Install dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+          # The docs discourage caching `node-modules`, cf. https://github.com/actions/cache/blob/main/examples.md#node---npm
+          path: /home/runner/.npm
+          key: npm-cache-${{ hashFiles('./vscode-extension/package-lock.json') }}
+      - name: Install node modules
         run: npm ci
         working-directory: ./vscode-extension
       - name: Check style

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -407,14 +407,14 @@ jobs:
           node-version-file: ./vscode-extension/package.json
           cache: npm
           cache-dependency-path: ./vscode-extension/package-lock.json
-      - name: Cache node_modules
+      - name: Cache npm cache
         uses: actions/cache@v4
-        id: node-modules-cache
+        id: cache-npm-cache
         with:
-          path: ./vscode-extension/node_modules
-          key: modules-${{ hashFiles('./vscode-extension/package-lock.json') }}
-      - name: Install dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+          # The docs discourage caching `node-modules`, cf. https://github.com/actions/cache/blob/main/examples.md#node---npm
+          path: /home/runner/.npm
+          key: npm-cache-${{ hashFiles('./vscode-extension/package-lock.json') }}
+      - name: Install node modules
         run: npm ci
         working-directory: ./vscode-extension
       - name: Build + Pack Extension

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -870,7 +870,14 @@ jobs:
           node-version-file: ./system-tests/package.json
           cache: npm
           cache-dependency-path: ./system-tests/package-lock.json
-      - name: Install dependencies
+      - name: Cache npm cache
+        uses: actions/cache@v4
+        id: cache-npm-cache
+        with:
+          # The docs discourage caching `node-modules`, cf. https://github.com/actions/cache/blob/main/examples.md#node---npm
+          path: /home/runner/.npm
+          key: npm-cache-${{ hashFiles('./system-tests/package-lock.json') }}
+      - name: Install node modules
         run: npm ci
         working-directory: ./system-tests
       - name: Run license scanner

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -451,12 +451,16 @@ jobs:
           node-version-file: ./vscode-extension/package.json
           cache: npm
           cache-dependency-path: ./vscode-extension/package-lock.json
-      - name: Cache node_modules
+      - name: Cache npm cache
         uses: actions/cache@v4
-        id: node-modules-cache
+        id: cache-npm-cache
         with:
-          path: ./vscode-extension/node_modules
-          key: modules-${{ hashFiles('./vscode-extension/package-lock.json') }}
+          # The docs discourage caching `node-modules`, cf. https://github.com/actions/cache/blob/main/examples.md#node---npm
+          path: /home/runner/.npm
+          key: npm-cache-${{ hashFiles('./vscode-extension/package-lock.json') }}
+      - name: Install node modules
+        run: npm ci
+        working-directory: vscode-extension
       - name: Install SonarScanner
         uses: digitalservicebund/github-actions/setup-sonarscanner@7c3c5fd3b1467215f9e6c66181a37538607999b1
       - name: Establish virtual display buffer
@@ -469,7 +473,6 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           DISPLAY: ":99.0"
         run: |
-          npm ci
           npm run coverage
           sonar-scanner
         working-directory: ./vscode-extension

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -162,14 +162,14 @@ jobs:
           node-version-file: ./frontend/package.json
           cache: npm
           cache-dependency-path: ./frontend/package-lock.json
-      - name: Cache node_modules
+      - name: Cache npm cache
         uses: actions/cache@v4
-        id: node-modules-cache
+        id: cache-npm-cache
         with:
-          path: ./frontend/node_modules
-          key: modules-${{ hashFiles('./frontend/package-lock.json') }}
-      - name: Install dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+          # The docs discourage caching `node-modules`, cf. https://github.com/actions/cache/blob/main/examples.md#node---npm
+          path: /home/runner/.npm
+          key: npm-cache-${{ hashFiles('./frontend/package-lock.json') }}
+      - name: Install node modules
         run: npm ci
         working-directory: ./frontend
       - name: Check style

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -371,20 +371,20 @@ jobs:
           node-version-file: ./vscode-extension/package.json
           cache: npm
           cache-dependency-path: ./vscode-extension/package-lock.json
-      - name: Cache node_modules
+      - name: Cache npm cache
         uses: actions/cache@v4
-        id: node-modules-cache
+        id: cache-npm-cache
         with:
-          path: ./vscode-extension/node_modules
-          key: modules-${{ hashFiles('./vscode-extension/package-lock.json') }}
+          # The docs discourage caching `node-modules`, cf. https://github.com/actions/cache/blob/main/examples.md#node---npm
+          path: /home/runner/.npm
+          key: npm-cache-${{ hashFiles('./vscode-extension/package-lock.json') }}
+      - name: Install node modules
+        run: npm ci
+        working-directory: vscode-extension
       - name: Establish virtual display buffer
         run: |
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
           echo "Xvfb started"
-      - name: Install dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        run: npm ci
-        working-directory: ./vscode-extension
       - name: Run tests
         run: npm test
         working-directory: ./vscode-extension

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -270,7 +270,14 @@ jobs:
           node-version-file: ./frontend/package.json
           cache: npm
           cache-dependency-path: ./frontend/package-lock.json
-      - name: Install dependencies
+      - name: Cache npm cache
+        uses: actions/cache@v4
+        id: cache-npm-cache
+        with:
+          # The docs discourage caching `node-modules`, cf. https://github.com/actions/cache/blob/main/examples.md#node---npm
+          path: /home/runner/.npm
+          key: npm-cache-${{ hashFiles('./frontend/package-lock.json') }}
+      - name: Install node modules
         run: npm ci
         working-directory: ./frontend
       - name: Run license scanner

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -222,12 +222,16 @@ jobs:
           node-version-file: ./frontend/package.json
           cache: npm
           cache-dependency-path: ./frontend/package-lock.json
-      - name: Cache node_modules
+      - name: Cache npm cache
         uses: actions/cache@v4
-        id: node-modules-cache
+        id: cache-npm-cache
         with:
-          path: analyze-frontend:./frontend/node_modules
-          key: modules-${{ hashFiles('./frontend/package-lock.json') }}
+          # The docs discourage caching `node-modules`, cf. https://github.com/actions/cache/blob/main/examples.md#node---npm
+          path: /home/runner/.npm
+          key: npm-cache-${{ hashFiles('./frontend/package-lock.json') }}
+      - name: Install node modules
+        run: npm ci
+        working-directory: ./frontend
       - name: Install SonarScanner
         uses: digitalservicebund/github-actions/setup-sonarscanner@7c3c5fd3b1467215f9e6c66181a37538607999b1
       - name: Establish virtual display buffer
@@ -240,7 +244,6 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           DISPLAY: ":99.0"
         run: |
-          npm ci
           npm run coverage
           sonar-scanner
         working-directory: ./frontend

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -841,14 +841,14 @@ jobs:
           node-version-file: ./system-tests/package.json
           cache: npm
           cache-dependency-path: ./system-tests/package-lock.json
-      - name: Cache node_modules
+      - name: Cache npm cache
         uses: actions/cache@v4
-        id: node-modules-cache
+        id: cache-npm-cache
         with:
-          path: ./system-tests/node_modules
-          key: modules-${{ hashFiles('./system-tests/package-lock.json') }}
-      - name: Install dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+          # The docs discourage caching `node-modules`, cf. https://github.com/actions/cache/blob/main/examples.md#node---npm
+          path: /home/runner/.npm
+          key: npm-cache-${{ hashFiles('./system-tests/package-lock.json') }}
+      - name: Install node modules
         run: npm ci
         working-directory: ./system-tests
       - name: Check style

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -191,14 +191,14 @@ jobs:
           node-version-file: ./frontend/package.json
           cache: npm
           cache-dependency-path: ./frontend/package-lock.json
-      - name: Cache node_modules
+      - name: Cache npm cache
         uses: actions/cache@v4
-        id: node-modules-cache
+        id: cache-npm-cache
         with:
-          path: ./frontend/node_modules
-          key: modules-${{ hashFiles('./frontend/package-lock.json') }}
-      - name: Install dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+          # The docs discourage caching `node-modules`, cf. https://github.com/actions/cache/blob/main/examples.md#node---npm
+          path: /home/runner/.npm
+          key: npm-cache-${{ hashFiles('./frontend/package-lock.json') }}
+      - name: Install node modules
         run: npm ci
         working-directory: ./frontend
       - name: Check style

--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -27,6 +27,7 @@ jobs:
           node-version-file: ./frontend/.node-version
           cache: npm
           cache-dependency-path: ./frontend/package-lock.json
+      # TODO: don't cache node-modules, but the npm cache itself
       - name: cache node modules
         id: cache-node
         uses: actions/cache@v3

--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -35,9 +35,7 @@ jobs:
           path: /home/runner/.npm
           key: npm-cache-${{ hashFiles('./frontend/package-lock.json') }}
       - name: Install node modules
-        if: steps.cache-npm-cache.outputs.cache-hit != 'true'
-        run: |
-          npm ci
+        run: npm ci
         working-directory: ./frontend
       - name: Get Playwright version
         working-directory: ./frontend

--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -27,13 +27,12 @@ jobs:
           node-version-file: ./frontend/.node-version
           cache: npm
           cache-dependency-path: ./frontend/package-lock.json
-      - name: Cache npm cache 
+      - name: Cache npm cache
+        uses: actions/cache@v4
         id: cache-npm-cache
-        uses: actions/cache@v3
         with:
           # The docs discourage caching `node-modules`, cf. https://github.com/actions/cache/blob/main/examples.md#node---npm
-          path: |
-            /home/runner/.npm
+          path: /home/runner/.npm
           key: modules-${{ hashFiles('./frontend/package-lock.json') }}
       - name: Install node modules
         if: steps.cache-npm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -28,6 +28,8 @@ jobs:
           cache: npm
           cache-dependency-path: ./frontend/package-lock.json
       # TODO: don't cache node-modules, but the npm cache itself
+      - name: Where's the npm cache?
+        run: npm config get cache
       - name: cache node modules
         id: cache-node
         uses: actions/cache@v3

--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -27,18 +27,16 @@ jobs:
           node-version-file: ./frontend/.node-version
           cache: npm
           cache-dependency-path: ./frontend/package-lock.json
-      # TODO: don't cache node-modules, but the npm cache itself
-      - name: Where's the npm cache?
-        run: npm config get cache
-      - name: cache node modules
-        id: cache-node
+      - name: Cache npm cache 
+        id: cache-npm-cache
         uses: actions/cache@v3
         with:
+          # The docs discourage caching `node-modules`, cf. https://github.com/actions/cache/blob/main/examples.md#node---npm
           path: |
-            ./frontend/node_modules
+            /home/runner/.npm
           key: modules-${{ hashFiles('./frontend/package-lock.json') }}
       - name: Install node modules
-        if: steps.cache-node.outputs.cache-hit != 'true'
+        if: steps.cache-npm-cache.outputs.cache-hit != 'true'
         run: |
           npm ci
         working-directory: ./frontend

--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           # The docs discourage caching `node-modules`, cf. https://github.com/actions/cache/blob/main/examples.md#node---npm
           path: /home/runner/.npm
-          key: modules-${{ hashFiles('./frontend/package-lock.json') }}
+          key: npm-cache-${{ hashFiles('./frontend/package-lock.json') }}
       - name: Install node modules
         if: steps.cache-npm-cache.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
As per the docs of the `cache` action, we should cache the npm cache and not the `node-modules` folder.