### PR TITLE
Renderings Endpoint

### DIFF
--- a/doc/backend/norms-api-v1.yaml
+++ b/doc/backend/norms-api-v1.yaml
@@ -204,6 +204,30 @@ paths:
               schema:
                 type: string
 
+  /renderings:
+    post:
+      summary: Create and return an HTML rendering of the provided LDML.de XML
+      parameters:
+        - in: query
+          name: show_metadata
+          schema:
+            type: boolean
+            default: false
+          description: Should the metadata table be included?
+      requestBody:
+        description: The LDML.de XML
+        required: true
+        content:
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/LegalDocML.de'
+      responses:
+        '200':
+          description: HTML rendering the provided LDML.de XML
+          content:
+            text/html:
+              schema:
+                type: string
 
 components:
   schemas:


### PR DESCRIPTION
We currently create the HTML-render for different laws by using different endpoints and the `Accept: text/html` header. This does not yet support the use case of rendering a not yet saved law for eg. the metadata preview.
We also have two different rendering modes: one including the metadata table and one without this table. Currently the decision which mode to use is based on the endpoint (eg. target-laws get rendered with metadata and amending-laws without metadata). For different parts of our application we need a more fine grained way to decide when to use which render mode (eg. render a target-law without the metadata table).

Therefor a new endpoint is proposed that can handle both of these use cases by:
1. rendering any law whose XML representation is send to the endpoint
2. having a Query parameter that decides which rendering mode to use

As our api is resource based I propose the URL `/renderings` for this endpoint (think "create a new rendering-resource for the given XML")