### PR TITLE
Remove build script

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -54,3 +54,21 @@ lefthook install
 
 Opt in to CI posting notifications for failing jobs to a particular Slack channel by setting a repository secret
 with the name `SLACK_WEBHOOK_URL`, containing a url for [Incoming Webhooks](https://api.slack.com/messaging/webhooks).
+
+# How to run locally
+
+With Docker being installed (Compose Plugin needed) run following to start all containers:
+```bash
+docker compose up -d
+```
+
+Watch the state by either of:
+```bash
+docker container ls
+docker compose ls
+```
+
+To stop them:
+```bash
+docker compose down
+```

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -57,10 +57,15 @@ with the name `SLACK_WEBHOOK_URL`, containing a url for [Incoming Webhooks](http
 
 # How to run locally
 
+## Docker
+
 With Docker being installed (Compose Plugin needed) run following to start all containers:
 ```bash
 docker compose up -d
 ```
+
+Visit: [http://localhost:8080](http://localhost:8080)
+
 
 Watch the state by either of:
 ```bash
@@ -72,3 +77,25 @@ To stop them:
 ```bash
 docker compose down
 ```
+
+## Direct
+
+Run dependencies from the root of the project:
+```bash
+docker compose up postgres14 redis
+```
+
+Run from `./backend`:
+```bash
+./gradlew bootRun
+```
+More info on the backend part [here](./backend/README.md).
+
+Run from `./frontend`:
+```bash
+npm i
+npm run dev
+```
+More info on the frontend part [here](./frontend/README.md).
+
+Visit: [http://localhost:5173](http://localhost:5173)

--- a/buildProject.sh
+++ b/buildProject.sh
@@ -1,3 +1,0 @@
-#!   /bin/bash -e
-
-docker build -t ris-norms-app:001 -f DockerfileApp .

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,9 @@
 services:
   webapp:
     image: ris-norms-app:001
+    build: 
+      context: .
+      dockerfile: DockerfileApp
     environment:
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres14:5432/risnorms
       - REDIS_HOST=redis


### PR DESCRIPTION
By simply moving the Docker build command to the Compose file, we could tidy up the project a little more. Do you agree?