### PR TITLE
refactor: base article class on XML node

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Norm.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Norm.java
@@ -113,28 +113,7 @@ public class Norm {
 
     for (int i = 0; i < allArticles.get().getLength(); i++) {
       final Node articleNode = allArticles.get().item(i);
-
-      final Optional<String> guid = NodeParser.getValueFromExpression("./@GUID", articleNode);
-      final Optional<String> eId = NodeParser.getValueFromExpression("./@eId", articleNode);
-      final Optional<String> heading =
-          NodeParser.getValueFromExpression("./heading/text()", articleNode);
-      // not(normalize-space() is needed to filter out whitespaces which occur due to inner nodes
-      // like akn:marker
-      final Optional<String> enumeration =
-          NodeParser.getValueFromExpression(
-              "./num/text()[not(normalize-space() = '')]", articleNode);
-
-      final Optional<String> affectedDocumentEli =
-          NodeParser.getValueFromExpression(".//affectedDocument/@href", articleNode);
-
-      NormArticle newArticle =
-          NormArticle.builder()
-              .guid(guid)
-              .eid(eId)
-              .enumeration(enumeration)
-              .title(heading)
-              .affectedDocumentEli(affectedDocumentEli)
-              .build();
+      NormArticle newArticle = NormArticle.builder().node(articleNode).build();
       articles.add(newArticle);
     }
     return articles;

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/NormArticle.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/NormArticle.java
@@ -1,25 +1,84 @@
 package de.bund.digitalservice.ris.norms.domain.entity;
 
+import de.bund.digitalservice.ris.norms.domain.exceptions.XmlProcessingException;
+import java.util.NoSuchElementException;
 import java.util.Optional;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.experimental.SuperBuilder;
+import org.w3c.dom.Node;
 
 /**
- * Class representing an article entity. This class is annotated with Lombok annotations for
- * generating getters, setters, constructors, and builder methods.
+ * Represents an article inside a law with various attributes. This class is annotated with Lombok
+ * annotations for generating getters, setters, constructors, and builder methods.
  */
 @SuperBuilder(toBuilder = true)
 @AllArgsConstructor
-@Data
 public class NormArticle {
-  private Optional<String> guid;
+  @Getter private final Node node;
 
-  private Optional<String> enumeration;
+  /**
+   * Returns a GUID as {@link UUID} from a {@link Node} in a {@link Norm}.
+   *
+   * @return The GUID of the article
+   */
+  public Optional<String> getGuid() {
+    return getValueFromExpression("./@GUID", this.node);
+  }
 
-  private Optional<String> eid;
+  /**
+   * Returns the enumeration as {@link String} from a {@link Node} in a {@link Norm}.
+   *
+   * @return The enumeration of the article
+   */
+  public Optional<String> getEnumeration() {
+    // not(normalize-space() is needed to filter out whitespaces which occur due to inner nodes
+    // like akn:marker
+    return getValueFromExpression("./num/text()[not(normalize-space() = '')]", this.node);
+  }
 
-  private Optional<String> title;
+  /**
+   * Returns the eId as {@link String} from a {@link Node} in a {@link Norm}.
+   *
+   * @return The eId of the article
+   */
+  public Optional<String> getEid() {
+    return getValueFromExpression("./@eId", this.node);
+  }
 
-  private Optional<String> affectedDocumentEli;
+  /**
+   * Returns the heading as {@link String} from a {@link Node} in a {@link Norm}.
+   *
+   * @return The heading of the article
+   */
+  public Optional<String> getHeading() {
+    return getValueFromExpression("./heading/text()", this.node);
+  }
+
+  /**
+   * Returns the ELI of the affected document as {@link String} from a {@link Node} in a {@link
+   * Norm}.
+   *
+   * @return The ELI of the affected document of the article
+   */
+  public Optional<String> getAffectedDocumentEli() {
+    return getValueFromExpression(".//affectedDocument/@href", this.node);
+  }
+
+  private Optional<String> getValueFromExpression(String expression, Node xmlNode) {
+    XPath xPath = XPathFactory.newInstance().newXPath();
+    String result;
+    try {
+      result = (String) xPath.evaluate(expression, xmlNode, XPathConstants.STRING);
+    } catch (XPathExpressionException | NoSuchElementException e) {
+      throw new XmlProcessingException(e.getMessage(), e);
+    }
+    if (result.isEmpty()) return Optional.empty();
+
+    return Optional.of(result);
+  }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/NormArticle.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/NormArticle.java
@@ -1,12 +1,8 @@
 package de.bund.digitalservice.ris.norms.domain.entity;
 
-import de.bund.digitalservice.ris.norms.domain.exceptions.XmlProcessingException;
-import java.util.NoSuchElementException;
+import de.bund.digitalservice.ris.norms.utils.NodeParser;
 import java.util.Optional;
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
@@ -27,7 +23,7 @@ public class NormArticle {
    * @return The GUID of the article
    */
   public Optional<String> getGuid() {
-    return getValueFromExpression("./@GUID", this.node);
+    return NodeParser.getValueFromExpression("./@GUID", this.node);
   }
 
   /**
@@ -38,7 +34,8 @@ public class NormArticle {
   public Optional<String> getEnumeration() {
     // not(normalize-space() is needed to filter out whitespaces which occur due to inner nodes
     // like akn:marker
-    return getValueFromExpression("./num/text()[not(normalize-space() = '')]", this.node);
+    return NodeParser.getValueFromExpression(
+        "./num/text()[not(normalize-space() = '')]", this.node);
   }
 
   /**
@@ -47,7 +44,7 @@ public class NormArticle {
    * @return The eId of the article
    */
   public Optional<String> getEid() {
-    return getValueFromExpression("./@eId", this.node);
+    return NodeParser.getValueFromExpression("./@eId", this.node);
   }
 
   /**
@@ -56,7 +53,7 @@ public class NormArticle {
    * @return The heading of the article
    */
   public Optional<String> getHeading() {
-    return getValueFromExpression("./heading/text()", this.node);
+    return NodeParser.getValueFromExpression("./heading/text()", this.node);
   }
 
   /**
@@ -66,19 +63,6 @@ public class NormArticle {
    * @return The ELI of the affected document of the article
    */
   public Optional<String> getAffectedDocumentEli() {
-    return getValueFromExpression(".//affectedDocument/@href", this.node);
-  }
-
-  private Optional<String> getValueFromExpression(String expression, Node xmlNode) {
-    XPath xPath = XPathFactory.newInstance().newXPath();
-    String result;
-    try {
-      result = (String) xPath.evaluate(expression, xmlNode, XPathConstants.STRING);
-    } catch (XPathExpressionException | NoSuchElementException e) {
-      throw new XmlProcessingException(e.getMessage(), e);
-    }
-    if (result.isEmpty()) return Optional.empty();
-
-    return Optional.of(result);
+    return NodeParser.getValueFromExpression(".//affectedDocument/@href", this.node);
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/utils/XmlMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/utils/XmlMapper.java
@@ -13,10 +13,14 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import net.sf.saxon.TransformerFactoryImpl;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-/** Mapper class for converting between a string containing xml and {@link org.w3c.dom.Document}. */
+/**
+ * Mapper class for converting between a string containing xml and various types of w3c DOM
+ * elements.
+ */
 public class XmlMapper {
 
   // Private constructor to hide the implicit public one and prevent instantiation
@@ -48,18 +52,29 @@ public class XmlMapper {
   }
 
   /**
-   * Maps a {@link Document} to a string.
+   * Maps a string containing xml to a {@link Node}.
    *
-   * @param document The input {@link Document} to be mapped to a string
-   * @return the resulting text representation of the {@link Document}
+   * @param xmlText The input string containing xml to be mapped to a {@link Node}
+   * @return the resulting {@link Node}
    */
-  public static String toString(Document document) {
+  public static Node toNode(String xmlText) {
+    return toDocument(xmlText).getDocumentElement();
+  }
+
+  /**
+   * Maps a {@link Node} to a string. This can also be used for an entire {@link Document}, as a
+   * document is just a more specific version of a node.
+   *
+   * @param node The input {@link Node} to be mapped to a string
+   * @return the resulting text representation of the {@link Node}
+   */
+  public static String toString(Node node) {
     var writer = new StringWriter();
 
     try {
       new TransformerFactoryImpl()
           .newTransformer()
-          .transform(new DOMSource(document), new StreamResult(writer));
+          .transform(new DOMSource(node), new StreamResult(writer));
     } catch (TransformerException e) {
       throw new XmlProcessingException(e.getMessage(), e);
     }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/XmlMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/XmlMapperTest.java
@@ -9,26 +9,26 @@ import org.w3c.dom.Document;
 class XmlMapperTest {
 
   @Test
-  void itCanConvertTextToXml() {
+  void itCanConvertTextToXmlDocument() {
     // Given
     var text =
         """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                          </akn:FRBRExpression>
-                      </akn:identification>
-                    </akn:meta>
-                 </akn:act>
-              </akn:akomaNtoso>
-            """;
+                          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+                          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                             <akn:act name="regelungstext">
+                                <!-- Metadaten -->
+                                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                                      </akn:FRBRExpression>
+                                  </akn:identification>
+                                </akn:meta>
+                             </akn:act>
+                          </akn:akomaNtoso>
+                        """;
 
     // When
     final Document document = XmlMapper.toDocument(text);
@@ -45,26 +45,26 @@ class XmlMapperTest {
   }
 
   @Test
-  void itCanConvertTextToXmlAndBack() {
+  void itCanConvertTextToXmlDocumentAndBack() {
     // Given
     var text =
         """
-            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-               <akn:act name="regelungstext">
-                  <!-- Metadaten -->
-                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                        </akn:FRBRExpression>
-                    </akn:identification>
-                  </akn:meta>
-               </akn:act>
-            </akn:akomaNtoso>
-            """;
+                        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+                        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                           <akn:act name="regelungstext">
+                              <!-- Metadaten -->
+                              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                                    </akn:FRBRExpression>
+                                </akn:identification>
+                              </akn:meta>
+                           </akn:act>
+                        </akn:akomaNtoso>
+                        """;
 
     // When
     final Document document = XmlMapper.toDocument(text);
@@ -73,5 +73,32 @@ class XmlMapperTest {
 
     // Then
     assertThat(document.isEqualNode(document2)).isTrue();
+  }
+
+  @Test
+  void itCanConvertTextToXmlNode() {
+    // given
+    var text = "<node><inner-node>Hello</inner-node></node>";
+
+    // when
+    var node = XmlMapper.toNode(text);
+
+    // then
+    assertThat(node.getNodeName()).isEqualTo("node");
+    assertThat(node.getChildNodes().item(0).getTextContent()).isEqualTo("Hello");
+  }
+
+  @Test
+  void itCanConvertTextToXmlNodeAndBack() {
+    // given
+    var text = "<node><inner-node>Hello</inner-node></node>";
+
+    // when
+    var node1 = XmlMapper.toNode(text);
+    var asString = XmlMapper.toString(node1);
+    var node2 = XmlMapper.toNode(text);
+
+    // then
+    assertThat(node1.isEqualNode(node2)).isTrue();
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormArticleTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormArticleTest.java
@@ -1,17 +1,9 @@
 package de.bund.digitalservice.ris.norms.domain.entity;
 
+import static de.bund.digitalservice.ris.norms.utils.XmlMapper.toNode;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import de.bund.digitalservice.ris.norms.domain.exceptions.XmlProcessingException;
-import java.io.IOException;
-import java.io.StringReader;
-import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import org.junit.jupiter.api.Test;
-import org.w3c.dom.Node;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
 
 class NormArticleTest {
   @Test
@@ -22,7 +14,7 @@ class NormArticleTest {
                 <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung"></akn:article>
                 """;
 
-    var article = new NormArticle(stringToXmlNode(articleString));
+    var article = new NormArticle(toNode(articleString));
     var expectedGuid = "cdbfc728-a070-42d9-ba2f-357945afef06";
 
     // when
@@ -45,7 +37,7 @@ class NormArticleTest {
                 </akn:article>
                 """;
 
-    var article = new NormArticle(stringToXmlNode(articleString));
+    var article = new NormArticle(toNode(articleString));
     var expectedEnumeration = "Artikel 1";
 
     // when
@@ -64,7 +56,7 @@ class NormArticleTest {
                 </akn:article>
                 """;
 
-    var article = new NormArticle(stringToXmlNode(articleString));
+    var article = new NormArticle(toNode(articleString));
     var expectedEid = "hauptteil-1_art-1";
 
     // when
@@ -84,7 +76,7 @@ class NormArticleTest {
                 </akn:article>
                 """;
 
-    var article = new NormArticle(stringToXmlNode(articleString));
+    var article = new NormArticle(toNode(articleString));
     var expectedHeading = "Änderung des Vereinsgesetzes";
 
     // when
@@ -118,7 +110,7 @@ class NormArticleTest {
                 </akn:article>
                 """;
 
-    var article = new NormArticle(stringToXmlNode(articleString));
+    var article = new NormArticle(toNode(articleString));
     var expectedEli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
 
     // when
@@ -126,23 +118,5 @@ class NormArticleTest {
 
     // then
     assertThat(eli).isEqualTo(expectedEli);
-  }
-
-  private Node stringToXmlNode(String xmlText) {
-    final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-
-    try {
-      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-      factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-      factory.setExpandEntityReferences(false);
-
-      return factory
-          .newDocumentBuilder()
-          .parse(new InputSource((new StringReader(xmlText))))
-          .getDocumentElement();
-
-    } catch (ParserConfigurationException | SAXException | IOException e) {
-      throw new XmlProcessingException(e.getMessage(), e);
-    }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormArticleTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormArticleTest.java
@@ -1,0 +1,148 @@
+package de.bund.digitalservice.ris.norms.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.bund.digitalservice.ris.norms.domain.exceptions.XmlProcessingException;
+import java.io.IOException;
+import java.io.StringReader;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Node;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+class NormArticleTest {
+  @Test
+  void getGuid() {
+    // given
+    String articleString =
+        """
+                <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung"></akn:article>
+                """;
+
+    var article = new NormArticle(stringToXmlNode(articleString));
+    var expectedGuid = "cdbfc728-a070-42d9-ba2f-357945afef06";
+
+    // when
+    var guid = article.getGuid().get();
+
+    // then
+    assertThat(guid).isEqualTo(expectedGuid);
+  }
+
+  @Test
+  void getEnumeration() {
+    // given
+    String articleString =
+        """
+                <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                  <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                    <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />
+                    Artikel 1
+                  </akn:num>
+                </akn:article>
+                """;
+
+    var article = new NormArticle(stringToXmlNode(articleString));
+    var expectedEnumeration = "Artikel 1";
+
+    // when
+    var enumeration = article.getEnumeration().get();
+
+    // then
+    assertThat(enumeration).contains(expectedEnumeration);
+  }
+
+  @Test
+  void getEid() {
+    // given
+    String articleString =
+        """
+                <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                </akn:article>
+                """;
+
+    var article = new NormArticle(stringToXmlNode(articleString));
+    var expectedEid = "hauptteil-1_art-1";
+
+    // when
+    var eid = article.getEid().get();
+
+    // then
+    assertThat(eid).isEqualTo(expectedEid);
+  }
+
+  @Test
+  void getHeading() {
+    // given
+    String articleString =
+        """
+                <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                   <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                </akn:article>
+                """;
+
+    var article = new NormArticle(stringToXmlNode(articleString));
+    var expectedHeading = "Änderung des Vereinsgesetzes";
+
+    // when
+    var heading = article.getHeading().get();
+
+    // then
+    assertThat(heading).isEqualTo(expectedHeading);
+  }
+
+  @Test
+  void getAffectedDocumentEli() {
+    // given
+    String articleString =
+        """
+                <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                  <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                      <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                   <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                   <!-- Absatz (1) -->
+                   <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                      <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                         <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                      </akn:num>
+                      <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                         <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                            <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                  href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                         </akn:intro>
+                      </akn:list>
+                   </akn:paragraph>
+                </akn:article>
+                """;
+
+    var article = new NormArticle(stringToXmlNode(articleString));
+    var expectedEli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
+
+    // when
+    var eli = article.getAffectedDocumentEli().get();
+
+    // then
+    assertThat(eli).isEqualTo(expectedEli);
+  }
+
+  private Node stringToXmlNode(String xmlText) {
+    final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+
+    try {
+      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      factory.setExpandEntityReferences(false);
+
+      return factory
+          .newDocumentBuilder()
+          .parse(new InputSource((new StringReader(xmlText))))
+          .getDocumentElement();
+
+    } catch (ParserConfigurationException | SAXException | IOException e) {
+      throw new XmlProcessingException(e.getMessage(), e);
+    }
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormTest.java
@@ -331,13 +331,13 @@ class NormTest {
 
     // then
     assertThat(actualArticles).hasSize(expectedNumberOfArticles);
-    assertThat(actualArticles.getFirst().getTitle()).contains(firstExpectedHeading);
+    assertThat(actualArticles.getFirst().getHeading()).contains(firstExpectedHeading);
     assertThat(actualArticles.getFirst().getEnumeration()).contains("Artikel 1");
     assertThat(actualArticles.get(0).getEid()).contains("hauptteil-1_art-1");
     assertThat(actualArticles.get(0).getAffectedDocumentEli())
         .contains("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1");
 
-    assertThat(actualArticles.get(1).getTitle()).contains(secondExpectedHeading);
+    assertThat(actualArticles.get(1).getHeading()).contains(secondExpectedHeading);
     assertThat(actualArticles.get(1).getEnumeration()).contains("Artikel 3");
     assertThat(actualArticles.get(1).getEid()).contains("hauptteil-1_art-3");
     assertThat(actualArticles.get(1).getAffectedDocumentEli()).isNotPresent();


### PR DESCRIPTION
This PR:

- refactors the article to use an XML node as its data source
- extends the XML mapper to work with individual nodes in addition to documents