### PR TITLE
Refactor get/set simple metadata with an enum class

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/ProprietaryService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/ProprietaryService.java
@@ -42,10 +42,14 @@ public class ProprietaryService
     final Proprietary proprietary = norm.getMeta().getOrCreateProprietary();
     final MetadatenDs metadatenDs = proprietary.getOrCreateMetadatenDs();
 
-    metadatenDs.setFnaAt(query.atDate(), query.metadata().fna());
-    metadatenDs.setArtAt(query.atDate(), query.metadata().art());
-    metadatenDs.setTypAt(query.atDate(), query.metadata().typ());
-    metadatenDs.setSubtypAt(query.atDate(), query.metadata().subtyp());
+    metadatenDs.setSimpleProprietaryMetadata(
+        MetadatenDs.SimpleMetadatum.FNA, query.atDate(), query.metadata().fna());
+    metadatenDs.setSimpleProprietaryMetadata(
+        MetadatenDs.SimpleMetadatum.ART, query.atDate(), query.metadata().art());
+    metadatenDs.setSimpleProprietaryMetadata(
+        MetadatenDs.SimpleMetadatum.TYP, query.atDate(), query.metadata().typ());
+    metadatenDs.setSimpleProprietaryMetadata(
+        MetadatenDs.SimpleMetadatum.SUBTYP, query.atDate(), query.metadata().subtyp());
 
     updateNormPort.updateNorm(new UpdateNormPort.Command(norm));
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/MetadatenDs.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/MetadatenDs.java
@@ -20,111 +20,37 @@ public class MetadatenDs {
 
   private final Node node;
 
-  /**
-   * Retrieves all nodes of the specific metadatum.
-   *
-   * @param xpath of the node
-   * @return list of all metadata as {@link SimpleProprietaryValue}
-   */
-  public List<SimpleProprietaryValue> getNodes(final String xpath) {
-    return NodeParser.getNodesFromExpression(xpath, node).stream()
-        .map(SimpleProprietaryValue::new)
-        .toList();
-  }
+  /** The list of all simple metadata. They consist of a single string property. */
+  public enum SimpleMetadatum {
+    FNA("./fna"),
+    ART("./art"),
+    TYP("./typ"),
+    SUBTYP("./subtyp");
 
-  /**
-   * Retrieves the FNA value at a specific date. It looks for the one value where @start attribute
-   * is equals or before the given date and the @end attribute is equals or after the given date.
-   *
-   * @param date the specific date
-   * @return the optional fna value
-   */
-  public Optional<String> getFnaAt(final LocalDate date) {
-    return getSimpleValueAt("./fna", date);
-  }
+    private final String xpath;
 
-  /**
-   * Updates/Creates the new fna value at a specific date.
-   *
-   * @param date the specific date.
-   * @param fna the new fna value.
-   */
-  public void setFnaAt(final LocalDate date, final String fna) {
-    this.setSimpleValueAt("./fna", date, fna);
-  }
-
-  /**
-   * Retrieves the Art value at a specific date. It looks for the one value where @start attribute
-   * is equals or before the given date and the @end attribute is equals or after the given date.
-   *
-   * @param date the specific date
-   * @return Art or empty if it doesn't exist.
-   */
-  public Optional<String> getArtAt(final LocalDate date) {
-    return getSimpleValueAt("./art", date);
-  }
-
-  /**
-   * Updates/Creates the new art value at a specific date.
-   *
-   * @param date the specific date.
-   * @param art the new art value.
-   */
-  public void setArtAt(final LocalDate date, final String art) {
-    this.setSimpleValueAt("./art", date, art);
-  }
-
-  /**
-   * Retrieves the Typ value at a specific date. It looks for the one value where @start attribute
-   * is equals or before the given date and the @end attribute is equals or after the given date.
-   *
-   * @param date the specific date
-   * @return Typ or empty if it doesn't exist.
-   */
-  public Optional<String> getTypAt(final LocalDate date) {
-    return getSimpleValueAt("./typ", date);
-  }
-
-  /**
-   * Updates/Creates the new typ value at a specific date.
-   *
-   * @param date the specific date.
-   * @param typ the new art value.
-   */
-  public void setTypAt(final LocalDate date, final String typ) {
-    this.setSimpleValueAt("./typ", date, typ);
-  }
-
-  public Optional<String> getSubtypAt(final LocalDate date) {
-    return this.getSimpleValueAt("./subtyp", date);
-  }
-
-  /**
-   * Updates/Creates the new subtyp value at a specific date.
-   *
-   * @param date the specific date.
-   * @param subtyp the new subtyp value.
-   */
-  public void setSubtypAt(final LocalDate date, final String subtyp) {
-    this.setSimpleValueAt("./subtyp", date, subtyp);
+    SimpleMetadatum(final String xpath) {
+      this.xpath = xpath;
+    }
   }
 
   /**
    * It returns the value for a xpath at a specific date. If no matching value @start or @end is
    * found, it will retrieve the value from the node with neither @start nor @end.
    *
-   * @param xpath the xpath of the node
+   * @param simpleMetadatum the enum metadatum
    * @param date the specific date
    * @return an optional value, if found.
    */
-  private Optional<String> getSimpleValueAt(final String xpath, final LocalDate date) {
+  public Optional<String> getSimpleValueAt(
+      final SimpleMetadatum simpleMetadatum, final LocalDate date) {
     final List<SimpleProprietaryValue> valuesWithoutStartAndEnd =
-        getNodes(xpath).stream()
+        getNodes(simpleMetadatum.xpath).stream()
             .filter(f -> f.getStart().isEmpty() && f.getEnd().isEmpty())
             .toList();
 
     final List<SimpleProprietaryValue> valuesWithStartOrAndEnd =
-        getNodes(xpath).stream()
+        getNodes(simpleMetadatum.xpath).stream()
             .filter(f -> f.getStart().isPresent() || f.getEnd().isPresent())
             .filter(
                 f ->
@@ -143,36 +69,39 @@ public class MetadatenDs {
 
   /**
    * Creates or updates a metadata with simple value at the specific date. It sets the @start
-   * attribute to the given date. If node not present before, it will create a new one and set also
+   * attribute to the given date. If node not present, it will create a new one and set also
    * the @end attribute if there is a later fna node. The value would be the @start date of the next
    * closest FNA minus 1 day. Also, if there is a previous node it will set the @end attribute to 1
-   * day before of the newly updated/created node.
+   * day before of the newly updated/created node. Finally, it will also set the @end attribute of
+   * those nodes with neither @start nor @end attributes.
    *
-   * @param xpath the xpath of the node
-   * @param date the specific date
-   * @param newValue the new value
+   * @param simpleMetadatum - the enum metadatum
+   * @param date - the specific date
+   * @param newValue - the new value to update/create
    */
-  private void setSimpleValueAt(final String xpath, final LocalDate date, final String newValue) {
-    NodeParser.getNodeFromExpression(String.format("%s[@start='%s']", xpath, date.toString()), node)
+  public void setSimpleProprietaryMetadata(
+      final SimpleMetadatum simpleMetadatum, final LocalDate date, final String newValue) {
+    NodeParser.getNodeFromExpression(
+            String.format("%s[@start='%s']", simpleMetadatum.xpath, date.toString()), node)
         .ifPresentOrElse(
             fnaNode -> fnaNode.setTextContent(newValue),
             () -> {
               // 1. Check if we have later FNAs and get the next closest one
               final Optional<SimpleProprietaryValue> nextNode =
-                  getNodes(xpath).stream()
+                  getNodes(simpleMetadatum.xpath).stream()
                       .filter(f -> f.getStart().isPresent() && f.getStart().get().isAfter(date))
                       .min(Comparator.comparing(f -> f.getStart().get()));
 
               // 2. Check if we have previous FNAs and get the next closest one
               final Optional<SimpleProprietaryValue> previousNode =
-                  getNodes(xpath).stream()
+                  getNodes(simpleMetadatum.xpath).stream()
                       .filter(f -> f.getStart().isPresent() && f.getStart().get().isBefore(date))
                       .max(Comparator.comparing(f -> f.getStart().get()));
 
               // 3. Create new meta:fna node with the @start value and optional @end
               final Element newFnaElement =
                   NodeCreator.createElement(
-                      String.format("meta:%s", xpath.replace("./", "")), node);
+                      String.format("meta:%s", simpleMetadatum.xpath.replace("./", "")), node);
               newFnaElement.setTextContent(newValue);
               newFnaElement.setAttribute("start", date.toString());
               if (nextNode.isPresent() && nextNode.get().getStart().isPresent()) {
@@ -188,12 +117,24 @@ public class MetadatenDs {
 
               // 5. And finally set @end of nodes without @start and @end to one day before given
               // date
-              getNodes(xpath).stream()
+              getNodes(simpleMetadatum.xpath).stream()
                   .filter(f -> f.getStart().isEmpty() && f.getEnd().isEmpty())
                   .forEach(
                       value ->
                           ((Element) value.getNode())
                               .setAttribute("end", date.minusDays(1).toString()));
             });
+  }
+
+  /**
+   * Retrieves all nodes of the specific metadatum.
+   *
+   * @param xpath of the node
+   * @return list of all metadata as {@link SimpleProprietaryValue}
+   */
+  public List<SimpleProprietaryValue> getNodes(final String xpath) {
+    return NodeParser.getNodesFromExpression(xpath, node).stream()
+        .map(SimpleProprietaryValue::new)
+        .toList();
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Proprietary.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Proprietary.java
@@ -73,7 +73,9 @@ public class Proprietary {
    * @return FNA or empty if present neither in the MetadatenDe nor in the MetadatenDs block.
    */
   public Optional<String> getFna(final LocalDate date) {
-    return getMetadatenDs().flatMap(m -> m.getFnaAt(date)).or(this::getFna);
+    return getMetadatenDs()
+        .flatMap(m -> m.getSimpleValueAt(MetadatenDs.SimpleMetadatum.FNA, date))
+        .or(this::getFna);
   }
 
   private Optional<String> getArt() {
@@ -88,7 +90,9 @@ public class Proprietary {
    * @return Art or empty if present neither in the MetadatenDe nor in the MetadatenDs block.
    */
   public Optional<String> getArt(final LocalDate date) {
-    return getMetadatenDs().flatMap(m -> m.getArtAt(date)).or(this::getArt);
+    return getMetadatenDs()
+        .flatMap(m -> m.getSimpleValueAt(MetadatenDs.SimpleMetadatum.ART, date))
+        .or(this::getArt);
   }
 
   private Optional<String> getTyp() {
@@ -103,7 +107,9 @@ public class Proprietary {
    * @return Typ or empty if present neither in the MetadatenDe nor in the MetadatenDs block.
    */
   public Optional<String> getTyp(final LocalDate date) {
-    return getMetadatenDs().flatMap(m -> m.getTypAt(date)).or(this::getTyp);
+    return getMetadatenDs()
+        .flatMap(m -> m.getSimpleValueAt(MetadatenDs.SimpleMetadatum.TYP, date))
+        .or(this::getTyp);
   }
 
   /**
@@ -113,6 +119,7 @@ public class Proprietary {
    * @return Subtyp or empty if it doesn't exist.
    */
   public Optional<String> getSubtyp(final LocalDate date) {
-    return getMetadatenDs().flatMap(m -> m.getSubtypAt(date));
+    return getMetadatenDs()
+        .flatMap(m -> m.getSimpleValueAt(MetadatenDs.SimpleMetadatum.SUBTYP, date));
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/MetadatenDsTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/MetadatenDsTest.java
@@ -24,18 +24,45 @@ class MetadatenDsTest {
                             """))
             .build();
 
-    assertThat(metadatenDs.getFnaAt(LocalDate.parse("1980-01-01"))).isEmpty();
+    assertThat(
+            metadatenDs.getSimpleValueAt(
+                MetadatenDs.SimpleMetadatum.FNA, LocalDate.parse("1980-01-01")))
+        .isEmpty();
 
-    assertThat(metadatenDs.getFnaAt(LocalDate.parse("1990-01-01"))).contains("111-11-1");
-    assertThat(metadatenDs.getFnaAt(LocalDate.parse("1992-01-01"))).contains("111-11-1");
-    assertThat(metadatenDs.getFnaAt(LocalDate.parse("1994-12-31"))).contains("111-11-1");
+    assertThat(
+            metadatenDs.getSimpleValueAt(
+                MetadatenDs.SimpleMetadatum.FNA, LocalDate.parse("1990-01-01")))
+        .contains("111-11-1");
+    assertThat(
+            metadatenDs.getSimpleValueAt(
+                MetadatenDs.SimpleMetadatum.FNA, LocalDate.parse("1992-01-01")))
+        .contains("111-11-1");
+    assertThat(
+            metadatenDs.getSimpleValueAt(
+                MetadatenDs.SimpleMetadatum.FNA, LocalDate.parse("1994-12-31")))
+        .contains("111-11-1");
 
-    assertThat(metadatenDs.getFnaAt(LocalDate.parse("1995-01-01"))).contains("222-22-2");
-    assertThat(metadatenDs.getFnaAt(LocalDate.parse("1998-01-01"))).contains("222-22-2");
-    assertThat(metadatenDs.getFnaAt(LocalDate.parse("2000-12-31"))).contains("222-22-2");
+    assertThat(
+            metadatenDs.getSimpleValueAt(
+                MetadatenDs.SimpleMetadatum.FNA, LocalDate.parse("1995-01-01")))
+        .contains("222-22-2");
+    assertThat(
+            metadatenDs.getSimpleValueAt(
+                MetadatenDs.SimpleMetadatum.FNA, LocalDate.parse("1998-01-01")))
+        .contains("222-22-2");
+    assertThat(
+            metadatenDs.getSimpleValueAt(
+                MetadatenDs.SimpleMetadatum.FNA, LocalDate.parse("2000-12-31")))
+        .contains("222-22-2");
 
-    assertThat(metadatenDs.getFnaAt(LocalDate.parse("2001-01-01"))).contains("333-33-3");
-    assertThat(metadatenDs.getFnaAt(LocalDate.parse("2024-01-01"))).contains("333-33-3");
+    assertThat(
+            metadatenDs.getSimpleValueAt(
+                MetadatenDs.SimpleMetadatum.FNA, LocalDate.parse("2001-01-01")))
+        .contains("333-33-3");
+    assertThat(
+            metadatenDs.getSimpleValueAt(
+                MetadatenDs.SimpleMetadatum.FNA, LocalDate.parse("2024-01-01")))
+        .contains("333-33-3");
   }
 
   @Test
@@ -55,11 +82,13 @@ class MetadatenDsTest {
 
     final LocalDate newDate = LocalDate.parse("1990-01-01");
     assertThat(metadatenDs.getNodes("./fna")).hasSize(3);
-    assertThat(metadatenDs.getFnaAt(newDate)).contains("111-11-1");
+    assertThat(metadatenDs.getSimpleValueAt(MetadatenDs.SimpleMetadatum.FNA, newDate))
+        .contains("111-11-1");
 
-    metadatenDs.setFnaAt(newDate, "000-00-0");
+    metadatenDs.setSimpleProprietaryMetadata(MetadatenDs.SimpleMetadatum.FNA, newDate, "000-00-0");
 
-    assertThat(metadatenDs.getFnaAt(newDate)).contains("000-00-0");
+    assertThat(metadatenDs.getSimpleValueAt(MetadatenDs.SimpleMetadatum.FNA, newDate))
+        .contains("000-00-0");
     assertThat(metadatenDs.getNodes("./fna")).hasSize(3);
   }
 
@@ -77,12 +106,13 @@ class MetadatenDsTest {
 
     final LocalDate newDate = LocalDate.parse("1980-01-01");
 
-    assertThat(metadatenDs.getFnaAt(newDate)).isEmpty();
+    assertThat(metadatenDs.getSimpleValueAt(MetadatenDs.SimpleMetadatum.FNA, newDate)).isEmpty();
     assertThat(metadatenDs.getNodes("./fna")).isEmpty();
 
-    metadatenDs.setFnaAt(newDate, "000-00-0");
+    metadatenDs.setSimpleProprietaryMetadata(MetadatenDs.SimpleMetadatum.FNA, newDate, "000-00-0");
 
-    assertThat(metadatenDs.getFnaAt(newDate)).contains("000-00-0");
+    assertThat(metadatenDs.getSimpleValueAt(MetadatenDs.SimpleMetadatum.FNA, newDate))
+        .contains("000-00-0");
     assertThat(metadatenDs.getNodes("./fna")).hasSize(1);
 
     metadatenDs.getNodes("./fna").stream()
@@ -107,12 +137,13 @@ class MetadatenDsTest {
             .build();
 
     final LocalDate newDate = LocalDate.parse("1980-01-01");
-    assertThat(metadatenDs.getFnaAt(newDate)).isEmpty();
+    assertThat(metadatenDs.getSimpleValueAt(MetadatenDs.SimpleMetadatum.FNA, newDate)).isEmpty();
     assertThat(metadatenDs.getNodes("./fna")).hasSize(3);
 
-    metadatenDs.setFnaAt(newDate, "000-00-0");
+    metadatenDs.setSimpleProprietaryMetadata(MetadatenDs.SimpleMetadatum.FNA, newDate, "000-00-0");
 
-    assertThat(metadatenDs.getFnaAt(newDate)).contains("000-00-0");
+    assertThat(metadatenDs.getSimpleValueAt(MetadatenDs.SimpleMetadatum.FNA, newDate))
+        .contains("000-00-0");
     assertThat(metadatenDs.getNodes("./fna")).hasSize(4);
 
     metadatenDs.getNodes("./fna").stream()
@@ -137,12 +168,14 @@ class MetadatenDsTest {
             .build();
 
     final LocalDate newDate = LocalDate.parse("2005-01-01");
-    assertThat(metadatenDs.getFnaAt(newDate)).contains("333-33-3");
+    assertThat(metadatenDs.getSimpleValueAt(MetadatenDs.SimpleMetadatum.FNA, newDate))
+        .contains("333-33-3");
     assertThat(metadatenDs.getNodes("./fna")).hasSize(3);
 
-    metadatenDs.setFnaAt(newDate, "000-00-0");
+    metadatenDs.setSimpleProprietaryMetadata(MetadatenDs.SimpleMetadatum.FNA, newDate, "000-00-0");
 
-    assertThat(metadatenDs.getFnaAt(newDate)).contains("000-00-0");
+    assertThat(metadatenDs.getSimpleValueAt(MetadatenDs.SimpleMetadatum.FNA, newDate))
+        .contains("000-00-0");
     final List<SimpleProprietaryValue> fnaValues = metadatenDs.getNodes("./fna");
     assertThat(fnaValues).hasSize(4);
 
@@ -176,18 +209,45 @@ class MetadatenDsTest {
                                             """))
             .build();
 
-    assertThat(metadatenDs.getSubtypAt(LocalDate.parse("1980-01-01"))).contains("subtyp0");
+    assertThat(
+            metadatenDs.getSimpleValueAt(
+                MetadatenDs.SimpleMetadatum.SUBTYP, LocalDate.parse("1980-01-01")))
+        .contains("subtyp0");
 
-    assertThat(metadatenDs.getSubtypAt(LocalDate.parse("1990-01-01"))).contains("subtyp1");
-    assertThat(metadatenDs.getSubtypAt(LocalDate.parse("1992-01-01"))).contains("subtyp1");
-    assertThat(metadatenDs.getSubtypAt(LocalDate.parse("1994-12-31"))).contains("subtyp1");
+    assertThat(
+            metadatenDs.getSimpleValueAt(
+                MetadatenDs.SimpleMetadatum.SUBTYP, LocalDate.parse("1990-01-01")))
+        .contains("subtyp1");
+    assertThat(
+            metadatenDs.getSimpleValueAt(
+                MetadatenDs.SimpleMetadatum.SUBTYP, LocalDate.parse("1992-01-01")))
+        .contains("subtyp1");
+    assertThat(
+            metadatenDs.getSimpleValueAt(
+                MetadatenDs.SimpleMetadatum.SUBTYP, LocalDate.parse("1994-12-31")))
+        .contains("subtyp1");
 
-    assertThat(metadatenDs.getSubtypAt(LocalDate.parse("1995-01-01"))).contains("subtyp2");
-    assertThat(metadatenDs.getSubtypAt(LocalDate.parse("1998-01-01"))).contains("subtyp2");
-    assertThat(metadatenDs.getSubtypAt(LocalDate.parse("2000-12-31"))).contains("subtyp2");
+    assertThat(
+            metadatenDs.getSimpleValueAt(
+                MetadatenDs.SimpleMetadatum.SUBTYP, LocalDate.parse("1995-01-01")))
+        .contains("subtyp2");
+    assertThat(
+            metadatenDs.getSimpleValueAt(
+                MetadatenDs.SimpleMetadatum.SUBTYP, LocalDate.parse("1998-01-01")))
+        .contains("subtyp2");
+    assertThat(
+            metadatenDs.getSimpleValueAt(
+                MetadatenDs.SimpleMetadatum.SUBTYP, LocalDate.parse("2000-12-31")))
+        .contains("subtyp2");
 
-    assertThat(metadatenDs.getSubtypAt(LocalDate.parse("2001-01-01"))).contains("subtyp3");
-    assertThat(metadatenDs.getSubtypAt(LocalDate.parse("2024-01-01"))).contains("subtyp3");
+    assertThat(
+            metadatenDs.getSimpleValueAt(
+                MetadatenDs.SimpleMetadatum.SUBTYP, LocalDate.parse("2001-01-01")))
+        .contains("subtyp3");
+    assertThat(
+            metadatenDs.getSimpleValueAt(
+                MetadatenDs.SimpleMetadatum.SUBTYP, LocalDate.parse("2024-01-01")))
+        .contains("subtyp3");
   }
 
   @Test
@@ -204,12 +264,15 @@ class MetadatenDsTest {
             .build();
 
     final LocalDate newDate = LocalDate.parse("2005-01-01");
-    assertThat(metadatenDs.getSubtypAt(newDate)).contains("subtyp0");
+    assertThat(metadatenDs.getSimpleValueAt(MetadatenDs.SimpleMetadatum.SUBTYP, newDate))
+        .contains("subtyp0");
     assertThat(metadatenDs.getNodes("./subtyp")).hasSize(1);
 
-    metadatenDs.setSubtypAt(newDate, "subtyp1");
+    metadatenDs.setSimpleProprietaryMetadata(
+        MetadatenDs.SimpleMetadatum.SUBTYP, newDate, "subtyp1");
 
-    assertThat(metadatenDs.getSubtypAt(newDate)).contains("subtyp1");
+    assertThat(metadatenDs.getSimpleValueAt(MetadatenDs.SimpleMetadatum.SUBTYP, newDate))
+        .contains("subtyp1");
     final List<SimpleProprietaryValue> subtypValues = metadatenDs.getNodes("./subtyp");
     assertThat(subtypValues).hasSize(2);
 
@@ -218,6 +281,8 @@ class MetadatenDsTest {
         .findFirst()
         .map(m -> assertThat(m.getEnd()).isEmpty());
 
-    assertThat(metadatenDs.getSubtypAt(newDate.minusDays(1))).contains("subtyp0");
+    assertThat(
+            metadatenDs.getSimpleValueAt(MetadatenDs.SimpleMetadatum.SUBTYP, newDate.minusDays(1)))
+        .contains("subtyp0");
   }
 }


### PR DESCRIPTION
After having introduced 4 metadata already I have realized that they all behave in the same way within the MetadatenDs

- Getting a value to a given date.
- Setting a value to a given date.

I have therefore introduced an enum class within the MetadatenDs entity. With this implementation, whenever we have a new simple metadata the only places we need to extend are:

- Are new entry in the enum class with the xpath
- For GET, add new method `getMetadatumAt()` in `Proprietary` (since it could be that it is present in `MetadatenDe` and not only `MetadatenDs`, this part can be further optimized), and extend the `ProprietaryResponseMapper` 
- For PUT just add a new line in ProprietaryService like     `metadatenDs.setSimpleProprietaryMetadata(MetadatenDs.SimpleMetadatum.NEW-METADATUM, query.atDate(), query.metadata().fna());`