### PR TITLE
RISDEV-3766 Adjust db models and ports for new database tables

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/AnnouncementDto.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/AnnouncementDto.java
@@ -1,0 +1,41 @@
+package de.bund.digitalservice.ris.norms.adapter.output.database.dto;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Data Transfer Object (DTO) class representing an announcement entity. This class is annotated
+ * with Lombok annotations for generating getters, setters, constructors, and builder methods.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Entity
+@Table(name = "announcements")
+public class AnnouncementDto {
+
+  @Id @GeneratedValue private UUID id;
+
+  @Column(name = "released_by_documentalist_at")
+  private Instant releasedByDocumentalistAt;
+
+  @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  @JoinColumn(name = "eli", referencedColumnName = "eli", nullable = false)
+  private NormDto normDto;
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/NormDto.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/NormDto.java
@@ -2,7 +2,6 @@ package de.bund.digitalservice.ris.norms.adapter.output.database.dto;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
@@ -25,7 +24,7 @@ import lombok.Setter;
 @Entity
 @Table(name = "norms")
 public class NormDto {
-  @Id @GeneratedValue private UUID guid;
+  @Id @NotNull private UUID guid;
 
   @NotNull @Column private String eli;
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/NormDto.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/NormDto.java
@@ -1,0 +1,33 @@
+package de.bund.digitalservice.ris.norms.adapter.output.database.dto;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Data Transfer Object (DTO) class representing a norm entity. This class is annotated with Lombok
+ * annotations for generating getters, setters, constructors, and builder methods.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Entity
+@Table(name = "norms")
+public class NormDto {
+  @Id @GeneratedValue private UUID guid;
+
+  @NotNull @Column private String eli;
+
+  @NotNull @Column private String xml;
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/AnnouncementMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/AnnouncementMapper.java
@@ -1,0 +1,40 @@
+package de.bund.digitalservice.ris.norms.adapter.output.database.mapper;
+
+import de.bund.digitalservice.ris.norms.adapter.output.database.dto.AnnouncementDto;
+import de.bund.digitalservice.ris.norms.domain.entity.Announcement;
+import javax.xml.transform.TransformerException;
+import javax.xml.xpath.XPathExpressionException;
+
+/** Mapper class for converting between {@link AnnouncementDto} and {@link Announcement}. */
+public class AnnouncementMapper {
+
+  // Private constructor to hide the implicit public one and prevent instantiation
+  private AnnouncementMapper() {}
+
+  /**
+   * Maps a {@link AnnouncementDto} to the domain {@link Announcement}.
+   *
+   * @param announcementDto The input {@link AnnouncementDto} to be mapped.
+   * @return A new {@link Announcement} mapped from the input {@link AnnouncementDto}.
+   */
+  public static Announcement mapToDomain(final AnnouncementDto announcementDto) {
+    return Announcement.builder()
+        .releasedByDocumentalistAt(announcementDto.getReleasedByDocumentalistAt())
+        .norm(NormMapper.mapToDomain(announcementDto.getNormDto()))
+        .build();
+  }
+
+  /**
+   * Maps a domain {@link Announcement} to {@link AnnouncementDto}.
+   *
+   * @param announcement The input {@link Announcement} to be mapped.
+   * @return A new {@link AnnouncementDto} mapped from the input {@link Announcement}.
+   */
+  public static AnnouncementDto mapToDto(final Announcement announcement)
+      throws XPathExpressionException, TransformerException {
+    return AnnouncementDto.builder()
+        .releasedByDocumentalistAt(announcement.getReleasedByDocumentalistAt())
+        .normDto(NormMapper.mapToDto(announcement.getNorm()))
+        .build();
+  }
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/NormMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/NormMapper.java
@@ -1,0 +1,40 @@
+package de.bund.digitalservice.ris.norms.adapter.output.database.mapper;
+
+import de.bund.digitalservice.ris.norms.adapter.output.database.dto.NormDto;
+import de.bund.digitalservice.ris.norms.domain.entity.Norm;
+import javax.xml.transform.TransformerException;
+import javax.xml.xpath.XPathExpressionException;
+
+/** Mapper class for converting between {@link NormDto} and {@link Norm}. */
+public class NormMapper {
+
+  // Private constructor to hide the implicit public one and prevent instantiation
+  private NormMapper() {}
+
+  /**
+   * Maps a {@link NormDto} to the domain {@link Norm}.
+   *
+   * @param normDto The input {@link NormDto} to be mapped.
+   * @return A new {@link Norm} mapped from the input {@link NormDto}.
+   */
+  public static Norm mapToDomain(final NormDto normDto) {
+    return Norm.builder().document(XmlMapper.toDocument(normDto.getXml())).build();
+    // TODO: (Malte Laukötter, 2024-04-15) should we assert/validate that the eli and guid are
+    // correct?
+  }
+
+  /**
+   * Maps a domain {@link Norm} to {@link NormDto}.
+   *
+   * @param norm The input {@link Norm} to be mapped.
+   * @return A new {@link NormDto} mapped from the input {@link Norm}.
+   */
+  public static NormDto mapToDto(final Norm norm)
+      throws XPathExpressionException, TransformerException {
+    return NormDto.builder()
+        .xml(XmlMapper.toString(norm.getDocument()))
+        .eli(norm.getEli().orElseThrow())
+        .guid(norm.getGuid().orElseThrow())
+        .build();
+  }
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/XmlMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/XmlMapper.java
@@ -1,0 +1,69 @@
+package de.bund.digitalservice.ris.norms.adapter.output.database.mapper;
+
+import de.bund.digitalservice.ris.norms.domain.exceptions.XmlProcessingException;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import net.sf.saxon.TransformerFactoryImpl;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+/** Mapper class for converting between a string containing xml and {@link org.w3c.dom.Document}. */
+public class XmlMapper {
+
+  // Private constructor to hide the implicit public one and prevent instantiation
+  private XmlMapper() {}
+
+  /**
+   * Maps a string containing xml to a {@link Document}.
+   *
+   * @param xmlText The input string containing xml to be mapped to a {@link Document}
+   * @return the resulting {@link Document}
+   */
+  public static Document toDocument(String xmlText) {
+
+    var factory = DocumentBuilderFactory.newInstance();
+
+    // XXE vulnerability hardening, cf. https://www.sonarsource.com/blog/secure-xml-processor/
+    try {
+      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+
+      factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      factory.setExpandEntityReferences(false);
+
+      final DocumentBuilder builder = factory.newDocumentBuilder();
+      final InputSource is = new InputSource(new StringReader(xmlText));
+      return builder.parse(is);
+    } catch (ParserConfigurationException | SAXException | IOException e) {
+      throw new XmlProcessingException(e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Maps a {@link Document} to a string.
+   *
+   * @param document The input {@link Document} to be mapped to a string
+   * @return the resulting text representation of the {@link Document}
+   */
+  public static String toString(Document document) {
+    var writer = new StringWriter();
+
+    try {
+      new TransformerFactoryImpl()
+          .newTransformer()
+          .transform(new DOMSource(document), new StreamResult(writer));
+    } catch (TransformerException e) {
+      throw new XmlProcessingException(e.getMessage(), e);
+    }
+
+    return writer.toString();
+  }
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/repository/AnnouncementRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/repository/AnnouncementRepository.java
@@ -1,6 +1,7 @@
 package de.bund.digitalservice.ris.norms.adapter.output.database.repository;
 
 import de.bund.digitalservice.ris.norms.adapter.output.database.dto.AnnouncementDto;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,4 +12,14 @@ import org.springframework.stereotype.Repository;
  * {@link AnnouncementDto}.
  */
 @Repository
-public interface AnnouncementRepository extends JpaRepository<AnnouncementDto, UUID> {}
+public interface AnnouncementRepository extends JpaRepository<AnnouncementDto, UUID> {
+
+  /**
+   * Finds a {@link AnnouncementDto} by its norms ELI (European Legislation Identifier).
+   *
+   * @param eli The ELI to search for.
+   * @return An {@link Optional} containing the found {@link AnnouncementDto} if exists, or empty if
+   *     not found.
+   */
+  Optional<AnnouncementDto> findByNormDtoEli(final String eli);
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/repository/AnnouncementRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/repository/AnnouncementRepository.java
@@ -1,0 +1,14 @@
+package de.bund.digitalservice.ris.norms.adapter.output.database.repository;
+
+import de.bund.digitalservice.ris.norms.adapter.output.database.dto.AnnouncementDto;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository interface for interacting with the database and managing {@link AnnouncementDto}
+ * entities. This interface extends {@link JpaRepository} and focuses on operations related to
+ * {@link AnnouncementDto}.
+ */
+@Repository
+public interface AnnouncementRepository extends JpaRepository<AnnouncementDto, UUID> {}

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/repository/NormRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/repository/NormRepository.java
@@ -1,0 +1,14 @@
+package de.bund.digitalservice.ris.norms.adapter.output.database.repository;
+
+import de.bund.digitalservice.ris.norms.adapter.output.database.dto.NormDto;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository interface for interacting with the database and managing {@link NormDto} entities.
+ * This interface extends {@link JpaRepository} and focuses on operations related to {@link
+ * NormDto}.
+ */
+@Repository
+public interface NormRepository extends JpaRepository<NormDto, UUID> {}

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/repository/NormRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/repository/NormRepository.java
@@ -1,6 +1,7 @@
 package de.bund.digitalservice.ris.norms.adapter.output.database.repository;
 
 import de.bund.digitalservice.ris.norms.adapter.output.database.dto.NormDto;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,4 +12,13 @@ import org.springframework.stereotype.Repository;
  * NormDto}.
  */
 @Repository
-public interface NormRepository extends JpaRepository<NormDto, UUID> {}
+public interface NormRepository extends JpaRepository<NormDto, UUID> {
+  /**
+   * Finds a {@link NormDto} by its ELI (European Legislation Identifier).
+   *
+   * @param eli The ELI to search for.
+   * @return An {@link Optional} containing the found {@link NormDto} if exists, or empty if not
+   *     found.
+   */
+  Optional<NormDto> findByEli(final String eli);
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/service/DBService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/service/DBService.java
@@ -46,7 +46,8 @@ public class DBService
         UpdateTargetLawXmlPort,
         UpdateAmendingLawXmlPort,
         UpdateAmendingLawPort,
-        UpdateNormPort {
+        UpdateNormPort,
+        UpdateAnnouncementPort {
 
   private final AmendingLawRepository amendingLawRepository;
 
@@ -159,6 +160,28 @@ public class DBService
                           normDto.setXml(normXml);
                           // we do not update the GUID or ELI as they may not change
                           return NormMapper.mapToDomain(normRepository.save(normDto));
+                        }));
+  }
+
+  @Override
+  public Optional<Announcement> updateAnnouncement(UpdateAnnouncementPort.Command command) {
+    var announcement = command.announcement();
+    return command
+        .announcement()
+        .getNorm()
+        .getEli()
+        .flatMap(
+            eli ->
+                announcementRepository
+                    .findByNormDtoEli(eli)
+                    .map(
+                        announcementDto -> {
+                          announcementDto.setReleasedByDocumentalistAt(
+                              announcement.getReleasedByDocumentalistAt());
+                          // It is not possible to change the norm associated with an announcement.
+                          // Therefore, we don't update that relationship.
+                          return AnnouncementMapper.mapToDomain(
+                              announcementRepository.save(announcementDto));
                         }));
   }
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/service/DBService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/service/DBService.java
@@ -4,12 +4,16 @@ import de.bund.digitalservice.ris.norms.adapter.output.database.dto.AmendingLawD
 import de.bund.digitalservice.ris.norms.adapter.output.database.dto.TargetLawDto;
 import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.AmendingLawMapper;
 import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.ArticleMapper;
+import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.NormMapper;
 import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.TargetLawMapper;
 import de.bund.digitalservice.ris.norms.adapter.output.database.repository.AmendingLawRepository;
+import de.bund.digitalservice.ris.norms.adapter.output.database.repository.AnnouncementRepository;
+import de.bund.digitalservice.ris.norms.adapter.output.database.repository.NormRepository;
 import de.bund.digitalservice.ris.norms.adapter.output.database.repository.TargetLawRepository;
 import de.bund.digitalservice.ris.norms.application.port.output.*;
 import de.bund.digitalservice.ris.norms.domain.entity.AmendingLaw;
 import de.bund.digitalservice.ris.norms.domain.entity.Article;
+import de.bund.digitalservice.ris.norms.domain.entity.Norm;
 import de.bund.digitalservice.ris.norms.domain.entity.TargetLaw;
 import jakarta.transaction.Transactional;
 import java.util.List;
@@ -31,6 +35,7 @@ public class DBService
         LoadArticlePort,
         LoadTargetLawPort,
         LoadTargetLawXmlPort,
+        LoadNormPort,
         UpdateTargetLawXmlPort,
         UpdateAmendingLawXmlPort,
         UpdateAmendingLawPort {
@@ -38,11 +43,18 @@ public class DBService
   private final AmendingLawRepository amendingLawRepository;
 
   private final TargetLawRepository targetLawRepository;
+  private final AnnouncementRepository announcementRepository;
+  private final NormRepository normRepository;
 
   public DBService(
-      AmendingLawRepository amendingLawRepository, TargetLawRepository targetLawRepository) {
+      AmendingLawRepository amendingLawRepository,
+      TargetLawRepository targetLawRepository,
+      AnnouncementRepository announcementRepository,
+      NormRepository normRepository) {
     this.amendingLawRepository = amendingLawRepository;
     this.targetLawRepository = targetLawRepository;
+    this.announcementRepository = announcementRepository;
+    this.normRepository = normRepository;
   }
 
   @Override
@@ -98,6 +110,11 @@ public class DBService
   @Override
   public Optional<String> loadTargetLawXmlByEli(LoadTargetLawXmlPort.Command command) {
     return targetLawRepository.findByEli(command.eli()).map(TargetLawDto::getXml);
+  }
+
+  @Override
+  public Optional<Norm> loadNorm(LoadNormPort.Command command) {
+    return normRepository.findByEli(command.eli()).map(NormMapper::mapToDomain);
   }
 
   @Override

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/service/DBService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/service/DBService.java
@@ -18,6 +18,8 @@ import de.bund.digitalservice.ris.norms.domain.entity.Article;
 import de.bund.digitalservice.ris.norms.domain.entity.Norm;
 import de.bund.digitalservice.ris.norms.domain.entity.TargetLaw;
 import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -39,6 +41,7 @@ public class DBService
         LoadTargetLawXmlPort,
         LoadNormPort,
         LoadAnnouncementPort,
+        LoadAllAnnouncementsPort,
         UpdateTargetLawXmlPort,
         UpdateAmendingLawXmlPort,
         UpdateAmendingLawPort {
@@ -125,6 +128,18 @@ public class DBService
     return announcementRepository
         .findByNormDtoEli(command.eli())
         .map(AnnouncementMapper::mapToDomain);
+  }
+
+  @Override
+  public List<Announcement> loadAllAnnouncements() {
+    return announcementRepository.findAll().stream()
+        .map(AnnouncementMapper::mapToDomain)
+        .sorted(
+            Comparator.comparing(
+                    (Announcement announcement) ->
+                        announcement.getNorm().getPublicationDate().orElse(LocalDate.MIN))
+                .reversed())
+        .toList();
   }
 
   @Override

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/service/DBService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/service/DBService.java
@@ -7,6 +7,7 @@ import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.Announcem
 import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.ArticleMapper;
 import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.NormMapper;
 import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.TargetLawMapper;
+import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.XmlMapper;
 import de.bund.digitalservice.ris.norms.adapter.output.database.repository.AmendingLawRepository;
 import de.bund.digitalservice.ris.norms.adapter.output.database.repository.AnnouncementRepository;
 import de.bund.digitalservice.ris.norms.adapter.output.database.repository.NormRepository;
@@ -44,7 +45,8 @@ public class DBService
         LoadAllAnnouncementsPort,
         UpdateTargetLawXmlPort,
         UpdateAmendingLawXmlPort,
-        UpdateAmendingLawPort {
+        UpdateAmendingLawPort,
+        UpdateNormPort {
 
   private final AmendingLawRepository amendingLawRepository;
 
@@ -140,6 +142,24 @@ public class DBService
                         announcement.getNorm().getPublicationDate().orElse(LocalDate.MIN))
                 .reversed())
         .toList();
+  }
+
+  @Override
+  public Optional<Norm> updateNorm(UpdateNormPort.Command command) {
+    var normXml = XmlMapper.toString(command.norm().getDocument());
+    return command
+        .norm()
+        .getEli()
+        .flatMap(
+            eli ->
+                normRepository
+                    .findByEli(eli)
+                    .map(
+                        normDto -> {
+                          normDto.setXml(normXml);
+                          // we do not update the GUID or ELI as they may not change
+                          return NormMapper.mapToDomain(normRepository.save(normDto));
+                        }));
   }
 
   @Override

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/service/DBService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/service/DBService.java
@@ -3,6 +3,7 @@ package de.bund.digitalservice.ris.norms.adapter.output.database.service;
 import de.bund.digitalservice.ris.norms.adapter.output.database.dto.AmendingLawDto;
 import de.bund.digitalservice.ris.norms.adapter.output.database.dto.TargetLawDto;
 import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.AmendingLawMapper;
+import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.AnnouncementMapper;
 import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.ArticleMapper;
 import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.NormMapper;
 import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.TargetLawMapper;
@@ -12,6 +13,7 @@ import de.bund.digitalservice.ris.norms.adapter.output.database.repository.NormR
 import de.bund.digitalservice.ris.norms.adapter.output.database.repository.TargetLawRepository;
 import de.bund.digitalservice.ris.norms.application.port.output.*;
 import de.bund.digitalservice.ris.norms.domain.entity.AmendingLaw;
+import de.bund.digitalservice.ris.norms.domain.entity.Announcement;
 import de.bund.digitalservice.ris.norms.domain.entity.Article;
 import de.bund.digitalservice.ris.norms.domain.entity.Norm;
 import de.bund.digitalservice.ris.norms.domain.entity.TargetLaw;
@@ -36,6 +38,7 @@ public class DBService
         LoadTargetLawPort,
         LoadTargetLawXmlPort,
         LoadNormPort,
+        LoadAnnouncementPort,
         UpdateTargetLawXmlPort,
         UpdateAmendingLawXmlPort,
         UpdateAmendingLawPort {
@@ -115,6 +118,13 @@ public class DBService
   @Override
   public Optional<Norm> loadNorm(LoadNormPort.Command command) {
     return normRepository.findByEli(command.eli()).map(NormMapper::mapToDomain);
+  }
+
+  @Override
+  public Optional<Announcement> loadAnnouncement(LoadAnnouncementPort.Command command) {
+    return announcementRepository
+        .findByNormDtoEli(command.eli())
+        .map(AnnouncementMapper::mapToDomain);
   }
 
   @Override

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/LoadAllAnnouncementsPort.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/LoadAllAnnouncementsPort.java
@@ -1,0 +1,16 @@
+package de.bund.digitalservice.ris.norms.application.port.output;
+
+import de.bund.digitalservice.ris.norms.domain.entity.Announcement;
+import java.util.List;
+
+/** Port interface for loading all {@link Announcement}s from the storage. */
+public interface LoadAllAnnouncementsPort {
+
+  /**
+   * Loads all {@link Announcement}s available in the system.
+   *
+   * @return A {@link List} of {@link Announcement}, which may be empty if no Announcement are
+   *     found.
+   */
+  List<Announcement> loadAllAnnouncements();
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/LoadAnnouncementPort.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/LoadAnnouncementPort.java
@@ -1,0 +1,32 @@
+package de.bund.digitalservice.ris.norms.application.port.output;
+
+import de.bund.digitalservice.ris.norms.domain.entity.Announcement;
+import java.util.Optional;
+
+/**
+ * Interface representing a port for loading a {@link Announcement} based on the ELI (European
+ * Legislation Identifier) of its {@link de.bund.digitalservice.ris.norms.domain.entity.Norm}.
+ * Implementations of this interface should provide functionality to load a announcement using the
+ * specified command.
+ */
+public interface LoadAnnouncementPort {
+
+  /**
+   * Loads a {@link Announcement} based on the provided ELI specified in the command.
+   *
+   * @param command The command specifying the ELI to identify the norm of the announcement to be
+   *     loaded.
+   * @return An {@link Optional} containing the loaded {@link Announcement} if found, or empty if
+   *     not found.
+   */
+  Optional<Announcement> loadAnnouncement(final Command command);
+
+  /**
+   * A record representing the command for loading an announcement. The command includes the ELI
+   * (European Legislation Identifier) to identify the announcement.
+   *
+   * @param eli The ELI (European Legislation Identifier) used to identify the announcement in the
+   *     command.
+   */
+  record Command(String eli) {}
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/LoadNormPort.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/LoadNormPort.java
@@ -1,0 +1,28 @@
+package de.bund.digitalservice.ris.norms.application.port.output;
+
+import de.bund.digitalservice.ris.norms.domain.entity.Norm;
+import java.util.Optional;
+
+/**
+ * Interface representing a port for loading a {@link Norm} based on the ELI (European Legislation
+ * Identifier). Implementations of this interface should provide functionality to load a norm using
+ * the specified command.
+ */
+public interface LoadNormPort {
+
+  /**
+   * Loads a {@link Norm} based on the provided ELI specified in the command.
+   *
+   * @param command The command specifying the ELI to identify the norm to be loaded.
+   * @return An {@link Optional} containing the loaded {@link Norm} if found, or empty if not found.
+   */
+  Optional<Norm> loadNorm(final Command command);
+
+  /**
+   * A record representing the command for loading a norm. The command includes the ELI (European
+   * Legislation Identifier) to identify the norm.
+   *
+   * @param eli The ELI (European Legislation Identifier) used to identify the norm in the command.
+   */
+  record Command(String eli) {}
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/UpdateAnnouncementPort.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/UpdateAnnouncementPort.java
@@ -1,0 +1,27 @@
+package de.bund.digitalservice.ris.norms.application.port.output;
+
+import de.bund.digitalservice.ris.norms.domain.entity.Announcement;
+import java.util.Optional;
+
+/**
+ * Interface representing a port for updating an {@link Announcement}. Implementations of this
+ * interface should provide functionality to update an announcement using the specified command.
+ */
+public interface UpdateAnnouncementPort {
+
+  /**
+   * Updates a {@link Announcement} based on the provided data in the command.
+   *
+   * @param command The command specifying the announcement to be updated.
+   * @return An {@link Optional} containing the {@link Announcement} if found, or empty if not
+   *     found.
+   */
+  Optional<Announcement> updateAnnouncement(final Command command);
+
+  /**
+   * A record representing the command for updating an announcement.
+   *
+   * @param announcement The updated announcement.
+   */
+  record Command(Announcement announcement) {}
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/UpdateNormPort.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/UpdateNormPort.java
@@ -1,0 +1,26 @@
+package de.bund.digitalservice.ris.norms.application.port.output;
+
+import de.bund.digitalservice.ris.norms.domain.entity.Norm;
+import java.util.Optional;
+
+/**
+ * Interface representing a port for updating a {@link Norm}. Implementations of this interface
+ * should provide functionality to update a norm using the specified command.
+ */
+public interface UpdateNormPort {
+
+  /**
+   * Updates a {@link Norm} based on the provided data in the command.
+   *
+   * @param command The command specifying the norm to be updated.
+   * @return An {@link Optional} containing the {@link Norm} if found, or empty if not found.
+   */
+  Optional<Norm> updateNorm(final Command command);
+
+  /**
+   * A record representing the command for updating a norm.
+   *
+   * @param norm The updated norm.
+   */
+  record Command(Norm norm) {}
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Announcement.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Announcement.java
@@ -1,0 +1,19 @@
+package de.bund.digitalservice.ris.norms.domain.entity;
+
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * Class representing an article entity. This class is annotated with Lombok annotations for
+ * generating getters, setters, constructors, and builder methods.
+ */
+@SuperBuilder(toBuilder = true)
+@AllArgsConstructor
+@Data
+public class Announcement {
+  private Instant releasedByDocumentalistAt;
+
+  private Norm norm;
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/NormDtoTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/NormDtoTest.java
@@ -1,0 +1,74 @@
+package de.bund.digitalservice.ris.norms.adapter.output.database.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Locale;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class NormDtoTest {
+
+  private static Validator validator;
+
+  @BeforeAll
+  public static void setUp() {
+    Locale.setDefault(Locale.ENGLISH);
+    final ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @Test
+  void testAllConstraintsAreMet() {
+    // Given
+    var xml =
+        """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """;
+    var guid = UUID.fromString("c01334e2-f12b-4055-ac82-15ac03c74c78");
+    var eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
+
+    // When
+    final NormDto normDto = NormDto.builder().xml(xml).eli(eli).guid(guid).build();
+    final Set<ConstraintViolation<NormDto>> violations = validator.validate(normDto);
+
+    // Then
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  void testMissingNotNullProperties() {
+    // Given
+    final NormDto normDto = new NormDto();
+
+    // When
+    final Set<ConstraintViolation<NormDto>> violations = validator.validate(normDto);
+
+    // Then
+    assertThat(violations)
+        .hasSize(3)
+        .extracting(
+            violation -> violation.getPropertyPath().toString() + " " + violation.getMessage())
+        .containsExactlyInAnyOrder(
+            "eli must not be null", "guid must not be null", "xml must not be null");
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/AnnouncementMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/AnnouncementMapperTest.java
@@ -1,0 +1,100 @@
+package de.bund.digitalservice.ris.norms.adapter.output.database.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.bund.digitalservice.ris.norms.adapter.output.database.dto.AnnouncementDto;
+import de.bund.digitalservice.ris.norms.adapter.output.database.dto.NormDto;
+import de.bund.digitalservice.ris.norms.domain.entity.Announcement;
+import de.bund.digitalservice.ris.norms.domain.entity.Norm;
+import java.time.Instant;
+import java.util.UUID;
+import javax.xml.transform.TransformerException;
+import javax.xml.xpath.XPathExpressionException;
+import org.junit.jupiter.api.Test;
+
+class AnnouncementMapperTest {
+
+  @Test
+  void itShouldMapToDomain() {
+    // Given
+    var xml =
+        """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                          </akn:FRBRExpression>
+                       </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """;
+    var normDto =
+        NormDto.builder()
+            .xml(xml)
+            .eli("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+            .guid(UUID.fromString("ba44d2ae-0e73-44ba-850a-932ab2fa553f"))
+            .build();
+    var announcementDto =
+        AnnouncementDto.builder().releasedByDocumentalistAt(Instant.now()).normDto(normDto).build();
+
+    // When
+    final Announcement announcement = AnnouncementMapper.mapToDomain(announcementDto);
+
+    // Then
+    assertThat(announcement).isNotNull();
+    assertThat(announcement.getNorm().getEli()).contains(announcementDto.getNormDto().getEli());
+    assertThat(announcement.getReleasedByDocumentalistAt())
+        .isEqualTo(announcementDto.getReleasedByDocumentalistAt());
+  }
+
+  @Test
+  void itShouldMapToDto() throws XPathExpressionException, TransformerException {
+    // Given
+    var xml =
+        """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                          </akn:FRBRExpression>
+                       </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """;
+    var announcement =
+        Announcement.builder()
+            .norm(Norm.builder().document(XmlMapper.toDocument(xml)).build())
+            .releasedByDocumentalistAt(Instant.now())
+            .build();
+
+    // When
+    final AnnouncementDto announcementDto = AnnouncementMapper.mapToDto(announcement);
+
+    // Then
+    assertThat(announcementDto).isNotNull();
+    assertThat(announcementDto.getNormDto().getEli())
+        .isEqualTo(announcement.getNorm().getEli().get());
+    assertThat(announcementDto.getReleasedByDocumentalistAt())
+        .isEqualTo(announcement.getReleasedByDocumentalistAt());
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/NormMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/NormMapperTest.java
@@ -1,0 +1,88 @@
+package de.bund.digitalservice.ris.norms.adapter.output.database.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.bund.digitalservice.ris.norms.adapter.output.database.dto.NormDto;
+import de.bund.digitalservice.ris.norms.domain.entity.Norm;
+import java.util.UUID;
+import javax.xml.transform.TransformerException;
+import javax.xml.xpath.XPathExpressionException;
+import org.junit.jupiter.api.Test;
+
+class NormMapperTest {
+
+  @Test
+  void itShouldMapToDomain() {
+    // Given
+    var xml =
+        """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                          </akn:FRBRExpression>
+                       </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """;
+    var normDto =
+        NormDto.builder()
+            .xml(xml)
+            .eli("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+            .guid(UUID.fromString("c01334e2-f12b-4055-ac82-15ac03c74c78"))
+            .build();
+
+    // When
+    final Norm norm = NormMapper.mapToDomain(normDto);
+
+    // Then
+    assertThat(norm).isNotNull();
+    assertThat(norm.getDocument().isEqualNode(XmlMapper.toDocument(xml))).isTrue();
+  }
+
+  @Test
+  void itShouldMapToDto() throws XPathExpressionException, TransformerException {
+    // Given
+    var xml =
+        """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                          </akn:FRBRExpression>
+                       </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """;
+    var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
+
+    // When
+    final NormDto normDto = NormMapper.mapToDto(norm);
+
+    // Then
+    assertThat(normDto).isNotNull();
+    assertThat(XmlMapper.toDocument(normDto.getXml()).isEqualNode(norm.getDocument())).isTrue();
+    assertThat(normDto.getEli()).isEqualTo(norm.getEli().get());
+    assertThat(normDto.getGuid()).isEqualTo(norm.getGuid().get());
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/XmlMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/XmlMapperTest.java
@@ -1,0 +1,76 @@
+package de.bund.digitalservice.ris.norms.adapter.output.database.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+class XmlMapperTest {
+
+  @Test
+  void itCanConvertTextToXml() {
+    // Given
+    var text =
+        """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """;
+
+    // When
+    final Document document = XmlMapper.toDocument(text);
+
+    // Then
+    assertThat(
+            document
+                .getElementsByTagName("akn:act")
+                .item(0)
+                .getAttributes()
+                .getNamedItem("name")
+                .getNodeValue())
+        .isEqualTo("regelungstext");
+  }
+
+  @Test
+  void itCanConvertTextToXmlAndBack() {
+    // Given
+    var text =
+        """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+               <akn:act name="regelungstext">
+                  <!-- Metadaten -->
+                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                        </akn:FRBRExpression>
+                    </akn:identification>
+                  </akn:meta>
+               </akn:act>
+            </akn:akomaNtoso>
+            """;
+
+    // When
+    final Document document = XmlMapper.toDocument(text);
+    final String text2 = XmlMapper.toString(document);
+    final Document document2 = XmlMapper.toDocument(text2);
+
+    // Then
+    assertThat(document.isEqualNode(document2)).isTrue();
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormTest.java
@@ -279,6 +279,172 @@ class NormTest {
     assertThat(actualPublishingDate).isEqualTo(expectedPublishingDate);
   }
 
+  @Test
+  void equalsShouldEqualWithSameXml() {
+    // given
+    String xml =
+        """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                              <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                              <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                              <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                           </akn:FRBRWork>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """;
+
+    Norm norm1 = new Norm(stringToXmlDocument(xml));
+    Norm norm2 = new Norm(stringToXmlDocument(xml));
+
+    // then
+    assertThat(norm1).isEqualTo(norm2);
+  }
+
+  @Test
+  void equalsShouldNotEqualWithDifferentXml() {
+    // given
+    String xml1 =
+        """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                              <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                              <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                              <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                           </akn:FRBRWork>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """;
+
+    String xml2 =
+        """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                              <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                              <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                              <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-06" name="verkuendungsfassung" />
+                           </akn:FRBRWork>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """;
+
+    Norm norm1 = new Norm(stringToXmlDocument(xml1));
+    Norm norm2 = new Norm(stringToXmlDocument(xml2));
+
+    // then
+    assertThat(norm1).isNotEqualTo(norm2);
+  }
+
+  @Test
+  void hashCodeShouldBeTheSameWithSameXml() {
+    // given
+    String xml =
+        """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                              <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                              <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                              <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                           </akn:FRBRWork>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """;
+
+    Norm norm1 = new Norm(stringToXmlDocument(xml));
+    Norm norm2 = new Norm(stringToXmlDocument(xml));
+
+    // then
+    assertThat(norm1.hashCode()).isEqualTo(norm2.hashCode());
+  }
+
+  @Test
+  void hashCodeShouldBeDifferentWithDifferentXml() {
+    // given
+    String xml1 =
+        """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                              <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                              <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                              <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                           </akn:FRBRWork>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """;
+
+    String xml2 =
+        """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                              <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                              <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                              <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-06" name="verkuendungsfassung" />
+                           </akn:FRBRWork>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """;
+
+    Norm norm1 = new Norm(stringToXmlDocument(xml1));
+    Norm norm2 = new Norm(stringToXmlDocument(xml2));
+
+    // then
+    assertThat(norm1.hashCode()).isNotEqualTo(norm2.hashCode());
+  }
+
   private Document stringToXmlDocument(String xmlText) {
 
     final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/DBServiceIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/DBServiceIntegrationTest.java
@@ -776,4 +776,64 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
     // Then
     assertThat(normFromDatabase).contains(newNorm);
   }
+
+  @Test
+  void itUpdatesAnnouncement() throws XPathExpressionException, TransformerException {
+    // Given
+    final String xml =
+        """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+                    </akn:meta>
+
+                    <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                       <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                          <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                             <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Verkündungsfassung</akn:docStage>
+                             <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Gesetz zum ersten Teil der
+                                Reform des Nachrichtendienstrechts</akn:docTitle>
+                          </akn:p>
+                       </akn:longTitle>
+                       <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                          <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="2023-12-29">Vom
+                             29.12.2023</akn:date>
+                       </akn:block>
+                    </akn:preface>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """;
+    var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
+    var announcement =
+        Announcement.builder()
+            .norm(norm)
+            .releasedByDocumentalistAt(Instant.parse("2024-01-02T10:20:30.0Z"))
+            .build();
+    announcementRepository.save(AnnouncementMapper.mapToDto(announcement));
+
+    var newAnnouncement =
+        Announcement.builder()
+            .norm(norm)
+            .releasedByDocumentalistAt(Instant.parse("2024-02-03T10:20:30.0Z"))
+            .build();
+
+    // When
+    var announcementFromDatabase =
+        dbService.updateAnnouncement(new UpdateAnnouncementPort.Command(newAnnouncement));
+
+    // Then
+    assertThat(announcementFromDatabase).contains(newAnnouncement);
+  }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/DBServiceIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/DBServiceIntegrationTest.java
@@ -3,6 +3,7 @@ package de.bund.digitalservice.ris.norms.integration.adapter.output.database;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.AmendingLawMapper;
+import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.AnnouncementMapper;
 import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.NormMapper;
 import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.TargetLawMapper;
 import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.XmlMapper;
@@ -13,6 +14,7 @@ import de.bund.digitalservice.ris.norms.adapter.output.database.repository.Targe
 import de.bund.digitalservice.ris.norms.adapter.output.database.service.DBService;
 import de.bund.digitalservice.ris.norms.application.port.output.*;
 import de.bund.digitalservice.ris.norms.domain.entity.AmendingLaw;
+import de.bund.digitalservice.ris.norms.domain.entity.Announcement;
 import de.bund.digitalservice.ris.norms.domain.entity.Article;
 import de.bund.digitalservice.ris.norms.domain.entity.Norm;
 import de.bund.digitalservice.ris.norms.domain.entity.TargetLaw;
@@ -564,5 +566,48 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
 
     // Then
     assertThat(normOptional).isPresent().satisfies(normDb -> assertThat(normDb).contains(norm));
+  }
+
+  @Test
+  void itFindsAnnouncementOnDB() throws XPathExpressionException, TransformerException {
+    // Given
+    final String xml =
+        """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """;
+
+    // When
+    var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
+    var announcement =
+        Announcement.builder().releasedByDocumentalistAt(Instant.now()).norm(norm).build();
+    announcementRepository.save(AnnouncementMapper.mapToDto(announcement));
+
+    // When
+    final Optional<Announcement> announcementOptional =
+        dbService.loadAnnouncement(
+            new LoadAnnouncementPort.Command(
+                "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"));
+
+    // Then
+    assertThat(announcementOptional)
+        .isPresent()
+        .satisfies(announcementDb -> assertThat(announcementDb).contains(announcement));
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/DBServiceIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/DBServiceIntegrationTest.java
@@ -596,7 +596,10 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
     // When
     var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
     var announcement =
-        Announcement.builder().releasedByDocumentalistAt(Instant.now()).norm(norm).build();
+        Announcement.builder()
+            .releasedByDocumentalistAt(Instant.parse("2024-01-02T10:20:30.00Z"))
+            .norm(norm)
+            .build();
     announcementRepository.save(AnnouncementMapper.mapToDto(announcement));
 
     // When
@@ -671,13 +674,13 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
     // When
     var announcement1 =
         Announcement.builder()
-            .releasedByDocumentalistAt(Instant.now())
+            .releasedByDocumentalistAt(Instant.parse("2024-01-01T10:20:30.00Z"))
             .norm(Norm.builder().document(XmlMapper.toDocument(xml1)).build())
             .build();
     announcementRepository.save(AnnouncementMapper.mapToDto(announcement1));
     var announcement2 =
         Announcement.builder()
-            .releasedByDocumentalistAt(Instant.now())
+            .releasedByDocumentalistAt(Instant.parse("2024-01-02T10:20:30.00Z"))
             .norm(Norm.builder().document(XmlMapper.toDocument(xml2)).build())
             .build();
     announcementRepository.save(AnnouncementMapper.mapToDto(announcement2));

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/DBServiceIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/DBServiceIntegrationTest.java
@@ -3,19 +3,26 @@ package de.bund.digitalservice.ris.norms.integration.adapter.output.database;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.AmendingLawMapper;
+import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.NormMapper;
 import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.TargetLawMapper;
+import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.XmlMapper;
 import de.bund.digitalservice.ris.norms.adapter.output.database.repository.AmendingLawRepository;
+import de.bund.digitalservice.ris.norms.adapter.output.database.repository.AnnouncementRepository;
+import de.bund.digitalservice.ris.norms.adapter.output.database.repository.NormRepository;
 import de.bund.digitalservice.ris.norms.adapter.output.database.repository.TargetLawRepository;
 import de.bund.digitalservice.ris.norms.adapter.output.database.service.DBService;
 import de.bund.digitalservice.ris.norms.application.port.output.*;
 import de.bund.digitalservice.ris.norms.domain.entity.AmendingLaw;
 import de.bund.digitalservice.ris.norms.domain.entity.Article;
+import de.bund.digitalservice.ris.norms.domain.entity.Norm;
 import de.bund.digitalservice.ris.norms.domain.entity.TargetLaw;
 import de.bund.digitalservice.ris.norms.integration.BaseIntegrationTest;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import javax.xml.transform.TransformerException;
+import javax.xml.xpath.XPathExpressionException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +34,10 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
   @Autowired private AmendingLawRepository amendingLawRepository;
 
   @Autowired private TargetLawRepository targetLawRepository;
+
+  @Autowired private AnnouncementRepository announcementRepository;
+
+  @Autowired private NormRepository normRepository;
 
   final TargetLaw targetLaw =
       TargetLaw.builder()
@@ -55,6 +66,8 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
   void cleanUp() {
     amendingLawRepository.deleteAll();
     targetLawRepository.deleteAll();
+    announcementRepository.deleteAll();
+    normRepository.deleteAll();
   }
 
   @Test
@@ -513,5 +526,43 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
     assertThat(amendingLawFromDatabase.getTitle()).isEqualTo(title2);
     assertThat(amendingLawFromDatabase.getXml()).isEqualTo(xml2);
     assertThat(amendingLawFromDatabase.getReleasedAt()).isEqualTo(timestampNow2);
+  }
+
+  @Test
+  void itFindsNormOnDB() throws XPathExpressionException, TransformerException {
+    // Given
+    final String xml =
+        """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """;
+
+    // When
+    var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
+    normRepository.save(NormMapper.mapToDto(norm));
+
+    // When
+    final Optional<Norm> normOptional =
+        dbService.loadNorm(
+            new LoadNormPort.Command("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"));
+
+    // Then
+    assertThat(normOptional).isPresent().satisfies(normDb -> assertThat(normDb).contains(norm));
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/DBServiceIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/DBServiceIntegrationTest.java
@@ -610,4 +610,82 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
         .isPresent()
         .satisfies(announcementDb -> assertThat(announcementDb).contains(announcement));
   }
+
+  @Test
+  void itLoadsAllAnnouncementsFromDB() throws XPathExpressionException, TransformerException {
+    // Given
+    final String xml1 =
+        """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                            <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                            <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                            <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                          </akn:FRBRWork>
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """;
+
+    final String xml2 =
+        """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                            <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="413" />
+                            <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                            <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="2023-12-29" name="verkuendungsfassung" />
+                          </akn:FRBRWork>
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """;
+
+    // When
+    var announcement1 =
+        Announcement.builder()
+            .releasedByDocumentalistAt(Instant.now())
+            .norm(Norm.builder().document(XmlMapper.toDocument(xml1)).build())
+            .build();
+    announcementRepository.save(AnnouncementMapper.mapToDto(announcement1));
+    var announcement2 =
+        Announcement.builder()
+            .releasedByDocumentalistAt(Instant.now())
+            .norm(Norm.builder().document(XmlMapper.toDocument(xml2)).build())
+            .build();
+    announcementRepository.save(AnnouncementMapper.mapToDto(announcement2));
+
+    // When
+    final List<Announcement> announcements = dbService.loadAllAnnouncements();
+
+    // Then
+    assertThat(announcements).containsExactly(announcement2, announcement1);
+  }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/DBServiceIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/DBServiceIntegrationTest.java
@@ -688,4 +688,89 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
     // Then
     assertThat(announcements).containsExactly(announcement2, announcement1);
   }
+
+  @Test
+  void itUpdatesNorm() throws XPathExpressionException, TransformerException {
+    // Given
+    final String oldXml =
+        """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+                    </akn:meta>
+
+                    <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                       <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                          <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                             <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Verkündungsfassung</akn:docStage>
+                             <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Gesetz zum ersten Teil der
+                                Reform des Nachrichtendienstrechts</akn:docTitle>
+                          </akn:p>
+                       </akn:longTitle>
+                       <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                          <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="2023-12-29">Vom
+                             29.12.2023</akn:date>
+                       </akn:block>
+                    </akn:preface>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """;
+    var oldNorm = Norm.builder().document(XmlMapper.toDocument(oldXml)).build();
+    normRepository.save(NormMapper.mapToDto(oldNorm));
+
+    final String newXml =
+        """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                          </akn:FRBRExpression>
+                       </akn:identification>
+                    </akn:meta>
+
+                    <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                       <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                          <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                             <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Verkündungsfassung</akn:docStage>
+                             <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Gesetz zum zweiten Teil der
+                                Reform des Nachrichtendienstrechts</akn:docTitle>
+                          </akn:p>
+                       </akn:longTitle>
+                       <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                          <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="2024-02-01">Vom
+                             01.02.2024</akn:date>
+                       </akn:block>
+                    </akn:preface>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """;
+    var newNorm = Norm.builder().document(XmlMapper.toDocument(newXml)).build();
+
+    // When
+    var normFromDatabase = dbService.updateNorm(new UpdateNormPort.Command(newNorm));
+
+    // Then
+    assertThat(normFromDatabase).contains(newNorm);
+  }
 }


### PR DESCRIPTION
Todo:

* [x] saving of announcements
* [x] adjustments once the Norms Domain Object exists (see todo comments, also there are some changes in this PR to that class that need to be overwritten by the changes made to the norms domain object as they where only made here to be able to implement the other stuff here already)