### PR TITLE
Refactor temporal page tests

### DIFF
--- a/frontend/e2e/navigate-to-temporal-data-page-and-test-content.spec.ts
+++ b/frontend/e2e/navigate-to-temporal-data-page-and-test-content.spec.ts
@@ -72,6 +72,7 @@ test.describe("manage temporal data for an amending law", () => {
       await newDateInput.fill("02.06.2023")
 
       await saveButton.click()
+      await sharedPage.waitForResponse(/\/timeBoundaries$/)
       await sharedPage.reload()
 
       await expect(dateInputs).toHaveCount(3)
@@ -92,6 +93,7 @@ test.describe("manage temporal data for an amending law", () => {
       await dateInputToEdit.fill("03.06.2023")
 
       await saveButton.click()
+      await sharedPage.waitForResponse(/\/timeBoundaries$/)
       await sharedPage.reload()
 
       await expect(dateInputs.nth(1)).toHaveValue("03.06.2023")
@@ -109,6 +111,7 @@ test.describe("manage temporal data for an amending law", () => {
         await deleteButton.click()
 
         await saveButton.click()
+        await sharedPage.waitForResponse(/\/timeBoundaries$/)
         await sharedPage.reload()
 
         await expect(dateInputs).toHaveCount(i)

--- a/frontend/src/components/RisTemporalDataIntervals.spec.ts
+++ b/frontend/src/components/RisTemporalDataIntervals.spec.ts
@@ -14,11 +14,14 @@ describe("RisTemporalDateIntervals", () => {
       props: { dates },
     })
 
-    const inputs = screen.getAllByTestId("date-input-field")
+    const inputs = screen.getAllByRole<HTMLInputElement>("textbox", {
+      name: /Zeitgrenze \d+/,
+    })
+
     expect(inputs.length).toBe(dates.length)
 
     inputs.forEach((input, index) => {
-      const inputElement = input as HTMLInputElement
+      const inputElement = input
       const expectedValue = dayjs(dates[index].date).format("DD.MM.YYYY")
       expect(inputElement.value).toBe(expectedValue)
     })
@@ -42,9 +45,17 @@ describe("RisTemporalDateIntervals", () => {
       props: { dates },
     })
 
-    expect(screen.getAllByTestId("date-input-field").length).toBe(2)
-    await user.click(screen.getByTestId("delete-button-0"))
-    expect(screen.getAllByTestId("date-input-field").length).toBe(1)
+    expect(
+      screen.getAllByRole("textbox", { name: /Zeitgrenze \d+/ }),
+    ).toHaveLength(2)
+
+    await user.click(
+      screen.getByRole("button", { name: "Zeitgrenze 1 löschen" }),
+    )
+
+    expect(
+      screen.getAllByRole("textbox", { name: /Zeitgrenze \d+/ }),
+    ).toHaveLength(1)
   })
 
   it("disables the delete button when there is only one date input", async () => {
@@ -53,8 +64,9 @@ describe("RisTemporalDateIntervals", () => {
       props: { dates },
     })
 
-    const deleteButton = screen.getByTestId("delete-button-0")
-    expect(deleteButton).toBeDisabled()
+    expect(
+      screen.getByRole("button", { name: "Zeitgrenze 1 löschen" }),
+    ).toBeDisabled()
   })
 
   it("emits an update when the list of dates is changed, doesn't mutate the model", async () => {
@@ -70,7 +82,9 @@ describe("RisTemporalDateIntervals", () => {
       props: { dates, "onUpdate:dates": onUpdate },
     })
 
-    await user.click(screen.getByTestId("delete-button-0"))
+    await user.click(
+      screen.getByRole("button", { name: "Zeitgrenze 1 löschen" }),
+    )
 
     expect(dates).toStrictEqual([
       { date: "2023-01-01", eid: "event-1", eventRefEid: "ref-1" },

--- a/frontend/src/components/RisTemporalDataIntervals.vue
+++ b/frontend/src/components/RisTemporalDataIntervals.vue
@@ -64,7 +64,6 @@ watch(newDate, async (newDateValue) => {
         :id="`date-${index}`"
         v-model="dateEntry.date"
         size="small"
-        data-testid="date-input-field"
       />
       <RisTextButton
         :icon="DeleteOutlineIcon"
@@ -73,7 +72,6 @@ watch(newDate, async (newDateValue) => {
         :label="`Zeitgrenze ${index + 1} löschen`"
         type="button"
         :disabled="isDeleteDisabled"
-        :data-testid="`delete-button-${index}`"
         icon-only
         @click.prevent="removeDateInput(index)"
       />
@@ -86,12 +84,7 @@ watch(newDate, async (newDateValue) => {
       class="col-span-2 grid grid-cols-subgrid items-center"
     >
       <span>Zeitgrenze hinzufügen</span>
-      <RisDateInput
-        id="new-date"
-        v-model="newDate"
-        size="small"
-        data-testid="new-date-input-field"
-      />
+      <RisDateInput id="new-date" v-model="newDate" size="small" />
     </label>
   </form>
 </template>

--- a/frontend/src/views/TemporalData.vue
+++ b/frontend/src/views/TemporalData.vue
@@ -25,9 +25,7 @@ async function handleSave() {
     class="grid h-full grid-cols-3 grid-rows-[5rem,1fr] gap-x-32 overflow-hidden p-40"
   >
     <div class="col-span-3 mb-40 flex items-center justify-between">
-      <h1 class="ds-heading-02-reg" data-testid="temporalDataHeading">
-        Zeitgrenzen anlegen
-      </h1>
+      <h1 class="ds-heading-02-reg">Zeitgrenzen anlegen</h1>
       <RisTextButton
         label="Speichern"
         size="small"


### PR DESCRIPTION
This PR:

- Splits the tests for changing temporal data into multiple smaller tests in order to make it easier to see what goes wrong and which tests (if any) are flaky
- Removes some sources of flakyness by waiting for API requests to finish before making assertions
- Refactors selectors in E2E tests and unit tests to conform to Playwright/Testing Library best practices
- Removes test IDs