### PR TITLE
Do not handle old text for update mod

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/NormController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/NormController.java
@@ -204,7 +204,6 @@ public class NormController {
                 updateModRequestSchema.getRefersTo(),
                 updateModRequestSchema.getTimeBoundaryEid(),
                 updateModRequestSchema.getDestinationHref(),
-                updateModRequestSchema.getOldText(),
                 updateModRequestSchema.getNewText(),
                 dryRun))
         .map(UpdateModResponseMapper::fromResult)

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/UpdateModRequestSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/UpdateModRequestSchema.java
@@ -14,6 +14,5 @@ public class UpdateModRequestSchema {
   @NotNull private String refersTo;
   private String timeBoundaryEid;
   @NotNull private String destinationHref;
-  @NotNull private String oldText;
   @NotNull private String newText;
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/UpdateModUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/UpdateModUseCase.java
@@ -30,7 +30,6 @@ public interface UpdateModUseCase {
    * @param refersTo - the type of the amending command
    * @param timeBoundaryEid - the eId of the temporal group of the time boundary
    * @param destinationHref - the ELI + eid + counting of the target law
-   * @param oldText - the previous text that should be replaced
    * @param newText - the new text to replace the old one
    * @param dryRun - if true the updating is executed but the results are discarded and not saved.
    *     Default: false
@@ -41,7 +40,6 @@ public interface UpdateModUseCase {
       String refersTo,
       String timeBoundaryEid,
       String destinationHref,
-      String oldText,
       String newText,
       boolean dryRun) {
     public Query(
@@ -50,9 +48,8 @@ public interface UpdateModUseCase {
         String refersTo,
         String timeBoundaryEid,
         String destinationHref,
-        String oldText,
         String newText) {
-      this(eli, eid, refersTo, timeBoundaryEid, destinationHref, oldText, newText, false);
+      this(eli, eid, refersTo, timeBoundaryEid, destinationHref, newText, false);
     }
   }
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/NormService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/NormService.java
@@ -134,9 +134,6 @@ public class NormService
 
   @Override
   public Optional<UpdateModUseCase.Result> updateMod(UpdateModUseCase.Query query) {
-
-    // TODO query.oldText is not being handled
-
     final Optional<Norm> amendingNormOptional =
         loadNormPort.loadNorm(new LoadNormPort.Command(query.eli()));
     if (amendingNormOptional.isEmpty()) {

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/NormControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/NormControllerTest.java
@@ -298,7 +298,7 @@ class NormControllerTest {
                   .accept(MediaType.APPLICATION_JSON)
                   .contentType(MediaType.APPLICATION_JSON)
                   .content(
-                      "{\"refersTo\": \"aenderungsbefehl-ersetzen\", \"timeBoundaryEid\": \"new-time-boundary-eid\", \"destinationHref\": \"new-destination-href\", \"oldText\": \"old text\", \"newText\": \"new test text\"}"))
+                      "{\"refersTo\": \"aenderungsbefehl-ersetzen\", \"timeBoundaryEid\": \"new-time-boundary-eid\", \"destinationHref\": \"new-destination-href\", \"newText\": \"new test text\"}"))
           .andExpect(status().isOk())
           .andExpect(content().contentType(MediaType.APPLICATION_JSON))
           .andExpect(jsonPath("amendingNormXml").value(xml))
@@ -326,7 +326,7 @@ class NormControllerTest {
                   .accept(MediaType.APPLICATION_JSON)
                   .contentType(MediaType.APPLICATION_JSON)
                   .content(
-                      "{\"refersTo\": \"aenderungsbefehl-ersetzen\", \"timeBoundaryEid\": \"new-time-boundary-eid\", \"destinationHref\": \"new-destination-href\", \"oldText\": \"old text\", \"newText\": \"new test text\"}"))
+                      "{\"refersTo\": \"aenderungsbefehl-ersetzen\", \"timeBoundaryEid\": \"new-time-boundary-eid\", \"destinationHref\": \"new-destination-href\", \"newText\": \"new test text\"}"))
           .andExpect(status().isOk())
           .andExpect(content().contentType(MediaType.APPLICATION_JSON))
           .andExpect(jsonPath("amendingNormXml").value(xml))
@@ -351,7 +351,7 @@ class NormControllerTest {
                   .accept(MediaType.APPLICATION_JSON)
                   .contentType(MediaType.APPLICATION_JSON)
                   .content(
-                      "{\"refersTo\": \"aenderungsbefehl-ersetzen\", \"timeBoundaryEid\": \"new-time-boundary-eid\", \"destinationHref\": \"new-destination-href\", \"oldText\": \"old text\", \"newText\": \"new test text\"}"))
+                      "{\"refersTo\": \"aenderungsbefehl-ersetzen\", \"timeBoundaryEid\": \"new-time-boundary-eid\", \"destinationHref\": \"new-destination-href\", \"newText\": \"new test text\"}"))
           .andExpect(status().isNotFound());
     }
   }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/NormControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/NormControllerTest.java
@@ -332,7 +332,7 @@ class NormControllerTest {
           .andExpect(jsonPath("amendingNormXml").value(xml))
           .andExpect(jsonPath("targetNormZf0Xml").value(targetNormXml));
 
-      verify(updateModUseCase, times(1)).updateMod(argThat(query -> query.dryRun()));
+      verify(updateModUseCase, times(1)).updateMod(argThat(UpdateModUseCase.Query::dryRun));
     }
 
     @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/NormServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/NormServiceTest.java
