### PR TITLE
Prototype for node selection & copying elis - alternative version

### DIFF
--- a/frontend/src/components/RisLawPreview.vue
+++ b/frontend/src/components/RisLawPreview.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-withDefaults(
+import { nextTick, reactive, ref, watch } from "vue"
+
+const props = withDefaults(
   defineProps<{
     content: string
     highlightMods: boolean
@@ -10,12 +12,304 @@ withDefaults(
     highlightAffectedDocument: false,
   },
 )
+
+type SavePayload = {
+  modifiedElement: string
+  quotedTextFrom: string
+  quotedTextTo: string
+  targetLawEli: string
+}
+
+const emit = defineEmits<{
+  save: [value: SavePayload]
+}>()
+
+/* -------------------------------------------------- *
+ * Data                                               *
+ * -------------------------------------------------- */
+
+// The following are used to de-serialize structured data like change commands,
+// refs, and quoted texts from the attributes in the corresponding HTML
+// elements.
+
+type QuotedText = {
+  eId?: string
+  guid?: string
+  text?: string
+}
+
+type Ref = {
+  eId?: string
+  guid?: string
+  href?: string
+}
+
+type ChangeCommand = {
+  eId?: string
+  refersTo?: string
+  guid?: string
+  ref?: Ref
+  quotedText?: [source: QuotedText | null, target: QuotedText | null]
+}
+
+function getQuotedText(el: HTMLElement): QuotedText {
+  return {
+    eId: el.dataset["eid"],
+    guid: el.dataset["guid"],
+    text: el.innerText,
+  }
+}
+
+function getRef(el: HTMLElement): Ref {
+  return {
+    eId: el.dataset["eid"],
+    guid: el.dataset["guid"],
+    href: el.dataset["href"],
+  }
+}
+
+function getChangeCommand(el: HTMLElement): ChangeCommand {
+  const quotedTextEls = el.querySelectorAll(".akn-quotedText")
+
+  const quotedTextSrc =
+    quotedTextEls[0] instanceof HTMLElement
+      ? getQuotedText(quotedTextEls[0])
+      : null
+
+  const quotedTextTarget =
+    quotedTextEls[1] instanceof HTMLElement
+      ? getQuotedText(quotedTextEls[1])
+      : null
+
+  const ref = el.querySelector(".akn-ref")
+
+  return {
+    eId: el.dataset["eid"],
+    refersTo: el.dataset["refersto"],
+    guid: el.dataset["guid"],
+    ref: ref instanceof HTMLElement ? getRef(ref) : undefined,
+    quotedText: [quotedTextSrc, quotedTextTarget],
+  }
+}
+
+/* -------------------------------------------------- *
+ * Wiring up the DOM                                  *
+ * -------------------------------------------------- */
+
+// Keeps track of event handlers so we can clean them up when we need to.
+const handlers: Array<{
+  el: HTMLElement
+  event: keyof HTMLElementEventMap
+  handler: Parameters<HTMLElement["addEventListener"]>[1]
+}> = []
+
+// This is the HTML element where the preview will appear.
+const container = ref<HTMLElement | null>()
+
+// This connects the 3rd-party HTML with Vue, mostly by manually wiring up
+// event handlers and setting some additional supporting properties on the
+// relevant elements. If we were to actually use this I would build this in
+// a more modular way as we will likely need more things than just mods.
+async function connect() {
+  // Need to tick in order to give Vue some time to render the HTML first
+  await nextTick()
+
+  // Clean up existing handlers first to avoid memory leaks. To keep this
+  // simple, we just recreate everything whenever the content changes.
+  handlers.forEach(({ el, event, handler }) => {
+    el.removeEventListener(event, handler)
+  })
+
+  const modElements = container.value?.querySelectorAll(".akn-mod")
+
+  modElements?.forEach((modElement) => {
+    // Nothing to do if the element has an unexpected type
+    if (!(modElement instanceof HTMLElement)) return
+
+    // De-serialize data from the attributes on the element
+    const changeCommand = getChangeCommand(modElement)
+
+    // Create and register event handlers
+    const onClick = (event: Event) => {
+      if (!(event instanceof PointerEvent)) return
+
+      toggleSelectedChangeCommand(changeCommand, modElement, {
+        selectMultiple: event.metaKey,
+      })
+    }
+
+    modElement.addEventListener("click", onClick)
+    handlers.push({ el: modElement, event: "click", handler: onClick })
+
+    const onKeyPress = (event: Event) => {
+      if (event instanceof KeyboardEvent && event.key === "Enter") {
+        beginEditChangeCommand(changeCommand)
+        event.stopPropagation()
+      }
+    }
+    modElement.addEventListener("keypress", onKeyPress)
+    handlers.push({ el: modElement, event: "keypress", handler: onKeyPress })
+
+    // Make additional changes to the element, e.g. for keyboard naviation.
+    // This could potentially also be accessibility stuff.
+    modElement.tabIndex = 1
+  })
+}
+
+// Wire up event handling etc. whenever the document changes
+watch(
+  () => props.content,
+  () => {
+    connect()
+  },
+  { immediate: true },
+)
+
+/* -------------------------------------------------- *
+ * Selection management                               *
+ * -------------------------------------------------- */
+
+const selectedChangeCommands = reactive<ChangeCommand[]>([])
+
+function toggleSelectedChangeCommand(
+  changeCommand: ChangeCommand,
+  el: HTMLElement,
+  opts = { selectMultiple: false },
+) {
+  if (!opts.selectMultiple) {
+    selectedChangeCommands.splice(0, selectedChangeCommands.length)
+    container.value
+      ?.querySelectorAll(".akn-mod.selected")
+      ?.forEach((el) => el.classList.remove("selected"))
+  }
+
+  const inList = selectedChangeCommands.findIndex(
+    (i) => i.eId === changeCommand.eId,
+  )
+
+  if (inList >= 0) {
+    el.classList.remove("selected")
+    selectedChangeCommands.splice(inList, 1)
+  } else {
+    el.classList.add("selected")
+    selectedChangeCommands.push(changeCommand)
+  }
+}
+
+/* -------------------------------------------------- *
+ * Editing form                                       *
+ * -------------------------------------------------- */
+
+const dialogEl = ref<HTMLDialogElement | null>()
+
+const changeCommandEid = ref("")
+const changeCommandTargetEli = ref("")
+const changeCommandReplaceFrom = ref("")
+const changeCommandReplaceTo = ref("")
+
+function beginEditChangeCommand(changeCommand: ChangeCommand) {
+  changeCommandEid.value = changeCommand.eId ?? ""
+  changeCommandTargetEli.value = changeCommand.ref?.href ?? ""
+  changeCommandReplaceFrom.value = changeCommand.quotedText?.[0]?.text ?? ""
+  changeCommandReplaceTo.value = changeCommand.quotedText?.[1]?.text ?? ""
+
+  dialogEl.value?.show()
+}
+
+function saveEditChangeCommand() {
+  emit("save", {
+    modifiedElement: changeCommandEid.value,
+    targetLawEli: changeCommandTargetEli.value,
+    quotedTextFrom: changeCommandReplaceFrom.value,
+    quotedTextTo: changeCommandReplaceTo.value,
+  })
+
+  closeEditChangeCommand()
+}
+
+function closeEditChangeCommand() {
+  changeCommandEid.value = ""
+  changeCommandTargetEli.value = ""
+  changeCommandReplaceFrom.value = ""
+  changeCommandReplaceTo.value = ""
+
+  dialogEl.value?.close()
+}
 </script>
 
 <template>
   <div class="overflow-hidden">
+    <dialog
+      ref="dialogEl"
+      class="absolute left-auto right-32 top-32 w-[600px] rounded-md border-2 border-blue-900 bg-white p-16"
+    >
+      <form class="flex flex-col gap-16">
+        <fieldset class="flex gap-16">
+          <label class="flex-1" for="aenderungstyp">
+            Änderungstyp
+            <select
+              id="aenderungstyp"
+              class="ds-select ds-select-medium"
+              disabled
+            ></select
+          ></label>
+
+          <label class="flex-1" for="zeitgrenze">
+            Zeitgrenze
+            <select
+              id="zeitgrenze"
+              class="ds-select ds-select-medium"
+              disabled
+            ></select
+          ></label>
+        </fieldset>
+
+        <label for="eli-zielgesetz">
+          ELI Zielgesetz
+          <input
+            id="eli-zielgesetz"
+            v-model="changeCommandTargetEli"
+            type="text"
+            class="ds-input ds-input-medium"
+          />
+        </label>
+
+        <label for="textstelle">
+          zu ersetzende Textstelle
+          <input
+            id="textstelle"
+            v-model="changeCommandReplaceFrom"
+            type="text"
+            class="ds-input ds-input-medium"
+          />
+        </label>
+
+        <label for="textinhalt">
+          neuer Textinhalt
+          <textarea
+            id="textinhalt"
+            v-model="changeCommandReplaceTo"
+            class="ds-textarea"
+          />
+        </label>
+      </form>
+
+      <footer class="mt-16 flex justify-end gap-14 border-t pt-16">
+        <button
+          class="ds-button ds-button-secondary"
+          @click="closeEditChangeCommand()"
+        >
+          Abbrechen
+        </button>
+        <button class="ds-button" @click="saveEditChangeCommand()">
+          Speichern
+        </button>
+      </footer>
+    </dialog>
+
     <!-- eslint-disable vue/no-v-html -->
     <div
+      ref="container"
       class="flex h-full overflow-auto bg-white p-8"
       :class="{
         'highlight-mods': highlightMods,
@@ -113,7 +407,7 @@ withDefaults(
 }
 
 .highlight-mods :deep(.akn-mod):hover {
-  @apply -mx-[3px] -my-1 inline-block border-2 border-dotted border-highlight-mod-border bg-highlight-mod-hover px-2;
+  @apply -mx-[3px] -my-1 inline-block cursor-pointer border-2 border-dotted border-highlight-mod-border bg-highlight-mod-hover px-2;
 }
 
 /* This is currently unused as the .selected class is never applied to elements */

--- a/frontend/src/composables/useAmendingLawHtml.ts
+++ b/frontend/src/composables/useAmendingLawHtml.ts
@@ -9,9 +9,11 @@ import { getAmendingLawHtmlByEli } from "@/services/amendingLawsService"
  *
  * @returns A reference to the amending law rendered HTML or undefined if it is not available (or still loading).
  */
-export function useAmendingLawHtml(
-  eli: MaybeRefOrGetter<string | undefined>,
-): Readonly<Ref<string | undefined>> {
+export function useAmendingLawHtml(eli: MaybeRefOrGetter<string | undefined>): {
+  html: Readonly<Ref<string | undefined>>
+
+  reload: () => Promise<void>
+} {
   const amendingLawHtml = ref<string>()
 
   watch(
@@ -24,5 +26,13 @@ export function useAmendingLawHtml(
     { immediate: true },
   )
 
-  return readonly(amendingLawHtml)
+  async function reload() {
+    const eliVal = toValue(eli)
+    if (eliVal) amendingLawHtml.value = await getAmendingLawHtmlByEli(eliVal)
+  }
+
+  return {
+    html: readonly(amendingLawHtml),
+    reload,
+  }
 }

--- a/frontend/src/views/AmendingLawOverview.vue
+++ b/frontend/src/views/AmendingLawOverview.vue
@@ -1,10 +1,47 @@
 <script setup lang="ts">
-import { useEliPathParameter } from "@/composables/useEliPathParameter"
 import RisLawPreview from "@/components/RisLawPreview.vue"
 import { useAmendingLawHtml } from "@/composables/useAmendingLawHtml"
+import { useArticleXml } from "@/composables/useArticleXml"
+import { useEliPathParameter } from "@/composables/useEliPathParameter"
 
 const eli = useEliPathParameter()
-const amendingLawHtml = useAmendingLawHtml(eli)
+const { html: amendingLawHtml, reload } = useAmendingLawHtml(eli)
+
+/* -------------------------------------------------- *
+ * Saving changes                                     *
+ * -------------------------------------------------- */
+
+const amendingLawXml = useArticleXml(() => ({ eli: eli.value, eid: "" }))
+
+async function saveChanges(value: {
+  modifiedElement: string
+  targetLawEli: string
+  quotedTextFrom: string
+  quotedTextTo: string
+}) {
+  const parser = new DOMParser()
+  const xmlDom = parser.parseFromString(
+    amendingLawXml.xml.value ?? "",
+    "application/xml",
+  )
+
+  const mod = xmlDom.querySelector(`[eId=${value.modifiedElement}]`)
+
+  if (!mod) {
+    console.log(`[eId=${value.modifiedElement}] not found!`)
+    return
+  }
+
+  const quotedTextEls = mod.querySelectorAll("quotedText")
+  quotedTextEls[0].innerHTML = value.quotedTextFrom
+  quotedTextEls[1].innerHTML = value.quotedTextTo
+
+  const serializer = new XMLSerializer()
+  const result = serializer.serializeToString(xmlDom)
+
+  await amendingLawXml.update(result)
+  reload()
+}
 </script>
 
 <template>
@@ -15,6 +52,7 @@ const amendingLawHtml = useAmendingLawHtml(eli)
       :content="amendingLawHtml ?? ''"
       highlight-mods
       highlight-affected-document
+      @save="saveChanges($event)"
     />
   </div>
 </template>


### PR DESCRIPTION
**DO NOT MERGE** - This is just a prototype and has neither tests nor documentation and includes changes that are just there to demonstrate the abilities of it. If we want to use (some of) this approach we should copy the needed parts to a new PR and add tests, docs, ...

## Ideas tested in this prototype

This prototype broadly tries to achieve similar results as #233, but:

- It's a bit less elaborate and doesn't support as many features
- Uses a slightly different approach (less "smart", more manual work, but therefore perhaps more robust and easier to understand)

### General approach

We're using an `init` function which is run whenever the HTML content of the preview changes. This function:

- Cleans up any artifacts (event handlers, etc.) from previous runs of `init` to make sure we're not producing memory leaks. 

- Queries certain types of elements from the HTML and progressively enhances them, e.g. by registering event handlers and adding properties such as tab index and aria attributes for accessibility where applicable.

- For each element, relevant additional information (e.g. the eId) is read from the `dataset` of the element and can be used by the event handler.

This approach allows us to create event handlers that are very specific to each relevant element. This avoids the need of parsing the eId in order to get the type of the element.

### Clicking on nodes

Currently all events are handled inside the `RisLawPreview` component, but for the actual application, the component should emit the event so it can be handled by the parent component instead.

This can easily be done by making the event handlers emit an event similar to `content:click` in the other prototype, with the added benefit that the parent doesn't need to figure out the type of the element that is being clicked on.

### Highlighting selected nodes

This happens by

- Keeping track of the currently selected nodes
- Toggling a `selected` class on the relevant nodes

For the actual application we would also put a v-model behind this so the selection is accessible to and can be managed from the outside. We can then watch the model and make the DOM changes accordingly.

### Additional UI in the preview

This is not implemented in this prototype, but I would solve it somehow like this:

- Again, register an event handler specifically for each relevant element
- In the event handler, grab the rect and coordinates of the element
- Use this information to fixed or absolutely position the UI
- Unlike the other prototype: no slots or teleports

### Loading data for inputs

Similarly to the other prototype, elements are identified by their type + eId, both pieces of information being available in the HTML. This information is used to find the element in XML and extract additional data. 

I also tried parsing it from the HTML, but that seems unnecessarily complicated if it's all in the XML already. 

Furthermore, I tried using `querySelector` instead of XPath. This feels more familiar and natural in the frontend, but I agree with @malte-laukoetter that it would be better to keep the selectors consistent with the backend, which will most likely use/already uses XPath.

### Saving data from the inputs

Just the other way around as loading: Query selectors in XML, replace data, send back to the backend using the XML endpoints.

### Multiselect

See "Highlighting selected nodes" above.

### Overall

Some principles are shared with the other prototype:

- No changes to the XSLT
- The rendering is used to highlight stuff, provide a UI and to identify elements, not as the source for the data
- The actual changes to the data always happen directly on the XML

It diverges in that it doesn't use any Vue APIs or components for wiring up interactions or positioning UIs. Instead, it uses regular DOM APIs such as `addEventListener`, `HTMLElement.dataset`, ... in an imperative way. While admittedly more verbose and less elegant, I prefer this approach because I believe it to be more robust and simpler to understand and extend.

The important bit is that all this complexity is hidden inside the preview component and therefore contained in one specific spot.

## Thoughts

- For the reasons mentioned above, I prefer this approach to the teleports/slots approach of the other prototype, especially since that "is not 100% the way vue recommends using `<Teleport />`" (according to @malte-laukoetter)

- I also think it's a good idea to have individual, optimized listeners on all events instead of one big listener that manages all the possible cases.

- Using XML as the data source in the frontend and manipulating that instead of using an abstraction such as a JSON API feels like the correct way to go—more flexible, less complexity both in the frontend and the backend, and we need the XML endpoints anyways for the code editors.

- The XSLT doesn't need to include anything specifically for the preview except some high level information about element types and identifiers. Those can then be used to make the connection to the real data in the XML.

- Also have some ideas how the `init` method could be turned into some kind of plug-in system that just calls/exposes certain methods of "plugins". We could then have plugins for change commands, articles, ... whatever. That way the entire thing would be quite modular and maybe a bit more manageable.