### PR TITLE
Prevent page from breaking when no time boundary is selected

### DIFF
--- a/frontend/e2e/amending-laws-affected-document-editor.spec.ts
+++ b/frontend/e2e/amending-laws-affected-document-editor.spec.ts
@@ -224,6 +224,26 @@ test.describe("sidebar navigation", () => {
 
     await page.unrouteAll()
   })
+
+  test("does not render links when no time boundary is selected", async ({
+    page,
+  }) => {
+    page.route(/timeBoundaries/, async (route) => {
+      await route.fulfill({ json: [], status: 200 })
+    })
+
+    await page.goto(
+      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit",
+    )
+
+    await expect(page.getByText("Keine Zeitgrenze ausgewählt.")).toBeVisible()
+
+    await expect(
+      page
+        .getByRole("complementary", { name: "Inhaltsverzeichnis" })
+        .getByRole("link"),
+    ).toHaveCount(0)
+  })
 })
 
 test.describe("preview", () => {

--- a/frontend/src/composables/useTimeBoundaryPathParameter.spec.ts
+++ b/frontend/src/composables/useTimeBoundaryPathParameter.spec.ts
@@ -76,4 +76,23 @@ describe("useTimeBoundaryPathParameter", () => {
 
     expect(timeBoundaryAsDate.value).toEqual(new Date("2024-05-10"))
   })
+
+  test("should not set the time boundary to an empty value", async () => {
+    const routerReplace = vi.fn()
+
+    vi.doMock("vue-router", () => ({
+      useRoute: vi
+        .fn()
+        .mockReturnValue(reactive({ params: { timeBoundary: "2024-05-10" } })),
+      useRouter: vi.fn().mockReturnValue(reactive({ replace: routerReplace })),
+    }))
+
+    const { useTimeBoundaryPathParameter } = await import(
+      "./useTimeBoundaryPathParameter"
+    )
+    const { timeBoundary } = useTimeBoundaryPathParameter()
+
+    timeBoundary.value = ""
+    expect(routerReplace).not.toBeCalled()
+  })
 })

--- a/frontend/src/composables/useTimeBoundaryPathParameter.ts
+++ b/frontend/src/composables/useTimeBoundaryPathParameter.ts
@@ -31,8 +31,12 @@ export function useTimeBoundaryPathParameter(): {
         ? route.params.timeBoundary[0]
         : route.params.timeBoundary
     },
-    set(timeBoundary) {
-      router.replace({ params: { timeBoundary } })
+    set(newValue) {
+      // Setting this to an empty value would cause the router to throw an error
+      // about a missing parameter + it is most likely unintended behavior anyways.
+      if (!newValue) return
+
+      router.replace({ params: { timeBoundary: newValue } })
     },
   })
 

--- a/frontend/src/views/AmendingLawAffectedDocumentEditor.vue
+++ b/frontend/src/views/AmendingLawAffectedDocumentEditor.vue
@@ -120,8 +120,17 @@ const {
           </label>
         </div>
 
+        <RisCallout
+          v-if="!selectedTimeBoundary"
+          variant="warning"
+          title="Keine Zeitgrenze ausgewählt."
+          class="mx-16 mb-8"
+        />
+
         <!-- Frame link -->
+        <!-- Render conditionally on selectedTimeBoundary to prevent missing param errors in the route -->
         <router-link
+          v-if="selectedTimeBoundary"
           :to="{
             name: 'AmendingLawAffectedDocumentRahmenEditor',
             params: { timeBoundary: selectedTimeBoundary },
@@ -155,20 +164,23 @@ const {
           variant="simple"
         />
 
-        <router-link
-          v-for="element in elements"
-          :key="element.eid"
-          :to="{
-            name: 'AmendingLawAffectedDocumentElementEditor',
-            params: { eid: element.eid, timeBoundary: selectedTimeBoundary },
-          }"
-          active-class="font-bold underline bg-blue-200"
-          class="ds-label-02-reg block px-16 py-8 hover:bg-blue-200 hover:underline focus:bg-blue-200 focus:underline"
-        >
-          <span class="block overflow-hidden text-ellipsis whitespace-nowrap">
-            {{ element.title }}
-          </span>
-        </router-link>
+        <!-- Render conditionally on selectedTimeBoundary to prevent missing param errors in the route -->
+        <template v-if="selectedTimeBoundary">
+          <router-link
+            v-for="element in elements"
+            :key="element.eid"
+            :to="{
+              name: 'AmendingLawAffectedDocumentElementEditor',
+              params: { eid: element.eid, timeBoundary: selectedTimeBoundary },
+            }"
+            active-class="font-bold underline bg-blue-200"
+            class="ds-label-02-reg block px-16 py-8 hover:bg-blue-200 hover:underline focus:bg-blue-200 focus:underline"
+          >
+            <span class="block overflow-hidden text-ellipsis whitespace-nowrap">
+              {{ element.title }}
+            </span>
+          </router-link>
+        </template>
       </aside>
 
       <RouterView />


### PR DESCRIPTION
This could happen when-for whatever reason-a law has no time boundaries, or when fetching time boundaries takes longer than expected. In those cases, links in the sidebar need to be hidden because they depend on a selected time boundary. If no time boundary is selected, the router throws a missing param error.

RISDEV-0000