### PR TITLE
fix: change how layout is implemented

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -4,7 +4,9 @@ import RisNavbar from "@/components/controls/RisNavbar.vue"
 </script>
 
 <template>
-  <RisNavbar />
+  <RisNavbar class="fixed inset-x-0 top-0" />
 
-  <RouterView />
+  <div class="pt-80">
+    <RouterView />
+  </div>
 </template>

--- a/frontend/src/components/controls/RisNavbarSide.vue
+++ b/frontend/src/components/controls/RisNavbarSide.vue
@@ -137,7 +137,7 @@ export interface LevelTwoMenuItem {
 </script>
 
 <template>
-  <aside aria-labelledby="sidebarNavigation" class="w-[16rem]">
+  <aside aria-labelledby="sidebarNavigation">
     <span id="sidebarNavigation" hidden>SideBar Navigation</span>
     <router-link
       class="ds-link-01-bold flex h-80 items-center gap-12 border-b border-gray-400 px-14 text-blue-800"

--- a/frontend/src/views/AmendingLaw.vue
+++ b/frontend/src/views/AmendingLaw.vue
@@ -37,27 +37,31 @@ const { alerts, hideAlert } = useAlerts()
 </script>
 
 <template>
-  <div v-if="amendingLaw" class="flex min-h-screen flex-col bg-gray-100">
-    <RisAmendingLawInfoHeader :amending-law="amendingLaw" />
-    <div class="flex">
-      <RisNavbarSide
-        class="min-h-screen flex-none border-r border-gray-400 bg-white"
-        go-back-label="Zurück"
-        :go-back-route="{ name: 'Home' }"
-        :menu-items="menuItems"
-      />
-      <div class="w-full flex-1">
-        <RisAlert
-          v-for="[key, { variant, message }] in alerts"
-          :key="key"
-          :variant="variant"
-          @click="hideAlert(key)"
-        >
-          {{ message }}
-        </RisAlert>
-        <div class="w-full p-40">
-          <RouterView />
-        </div>
+  <div
+    v-if="amendingLaw"
+    class="grid h-[calc(100dvh-5rem)] grid-cols-[16rem,1fr] grid-rows-[5rem,1fr] overflow-hidden bg-gray-100"
+  >
+    <RisAmendingLawInfoHeader :amending-law="amendingLaw" class="col-span-2" />
+
+    <RisNavbarSide
+      class="col-span-1 w-full overflow-auto border-r border-gray-400 bg-white"
+      go-back-label="Zurück"
+      :go-back-route="{ name: 'Home' }"
+      :menu-items="menuItems"
+    />
+
+    <div class="col-span-1 overflow-auto">
+      <RisAlert
+        v-for="[key, { variant, message }] in alerts"
+        :key="key"
+        :variant="variant"
+        @click="hideAlert(key)"
+      >
+        {{ message }}
+      </RisAlert>
+
+      <div class="p-40">
+        <RouterView />
       </div>
     </div>
   </div>

--- a/frontend/src/views/AmendingLawAffectedDocumentEditor.vue
+++ b/frontend/src/views/AmendingLawAffectedDocumentEditor.vue
@@ -74,7 +74,7 @@ async function handleGeneratePreview() {
       <span>Zurück</span>
     </RouterLink>
 
-    <div class="flex h-dvh flex-col p-40">
+    <div class="flex h-[calc(100dvh-5rem)] flex-col p-40">
       <div class="mb-40 flex gap-16">
         <div class="flex-grow">
           <h1 class="ds-heading-02-reg">{{ targetLaw?.title }}</h1>

--- a/frontend/src/views/AmendingLawArticleEditor.vue
+++ b/frontend/src/views/AmendingLawArticleEditor.vue
@@ -135,7 +135,7 @@ watch(articleXml, (articleXml) => {
       <span>Zurück</span>
     </router-link>
 
-    <div class="flex h-dvh flex-col p-40">
+    <div class="flex h-[calc(100dvh-5rem)] flex-col p-40">
       <div class="mb-40 flex gap-16">
         <div class="flex-grow">
           <h1 class="ds-heading-02-reg">Artikel {{ article?.enumeration }}</h1>


### PR DESCRIPTION
In order to implement some advanced nested scrolling behavior such as required for the Zeitgrenzen management screen, we need layouting that is a bit more predictable. Note that this involves making headers fixed, which is not ideal because it takes up a lot of space. But since headers are going to be reworked some time soon (hopefully) anyways, that's fine for now.

RISDEV-3742