@@ -728,13 +728,7 @@ class NormServiceTest {
       var result =
           service.updateMod(
               new UpdateModUseCase.Query(
-                  eli,
-                  "eid",
-                  "refersTo",
-                  "time-boundary-eid",
-                  "destinanation-href",
-                  "old text",
-                  "new text"));
+                  eli, "eid", "refersTo", "time-boundary-eid", "destinanation-href", "new text"));
 
       // Then
       verify(loadNormPort, times(1))
@@ -759,7 +753,6 @@ class NormServiceTest {
                   "refersTo",
                   "time-boundary-eid",
                   "#THIS_IS_NOT_OK_A_HREF_IS_NEVER_RELATIVE",
-                  "old text",
                   "new text"));
 
       // Then
@@ -814,7 +807,6 @@ class NormServiceTest {
               "refersTo",
               newTimeBoundaryEid, // <- this will be set
               newDestinationHref, // <- this will be set in ActivMods AND mod
-              "old text",
               newText,
               false));
 
@@ -857,7 +849,6 @@ class NormServiceTest {
                   "refersTo",
                   newTimeBoundaryEid, // <- this will be set
                   newDestinationHref, // <- this will be set in ActivMods AND mod
-                  "old text",
                   newText,
                   false));
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/NormControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/NormControllerIntegrationTest.java
@@ -565,7 +565,6 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
       String eId = "hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1";
       String characterCount = "9-34";
       String destinationHref = eli + "/" + eId + "/" + characterCount + ".xml";
-      String oldText = "THIS_IS_NOT_BEING_HANDLED";
       String newText = "new test text";
 
       // When
@@ -581,8 +580,6 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
                           + timeBoundaryEId
                           + "\", \"destinationHref\": \""
                           + destinationHref
-                          + "\", \"oldText\": \""
-                          + oldText
                           + "\", \"newText\": \""
                           + newText
                           + "\"}"))
@@ -653,7 +650,6 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
       String eId = "hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1";
       String characterCount = "9-35"; // 9-34 would be correct -> This is wrong on purpose
       String destinationHref = eli + "/" + eId + "/" + characterCount + ".xml";
-      String oldText = "THIS_IS_NOT_BEING_HANDLED";
       String newText = "new test text"; // This is not being validated
 
       // When
@@ -669,8 +665,6 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
                           + timeBoundaryEId
                           + "\", \"destinationHref\": \""
                           + destinationHref
-                          + "\", \"oldText\": \""
-                          + oldText
                           + "\", \"newText\": \""
                           + newText
                           + "\"}"))

--- a/doc/backend/norms-api-v1.yaml
+++ b/doc/backend/norms-api-v1.yaml
@@ -534,8 +534,6 @@ components:
           type: string
         destinationHref:
           type: string
-        oldText:
-          type: string
         newText:
           type: string
 

--- a/frontend/src/composables/useMod.spec.ts
+++ b/frontend/src/composables/useMod.spec.ts
@@ -138,7 +138,6 @@ describe("useMod", () => {
       refersTo: "test-refersTo",
       timeBoundaryEid: "test-timeBoundaryEid",
       destinationHref: "test-destinationHref",
-      oldText: "test-oldText",
       newText: "test-newText",
     }
 
@@ -172,7 +171,6 @@ describe("useMod", () => {
       refersTo: "test-refersTo",
       timeBoundaryEid: "test-timeBoundaryEid",
       destinationHref: "test-destinationHref",
-      oldText: "test-oldText",
       newText: "test-newText",
     }
 

--- a/frontend/src/services/ldmldeModService.spec.ts
+++ b/frontend/src/services/ldmldeModService.spec.ts
@@ -140,7 +140,6 @@ describe("ldmldeModService", () => {
         refersTo: "test-refersTo",
         timeBoundaryEid: "test-timeBoundaryEid",
         destinationHref: "test-destinationHref",
-        oldText: "test-oldText",
         newText: "test-newText",
       }
 

--- a/frontend/src/types/ModType.ts
+++ b/frontend/src/types/ModType.ts
@@ -9,6 +9,5 @@ export interface ModData {
   refersTo: string
   timeBoundaryEid?: string
   destinationHref: string
-  oldText: string
   newText: string
 }

--- a/frontend/src/views/AmendingLawArticleEditor.vue
+++ b/frontend/src/views/AmendingLawArticleEditor.vue
@@ -115,7 +115,6 @@ async function handleGeneratePreview() {
       refersTo: selectedMod.value,
       timeBoundaryEid: timeBoundary.value?.temporalGroupEid,
       destinationHref: destinationHref.value,
-      oldText: quotedTextFirst.value,
       newText: quotedTextSecond.value,
     })
 
@@ -157,7 +156,6 @@ async function handleSave() {
     refersTo: selectedMod.value,
     timeBoundaryEid: timeBoundary.value?.temporalGroupEid,
     destinationHref: destinationHref.value,
-    oldText: quotedTextFirst.value,
     newText: quotedTextSecond.value,
   }
 


### PR DESCRIPTION
oldText is not being handled neither by UpdateModService nor the Validator.