### PR TITLE
chore: Internal GitHub Action migration

### DIFF
--- a/.github/workflows/frontend-jobs.yml
+++ b/.github/workflows/frontend-jobs.yml
@@ -94,7 +94,7 @@ jobs:
         run: npm ci
         working-directory: ./frontend
       - name: Install SonarScanner
-        uses: digitalservicebund/github-actions/setup-sonarscanner@7c3c5fd3b1467215f9e6c66181a37538607999b1
+        uses: digitalservicebund/setup-sonarscanner@3ade23691f865c02dce6b46452947a0e7944196e # v1.0.0
       - name: Establish virtual display buffer
         run: |
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -64,7 +64,7 @@ jobs:
      steps:
        - uses: chainguard-dev/actions/setup-gitsign@ac42db4c9c2e2bd9f66aadf3290c5995891d91a3
        - name: Deploy new images
-         uses: digitalservicebund/github-actions/argocd-deploy@0ec47e73b6068bde71db075af6bf9ae27cb08b1b
+         uses: digitalservicebund/argocd-deploy@4fac1bb67c92ed168f6d9b22f8779ce241a9e412 # v1.0.0
          with:
            environment: staging
            version: ${{ github.sha }}
@@ -75,7 +75,7 @@ jobs:
            argocd_pipeline_password: ${{ secrets.ARGOCD_PIPELINE_PASSWORD }}
            argocd_server: ${{ secrets.ARGOCD_SERVER }}
        - name: Track deploy
-         uses: digitalservicebund/github-actions/track-deployment@34a48d29a9c4cc2fd6710b8eb37e13618a08fa88
+         uses: digitalservicebund/track-deployment@5a2815e150e1268983aac5ca04c8c046ed1b614a # v1.0.0
          with:
            project: ris-norms
            environment: staging


### PR DESCRIPTION
As mentioned [here](https://digitalservicebund.slack.com/archives/C03M9TZTDK8/p1710341286056739), we have to split our internal GitHub actions repo. This PR update your CI configuration to point to the new repositories. Please, review and merge this PR. Don't hesitate to contact the Platform team if you run into any issue.