### PR TITLE
Prototype for node selection & copying elis

### DIFF
--- a/frontend/src/components/RisLawPreview.vue
+++ b/frontend/src/components/RisLawPreview.vue
@@ -123,8 +123,8 @@ watch(
 </template>
 
 <style scoped>
-.highlight-mods :deep([data-eId]) {
-  @apply -mx-2 px-2;
+:deep([data-eId]) {
+  @apply align-top;
 }
 
 :deep(:is(table, thead, td)) {
@@ -243,9 +243,5 @@ watch(
 /* This is currently unused as the .selected class is never applied to elements */
 .highlight-affected-document :deep(.akn-affectedDocument.selected) {
   @apply border border-solid border-highlight-affectedDocument-border bg-highlight-affectedDocument-selected px-2;
-}
-
-.highlight-mods :deep([data-eId]):hover {
-  @apply bg-yellow-900 bg-opacity-15;
 }
 </style>

--- a/frontend/src/components/RisLawPreview.vue
+++ b/frontend/src/components/RisLawPreview.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { watch } from "vue"
+import { nextTick, ref, watch } from "vue"
 
 /**
  * Slots
@@ -76,6 +76,18 @@ watch(
 function teleportEidSlotNameToEid(slotName: string) {
   return slotName.substring(4)
 }
+
+const contentHash = ref("")
+watch(
+  () => props.content,
+  async () => {
+    await nextTick()
+    contentHash.value = props.content
+    props.selectedEids.forEach((element) => {
+      getElementByEid(element)?.classList.add("selected")
+    })
+  },
+)
 </script>
 
 <template>
@@ -98,7 +110,7 @@ function teleportEidSlotNameToEid(slotName: string) {
       v-for="name in Object.keys($slots).filter((key) =>
         key.startsWith('eid:'),
       )"
-      :key="name"
+      :key="`${contentHash}-${name}`"
     >
       <Teleport
         v-if="getElementByEid(teleportEidSlotNameToEid(name))"

--- a/frontend/src/composables/useAmendingLawHtml.spec.ts
+++ b/frontend/src/composables/useAmendingLawHtml.spec.ts
@@ -19,7 +19,7 @@ describe("useAmendingLawHtml", () => {
     const eli = ref(
       "eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1",
     )
-    const html = useAmendingLawHtml(eli)
+    const { html } = useAmendingLawHtml(eli)
     await vi.waitUntil(() => html.value)
 
     expect(html.value).toBe("<div></div>")

--- a/frontend/src/composables/useTargetLawHtml.ts
+++ b/frontend/src/composables/useTargetLawHtml.ts
@@ -1,5 +1,5 @@
 import { MaybeRefOrGetter, Ref, readonly, ref, toValue, watch } from "vue"
-import { getAmendingLawHtmlByEli } from "@/services/amendingLawsService"
+import { getTargetLawHtmlByEli } from "@/services/targetLawsService"
 
 /**
  * Get the rendered HTML of an amending law.
@@ -9,29 +9,20 @@ import { getAmendingLawHtmlByEli } from "@/services/amendingLawsService"
  *
  * @returns A reference to the amending law rendered HTML or undefined if it is not available (or still loading).
  */
-export function useAmendingLawHtml(eli: MaybeRefOrGetter<string | undefined>): {
-  html: Readonly<Ref<string | undefined>>
-  update: () => unknown
-} {
+export function useTargetLawHtml(
+  eli: MaybeRefOrGetter<string | undefined>,
+): Readonly<Ref<string | undefined>> {
   const amendingLawHtml = ref<string>()
 
   watch(
     () => toValue(eli),
     async (eli) => {
       if (eli) {
-        amendingLawHtml.value = await getAmendingLawHtmlByEli(eli)
+        amendingLawHtml.value = await getTargetLawHtmlByEli(eli)
       }
     },
     { immediate: true },
   )
 
-  return {
-    html: readonly(amendingLawHtml),
-    update: async () => {
-      const eliValue = toValue(eli)
-      if (eliValue) {
-        amendingLawHtml.value = await getAmendingLawHtmlByEli(eliValue)
-      }
-    },
-  }
+  return readonly(amendingLawHtml)
 }

--- a/frontend/src/services/eidService.ts
+++ b/frontend/src/services/eidService.ts
@@ -1,0 +1,22 @@
+type EidPart = "ändbefehl" | "bezugsdoc" | "text" | "intro"
+
+function takeUntil<T>(xs: T[], predicate: (x: T) => boolean): T[] {
+  const res = []
+  for (const x of xs) {
+    res.push(x)
+    if (predicate(x)) {
+      break
+    }
+  }
+  return res
+}
+
+export function reduceEidToPart(eid: string, part: EidPart): string {
+  return takeUntil(eid.split("_"), (eidPart) => eidPart.startsWith(part)).join(
+    "_",
+  )
+}
+
+export function eidHasPart(eid: string, part: EidPart): boolean {
+  return eid.includes(part)
+}

--- a/frontend/src/services/ldmlDeService.ts
+++ b/frontend/src/services/ldmlDeService.ts
@@ -1,0 +1,60 @@
+export function evaluateXPath(xpath: string, xml: Document) {
+  return xml
+    .createExpression(xpath, (prefix) => {
+      switch (prefix) {
+        case "akn":
+          return "http://Inhaltsdaten.LegalDocML.de/1.6/"
+      }
+      return null
+    })
+    .evaluate(xml)
+    .iterateNext()
+}
+
+function getChangeTypeNode(xml: Document, eid: string) {
+  return evaluateXPath(`//*[@eId="${eid}"]/@refersTo`, xml)
+}
+
+export function getChangeType(xml: Document, eid: string) {
+  return getChangeTypeNode(xml, eid)?.nodeValue
+}
+
+export function setChangeType(
+  xml: Document,
+  eid: string,
+  changeType: string,
+): Document {
+  const node = getChangeTypeNode(xml, eid)
+  if (node) {
+    node.nodeValue = changeType
+  }
+  return xml
+}
+
+export function getChangeRefHref(xml: Document, eid: string) {
+  return evaluateXPath(`//*[@eId="${eid}"]/akn:ref/@href`, xml)?.nodeValue
+}
+
+function getChangeNewTextNode(xml: Document, eid: string) {
+  return evaluateXPath(`(//*[@eId="${eid}"]/akn:quotedText)[2]`, xml)
+}
+
+export function getChangeNewText(xml: Document, eid: string) {
+  return getChangeNewTextNode(xml, eid)?.textContent
+}
+
+export function getTargetLawHref(xml: Document, eid: string) {
+  return evaluateXPath(`//*[@eId="${eid}"]/@href`, xml)?.nodeValue
+}
+
+export function setChangeNewText(
+  xml: Document,
+  eid: string,
+  newText: string,
+): Document {
+  const node = getChangeNewTextNode(xml, eid)
+  if (node) {
+    node.textContent = newText
+  }
+  return xml
+}

--- a/frontend/src/services/xmlService.ts
+++ b/frontend/src/services/xmlService.ts
@@ -1,0 +1,7 @@
+export function xmlStringToDocument(xmlString: string): Document {
+  return new DOMParser().parseFromString(xmlString, "application/xml")
+}
+
+export function xmlDocumentToString(xmlDoc: Document): string {
+  return new XMLSerializer().serializeToString(xmlDoc)
+}

--- a/frontend/src/views/AmendingLawArticleEditor.vue
+++ b/frontend/src/views/AmendingLawArticleEditor.vue
@@ -10,8 +10,6 @@ import { useArticle } from "@/composables/useArticle"
 import { useArticleXml } from "@/composables/useArticleXml"
 import { useEidPathParameter } from "@/composables/useEidPathParameter"
 import { useEliPathParameter } from "@/composables/useEliPathParameter"
-import { useTargetLaw } from "@/composables/useTargetLaw"
-import { useTargetLawXml } from "@/composables/useTargetLawXml"
 import { eidHasPart, reduceEidToPart } from "@/services/eidService"
 import { renderHtmlLaw } from "@/services/lawService"
 import {
@@ -42,8 +40,6 @@ const identifier = computed<LawElementIdentifier | undefined>(() =>
 const article = useArticle(identifier)
 const { xml: articleXml, update: updateArticleXml } = useArticleXml(identifier)
 const targetLawEli = computed(() => article.value?.affectedDocumentEli)
-const targetLaw = useTargetLaw(targetLawEli)
-const { xml: targetLawXml } = useTargetLawXml(targetLawEli)
 const { html: amendingLawHtml, update: updateAmendingLawHtml } =
   useAmendingLawHtml(eli)
 
@@ -292,35 +288,6 @@ function eidToSlotName(eid: string) {
           class="row-span-2 flex flex-col gap-8"
           aria-labelledby="changeCommandsEditor"
         >
-          <h3
-            id="originalArticleTitle"
-            class="ds-label-02-bold"
-            data-testid="targetLawHeading"
-          >
-            {{ targetLaw?.title }}
-          </h3>
-          <RisTabs
-            :tabs="[
-              { id: 'text', label: 'Text' },
-              { id: 'xml', label: 'XML' },
-            ]"
-          >
-            <template #text>
-              <RisLawPreview
-                class="ds-textarea flex-grow p-2"
-                :content="targetLawHtml"
-              />
-            </template>
-            <template #xml>
-              <RisCodeEditor
-                class="flex-grow"
-                :readonly="true"
-                :editable="false"
-                :initial-content="targetLawXml ?? ''"
-              ></RisCodeEditor>
-            </template>
-          </RisTabs>
-          =======
           <h3 id="changeCommandsEditor" class="ds-label-02-bold">
             <span class="block">Änderungsbefehle</span>
             <span>{{ article?.title }}</span>
@@ -337,7 +304,6 @@ function eidToSlotName(eid: string) {
               v-for="changeModEid in selectedChangeMods"
               #[eidToSlotName(changeModEid)]
             >
-              TEST
             </template>
             <template
               v-if="selectedBezugsDoc"
@@ -352,11 +318,13 @@ function eidToSlotName(eid: string) {
                 </button>
                 <button
                   class="ds-button ds-button-small ds-button-tertiary bg-white"
+                  disabled
                 >
-                  ELI kopiere
+                  ELI kopieren
                 </button>
                 <button
                   class="ds-button ds-button-small ds-button-tertiary bg-white"
+                  disabled
                 >
                   Öffnen
                 </button>
@@ -456,40 +424,6 @@ function eidToSlotName(eid: string) {
                 :readonly="true"
                 :editable="false"
                 :initial-content="previewXml"
-              ></RisCodeEditor>
-            </template>
-          </RisTabs>
-        </section>
-        <section
-          class="flex flex-col gap-8"
-          aria-labelledby="changeCommandsEditor"
-        >
-          <h3
-            id="changeCommandsEditor"
-            class="ds-label-02-bold"
-            data-testid="amendingLawHeading"
-          >
-            <span class="block">Änderungsbefehle</span>
-            <span>{{ article?.title }}</span>
-          </h3>
-          <RisTabs
-            v-model:active-tab="amendingLawActiveTab"
-            :tabs="[
-              { id: 'text', label: 'Text' },
-              { id: 'xml', label: 'XML' },
-            ]"
-          >
-            <template #text>
-              <RisLawPreview
-                class="ds-textarea flex-grow p-2"
-                :content="renderedHtml"
-              />
-            </template>
-            <template #xml>
-              <RisCodeEditor
-                class="flex-grow"
-                :initial-content="currentArticleXml"
-                @change="handleArticleXMLChange"
               ></RisCodeEditor>
             </template>
           </RisTabs>

--- a/frontend/src/views/AmendingLawOverview.vue
+++ b/frontend/src/views/AmendingLawOverview.vue
@@ -4,7 +4,7 @@ import RisLawPreview from "@/components/RisLawPreview.vue"
 import { useAmendingLawHtml } from "@/composables/useAmendingLawHtml"
 
 const eli = useEliPathParameter()
-const amendingLawHtml = useAmendingLawHtml(eli)
+const { html: amendingLawHtml } = useAmendingLawHtml(eli)
 </script>
 
 <template>


### PR DESCRIPTION
**DO NOT MERGE** - This is just a prototype and has neither tests nor documentation and includes changes that are just there to demonstrate the abilities of it. If we want to use (some of) this approach we should copy the needed parts to a new PR and add tests, docs, ...

# Ideas tested in this prototype
## Clicking on Nodes
For node selections a click handler on the preview-div is used that reacts to all clicks inside the preview. The clicked element is then identified based on its `data-eId` attribute. This creates a new `content:click` event on the `RisPreview` component that can then be used by the view to handle what exactly should happen.
To handle clicks on specific elements (e.g. only articles) and identify these correctly for e.g. the selected nodes the handler of `content:click` might need to shorten the eli to the length needed (e.g. removing everything after `art_x` to identify articles)

## Highlighting selected Nodes
The currently selected elements are identified by their eid. These are handled by the parent component and provided to `RisPreview` via a prop. These elements then get the additional class `.selected` applied to them. This class is used to change the styles applied to the selected elements.

## Additional UI in the Preview
Named slots of `RisPreview` that start with `eli:` are moved to the end of the elements with the eli provided after `eli:`. This is done by using `<Teleport>`.

It is not possible to move something in front of an existing element of the rendering in the HTML (visually it can be moved there using CSS).

## Loading Data for Inputs
For the inputs the data is loaded directly from the xml. For this the xml string is parsed to a Document. And then xPath expressions are used to find the data in the xml using the eli of e.g. the `akn:mod`.

## Saving Data from the Inputs
Saving is handled in almost the same way as loading: By identifying the node of the xml that needs to be changed using a xPath and then updating that nodes value. The xml then needs to be converted back to a string and is stored in `currentArticleXml `. -> The xml-editor is the source of truth and the inputs just modify its content in a convenient way.

The inputs are synced by using `v-model` with a `computed` defining both a `get` (load the data for the input from the xml) and a `set` (update the xml to include the change -> this then triggers a recomputation of the `get`). 

## Multi Select
Mutli select (with shift+click) is possible. When multiple `akn:mod`s are selected their values are shown when they are the same otherwise `mixed` is used as a value. When editing them the data of all selected `akn:mod`s is changed to the new value.

## Overall
1. No changes to the xslt
2. The rendering is used to highlight stuff, provide a ui and to identify elements. Not as the source for the data.
3. The actual changes to the data always happen directly on the XML
4. The logic how to put the additional UI to the correct spot is completly encapsulated by RisPreview

## Open Challenges
* How to add the correct a11y roles to the rendering to mark e.g. all `akn:mod`s as clickable. (as well as tabindex and keyboard events)
* probably some more

# My feelings / thoughts

## Clicking on Nodes
works but with the a11y challenges I'm quite unsure if this is the best way to handle it or if registering event handlers on the individual elements at the same time as e.g. a tabindex would be simpler / less likely to lead to forgetting something. It could also remove the need to shorten the elis to the expected parts

## Highlighting selected Nodes
Seems to work quite well, even though it is a bit annoying that the classes need to be readded with every change of the html (but I don't see a way around it).
Styling the nodes once this class was added was quite straight forward.

## Additional UI in the Preview
Quite nice to use from the outside. Has some limits in regards to what can be achieved and is not 100% the way vue recommends using `<Teleport />`

## Loading & Saving Data (Inputs)
I really like that this handles the data in its source format and no big parsing/mapping step is necessary.

The methods for using xPaths in JS are quite old and not that nice to use but wrapping them in our own functions should alleviate most of the pain from that. And while using `document.querySelector` would imo sometimes lead to nicer queries using xPath would allow us to use the same query language for both the backend and the frontend. Also xPath supports querying attributes so no extra step is needed for that.

The usage of the computed with setters together with v-model was surprisingly simple. I also like that it places the loading and modifying logic close together. I am almost wondering why vue isn't recommending that for most usages of v-model with more complex data structures in the background. 

## Conclusion
I really like the teleport+slot solution, using xml as directly as possible as well as the computed-vModel suff. I'm still a bit unsure of the usage of xPath over something like `querySelector` but with a tendency towards xPath.
I'm not at all sure if this one global click handler is a good way and would really like to try out / see some other ideas for this

## Further idea
Maybe a similar approach to the slots could be used for more specific event handlers, but I haven't tested how well vue works with dynamic event listener names:
Sketch: listener created like `<RisPreview @click:akn:mod="handler" />` and then the RisPreview component somehow automatically adds event listeners (tabindexes, etc...) to the elements of that type.

Edit: quick test of the idea

this should be doable with the help of `useAttrs` and then filtering the keys of that object for starting with `onClick:akn:`. We should even be able to define the event on `defineEmits` using
```
[key: `click:akn:${string}`]
```
as the event name, but even with that vue still throws a warning about a non declared emit.

RISDEV-3681