### PR TITLE
Skip analyze steps on dependabot actions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -109,6 +109,7 @@ jobs:
 
   analyze-time-machine:
     runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -109,7 +109,7 @@ jobs:
 
   analyze-time-machine:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot' }}
+    if: ${{ github.actor != 'dependabot' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -213,6 +213,7 @@ jobs:
 
   analyze-frontend:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -449,6 +450,7 @@ jobs:
 
   analyze-vscode-extension:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Dependabot does not have access to sonar tokens, so they always fail.
In addition, dependabot can hardly break sonar.