### PR TITLE
Component improvements

### DIFF
--- a/frontend/src/components/RisModForm.vue
+++ b/frontend/src/components/RisModForm.vue
@@ -118,7 +118,6 @@ function modTypeLabel(modType: ModType | "") {
         label="Änderungstyp"
         :model-value="modTypeLabel(textualModType)"
         read-only
-        size="small"
       />
       <RisDropdownInput
         id="timeBoundaries"
@@ -134,14 +133,12 @@ function modTypeLabel(modType: ModType | "") {
       label="ELI Zielgesetz"
       :model-value="destinationHrefEli"
       read-only
-      size="small"
     />
     <RisTextInput
       v-if="textualModType === 'aenderungsbefehl-ersetzen'"
       id="destinationHrefEid"
       v-model="destinationHrefEid"
       label="zu ersetzende Textstelle"
-      size="small"
       @blur="$emit('generate-preview')"
     />
     <RisTextAreaInput

--- a/frontend/src/components/RisTemporalDataIntervals.vue
+++ b/frontend/src/components/RisTemporalDataIntervals.vue
@@ -60,11 +60,7 @@ watch(newDate, async (newDateValue) => {
     <template v-for="(dateEntry, index) in dates" :key="index">
       <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
       <label :for="`date-${index}`">Zeitgrenze {{ index + 1 }}</label>
-      <RisDateInput
-        :id="`date-${index}`"
-        v-model="dateEntry.date"
-        size="small"
-      />
+      <RisDateInput :id="`date-${index}`" v-model="dateEntry.date" />
       <RisTextButton
         :icon="DeleteOutlineIcon"
         variant="ghost"

--- a/frontend/src/components/controls/RisCheckboxInput.spec.ts
+++ b/frontend/src/components/controls/RisCheckboxInput.spec.ts
@@ -66,10 +66,10 @@ describe("RisCheckboxInput", () => {
     expect(input).toBeEnabled()
   })
 
-  test("renders the regular variant by default", () => {
+  test("renders the mini variant by default", () => {
     renderComponent()
     const input = screen.getByRole("checkbox")
-    expect(input).not.toHaveClass("ds-checkbox-small")
+    expect(input).toHaveClass("ds-checkbox-mini")
   })
 
   test("renders the regular variant when specified", () => {

--- a/frontend/src/components/controls/RisCheckboxInput.story.vue
+++ b/frontend/src/components/controls/RisCheckboxInput.story.vue
@@ -4,14 +4,14 @@ import RisCheckboxInput from "./RisCheckboxInput.vue"
 
 <template>
   <Story :layout="{ type: 'grid', width: '250px' }">
-    <Variant title="Default regular size | checked">
+    <Variant title="Default mini size | checked">
       <RisCheckboxInput
         id="test-id"
         :model-value="true"
         label="Stammnorm"
       ></RisCheckboxInput>
     </Variant>
-    <Variant title="Default regular size | read-only and checked">
+    <Variant title="Default mini size | read-only and checked">
       <RisCheckboxInput
         id="test-id"
         read-only
@@ -19,10 +19,10 @@ import RisCheckboxInput from "./RisCheckboxInput.vue"
         label="Änderungsnorm"
       ></RisCheckboxInput>
     </Variant>
-    <Variant title="Default regular size | unchecked">
+    <Variant title="Default mini size | unchecked">
       <RisCheckboxInput id="test-id" label="Übergangsnorm"></RisCheckboxInput>
     </Variant>
-    <Variant title="Default regular size | read-only and unchecked">
+    <Variant title="Default mini size | read-only and unchecked">
       <RisCheckboxInput
         id="test-id"
         read-only
@@ -63,35 +63,35 @@ import RisCheckboxInput from "./RisCheckboxInput.vue"
       ></RisCheckboxInput>
     </Variant>
 
-    <Variant title="Mini size | checked">
+    <Variant title="Regular size | checked">
       <RisCheckboxInput
         id="test-id"
         :model-value="true"
-        size="mini"
+        size="regular"
         label="Stammnorm"
       ></RisCheckboxInput>
     </Variant>
-    <Variant title="Mini size | read-only and checked">
+    <Variant title="Regular size | read-only and checked">
       <RisCheckboxInput
         id="test-id"
         read-only
-        size="mini"
+        size="regular"
         :model-value="true"
         label="Änderungsnorm"
       ></RisCheckboxInput>
     </Variant>
-    <Variant title="Mini size | unchecked">
+    <Variant title="Regular size | unchecked">
       <RisCheckboxInput
         id="test-id"
-        size="mini"
+        size="regular"
         label="Übergangsnorm"
       ></RisCheckboxInput>
     </Variant>
-    <Variant title="Mini size | read-only and unchecked">
+    <Variant title="Regular size | read-only and unchecked">
       <RisCheckboxInput
         id="test-id"
         read-only
-        size="mini"
+        size="regular"
         label="Stammnorm"
       ></RisCheckboxInput>
     </Variant>

--- a/frontend/src/components/controls/RisCheckboxInput.vue
+++ b/frontend/src/components/controls/RisCheckboxInput.vue
@@ -17,8 +17,7 @@ const props = withDefaults(
   {
     modelValue: false,
     label: undefined,
-    size: "regular",
-    readOnly: false,
+    size: "mini",
   },
 )
 

--- a/frontend/src/components/controls/RisCheckboxInput.vue
+++ b/frontend/src/components/controls/RisCheckboxInput.vue
@@ -1,12 +1,8 @@
 <script lang="ts" setup>
-import { computed } from "vue"
-
-const props = withDefaults(
+withDefaults(
   defineProps<{
     /** Unique ID for the checkbox. */
     id: string
-    /** Value reflected of checkbox marked or not . */
-    modelValue?: boolean
     /** Optional label for the field */
     label?: string
     /** Optional size for the field */
@@ -15,35 +11,20 @@ const props = withDefaults(
     readOnly?: boolean
   }>(),
   {
-    modelValue: false,
     label: undefined,
     size: "mini",
   },
 )
 
-const emit = defineEmits<{
-  /**
-   * Emitted when the user changes the value of the form field.
-   */
-  "update:modelValue": [boolean | undefined]
-  /**
-   * Emitted when the user ticks the checkbox.
-   */
-  input: []
-}>()
-
-const localModelValue = computed({
-  get: () => props.modelValue,
-  set: (value) => emit("update:modelValue", value),
-})
+const checked = defineModel<boolean | undefined>({ default: false })
 </script>
 
 <template>
   <div class="grid gap-2">
     <input
       :id="id"
-      v-model="localModelValue"
-      class="ds-checkbox"
+      v-model="checked"
+      class="ds-checkbox bg-white"
       :class="{
         'ds-checkbox-mini': size === 'mini',
         'ds-checkbox-small': size === 'small',
@@ -51,7 +32,7 @@ const localModelValue = computed({
       }"
       :disabled="readOnly"
       type="checkbox"
-      @keydown.space.prevent="localModelValue = !localModelValue"
+      @keydown.space.prevent="checked = !checked"
     />
     <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
     <label v-if="label" :for="id" class="ds-label">

--- a/frontend/src/components/controls/RisCheckboxInput.vue
+++ b/frontend/src/components/controls/RisCheckboxInput.vue
@@ -16,6 +16,7 @@ withDefaults(
   },
 )
 
+/** Checked/unchecked value of the checkbox. */
 const checked = defineModel<boolean | undefined>({ default: false })
 </script>
 

--- a/frontend/src/components/controls/RisDateInput.spec.ts
+++ b/frontend/src/components/controls/RisDateInput.spec.ts
@@ -9,6 +9,7 @@ function renderComponent(options?: {
   modelValue?: string
   validationError?: ValidationError
   isReadOnly?: boolean
+  size?: "regular" | "medium" | "small"
 }) {
   const user = userEvent.setup()
   const props = {
@@ -16,6 +17,7 @@ function renderComponent(options?: {
     modelValue: options?.modelValue,
     validationError: options?.validationError,
     isReadOnly: options?.isReadOnly,
+    size: options?.size,
   }
   const utils = render(RisDateInput, { props })
   return { user, props, ...utils }
@@ -151,5 +153,33 @@ describe("DateInput", () => {
   test("sets the input to editable", () => {
     renderComponent({ isReadOnly: false })
     expect(screen.getByRole("textbox")).not.toHaveAttribute("readonly")
+  })
+
+  test("renders the small variant by default", () => {
+    renderComponent()
+    const input = screen.getByRole("textbox")
+    expect(input).not.toHaveClass("ds-input-medium")
+    expect(input).toHaveClass("ds-input-small")
+  })
+
+  test("renders the regular variant", () => {
+    renderComponent({ size: "regular" })
+    const input = screen.getByRole("textbox")
+    expect(input).not.toHaveClass("ds-input-medium")
+    expect(input).not.toHaveClass("ds-input-small")
+  })
+
+  test("renders the medium variant", () => {
+    renderComponent({ size: "medium" })
+    const input = screen.getByRole("textbox")
+    expect(input).toHaveClass("ds-input-medium")
+    expect(input).not.toHaveClass("ds-input-small")
+  })
+
+  test("renders the small variant", () => {
+    renderComponent({ size: "small" })
+    const input = screen.getByRole("textbox")
+    expect(input).not.toHaveClass("ds-input-medium")
+    expect(input).toHaveClass("ds-input-small")
   })
 })

--- a/frontend/src/components/controls/RisDateInput.vue
+++ b/frontend/src/components/controls/RisDateInput.vue
@@ -60,7 +60,7 @@ const effectiveHasError = computed(
 const conditionalClasses = computed(() => ({
   "has-error": effectiveHasError.value,
   "ds-input-medium": props.size === "medium",
-  "ds-input-small": props.size === "small",
+  "ds-input-small": props.size === "small" || !props.size,
 }))
 
 function validateInput() {
@@ -121,11 +121,11 @@ watch(inputCompleted, (is) => {
     :id="id"
     v-model="inputValue"
     v-maska
-    class="ds-input"
     :class="conditionalClasses"
+    :readonly="isReadOnly"
+    class="ds-input"
     data-maska="##.##.####"
     placeholder="TT.MM.JJJJ"
-    :readonly="isReadOnly"
     @blur="onBlur"
     @keydown.delete="backspaceDelete"
     @maska="onMaska"

--- a/frontend/src/components/controls/RisDropdownInput.spec.ts
+++ b/frontend/src/components/controls/RisDropdownInput.spec.ts
@@ -95,16 +95,6 @@ describe("Dropdown Input", () => {
     expect(emitted("update:modelValue")).toEqual([["t2"]])
   })
 
-  test("emits change event when selection changes", async () => {
-    const { emitted } = renderComponent({ modelValue: "t1" })
-
-    const input = screen.getByRole("combobox")
-    expect(input).toHaveValue("t1")
-
-    await userEvent.selectOptions(input, "t2")
-    expect(emitted("change")).toBeTruthy()
-  })
-
   test("renders a label when provided and associates it with the dropdown", () => {
     const labelText = "Test Label"
     renderComponent({ label: labelText })

--- a/frontend/src/components/controls/RisDropdownInput.vue
+++ b/frontend/src/components/controls/RisDropdownInput.vue
@@ -1,8 +1,11 @@
 <script lang="ts" setup>
 import { computed } from "vue"
 
+/** Describes a selectable option in the dropdown. */
 export type DropdownItem = {
+  /** Label of the item. */
   label: string
+  /** Value of the item. */
   value: string
 }
 
@@ -11,42 +14,23 @@ const props = defineProps<{
   id: string
   /** the items for the dropdown. */
   items: DropdownItem[]
-  /** Value reflected by choice of item . */
-  modelValue?: string
   /** Placeholder text if needed. */
   placeholder?: string
   /** Optional label for the field */
   label?: string
 }>()
 
-const emit = defineEmits<{
-  /**
-   * Emitted when the user changes the value of the form field. Note that this
-   * is only emitted when the value is empty or a valid date. All other states
-   * (e.g. partial dates while typing) are handled internally and not emitted.
-   */
-  "update:modelValue": [string | undefined]
-  /**
-   * Emitted when the user selects an option.
-   */
-  change: []
-}>()
-
-const localModelValue = computed({
-  get: () => props.modelValue ?? "",
-  set: (value) => {
-    emit("update:modelValue", value)
-  },
-})
+/** Selected value of the dropdown. */
+const modelValue = defineModel<string | undefined>()
 
 const hasPlaceholder = computed(() =>
-  Boolean(!props.modelValue && props.placeholder),
+  Boolean(!modelValue.value && props.placeholder),
 )
 </script>
 
 <template>
   <div class="grid gap-2">
-    <!-- Label should come from the surrounding context, e.g. InputField component -->
+    <!-- Label should come from the surrounding context -->
     <!-- eslint-disable vuejs-accessibility/form-control-has-label -->
     <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
     <label v-if="label" :for="id" class="ds-label">
@@ -54,13 +38,12 @@ const hasPlaceholder = computed(() =>
     </label>
     <select
       :id="id"
-      v-model="localModelValue"
+      v-model="modelValue"
       class="ds-select ds-select-small"
       :data-placeholder="hasPlaceholder ? true : undefined"
       tabindex="0"
-      @change="$emit('change')"
     >
-      <option v-if="placeholder && !localModelValue" disabled value="">
+      <option v-if="placeholder && !modelValue" disabled value="">
         {{ placeholder }}
       </option>
       <option v-for="item in items" :key="item.value" :value="item.value">

--- a/frontend/src/components/controls/RisTextInput.spec.ts
+++ b/frontend/src/components/controls/RisTextInput.spec.ts
@@ -63,11 +63,11 @@ describe("TextInput", () => {
     expect(input).toHaveAttribute("readonly")
   })
 
-  test("renders the regular variant by default", () => {
+  test("renders the small variant by default", () => {
     renderComponent()
     const input = screen.getByRole("textbox")
     expect(input).not.toHaveClass("ds-input-medium")
-    expect(input).not.toHaveClass("ds-input-small")
+    expect(input).toHaveClass("ds-input-small")
   })
 
   test("renders the regular variant", () => {

--- a/frontend/src/components/controls/RisTextInput.story.vue
+++ b/frontend/src/components/controls/RisTextInput.story.vue
@@ -4,7 +4,15 @@ import RisTextInput from "./RisTextInput.vue"
 
 <template>
   <Story :layout="{ type: 'grid' }">
-    <Variant title="Default (medium size)/label">
+    <Variant title="Default (small size) with label">
+      <RisTextInput
+        id="test-id"
+        placeholder="Placeholder text"
+        label="Änderungstyp"
+      ></RisTextInput>
+    </Variant>
+
+    <Variant title="Medium size with label">
       <RisTextInput
         id="test-id"
         placeholder="Placeholder text"
@@ -13,7 +21,7 @@ import RisTextInput from "./RisTextInput.vue"
       ></RisTextInput>
     </Variant>
 
-    <Variant title="Regular size/label">
+    <Variant title="Regular size with label">
       <RisTextInput
         id="test-id"
         placeholder="Placeholder text"
@@ -22,16 +30,7 @@ import RisTextInput from "./RisTextInput.vue"
       ></RisTextInput>
     </Variant>
 
-    <Variant title="Small size/label">
-      <RisTextInput
-        id="test-id"
-        placeholder="Placeholder text"
-        size="small"
-        label="Änderungstyp"
-      ></RisTextInput>
-    </Variant>
-
-    <Variant title="Read-only/No label">
+    <Variant title="Read-only without label">
       <RisTextInput
         id="test-id"
         placeholder="Placeholder text"

--- a/frontend/src/components/controls/RisTextInput.vue
+++ b/frontend/src/components/controls/RisTextInput.vue
@@ -19,7 +19,7 @@ const props = withDefaults(
   {
     modelValue: "",
     placeholder: undefined,
-    size: "regular",
+    size: "small",
     label: undefined,
   },
 )

--- a/frontend/src/components/controls/RisTextInput.vue
+++ b/frontend/src/components/controls/RisTextInput.vue
@@ -26,9 +26,7 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   /**
-   * Emitted when the user changes the value of the form field. Note that this
-   * is only emitted when the value is empty or a valid date. All other states
-   * (e.g. partial dates while typing) are handled internally and not emitted.
+   * Emitted when the user changes the value of the form field.
    */
   "update:modelValue": [value: string | undefined]
   /**

--- a/frontend/src/views/AmendingLaw.vue
+++ b/frontend/src/views/AmendingLaw.vue
@@ -67,5 +67,8 @@ const { alerts, hideAlert } = useAlerts()
       <RouterView />
     </div>
   </div>
-  <RisLoadingSpinner v-else />
+
+  <div v-else class="flex h-[calc(100dvh-5rem)] items-center justify-center">
+    <RisLoadingSpinner />
+  </div>
 </template>

--- a/frontend/src/views/AmendingLawAffectedDocumentRahmenEditor.vue
+++ b/frontend/src/views/AmendingLawAffectedDocumentRahmenEditor.vue
@@ -317,7 +317,7 @@ const {
               <fieldset class="contents">
                 <legend class="ds-label-02-bold col-span-2">Sachgebiet</legend>
                 <label :for="fnaId">Sachgebiet</label>
-                <RisTextInput :id="fnaId" v-model="fna" size="small" />
+                <RisTextInput :id="fnaId" v-model="fna" />
               </fieldset>
 
               <fieldset class="contents">
@@ -357,7 +357,6 @@ const {
                 <RisTextInput
                   :id="bezeichnungInVorlageId"
                   v-model="bezeichnungInVorlage"
-                  size="small"
                 />
               </fieldset>
 

--- a/frontend/src/views/AmendingLawAffectedDocumentRahmenEditor.vue
+++ b/frontend/src/views/AmendingLawAffectedDocumentRahmenEditor.vue
@@ -330,33 +330,30 @@ const {
                   :items="documentTypeItems"
                 />
 
-                <label :for="artNormSNid" class="self-start"
-                  >Art der Norm</label
-                >
+                <label :for="artNormSNid" class="self-start">
+                  Art der Norm
+                </label>
                 <div class="space-y-10">
                   <RisCheckboxInput
                     :id="artNormSNid"
                     v-model="artNormSN"
                     label="SN - Stammnorm"
-                    size="mini"
                   />
                   <RisCheckboxInput
                     :id="artNormANid"
                     v-model="artNormAN"
                     label="ÄN - Änderungsnorm"
-                    size="mini"
                   />
                   <RisCheckboxInput
                     :id="artNormUNid"
                     v-model="artNormUN"
                     label="ÜN - Übergangsnorm"
-                    size="mini"
                   />
                 </div>
 
-                <label :for="bezeichnungInVorlageId"
-                  >Bezeichnung gemäß Vorlage</label
-                >
+                <label :for="bezeichnungInVorlageId">
+                  Bezeichnung gemäß Vorlage
+                </label>
                 <RisTextInput
                   :id="bezeichnungInVorlageId"
                   v-model="bezeichnungInVorlage"
@@ -374,22 +371,21 @@ const {
                   :items="normgeberItems"
                 />
 
-                <label :for="beschliessendesOrganId"
-                  >beschließendes Organ</label
-                >
+                <label :for="beschliessendesOrganId">
+                  beschließendes Organ
+                </label>
                 <RisDropdownInput
                   :id="beschliessendesOrganId"
                   v-model="beschliessendesOrgan"
                   :items="beschliessendesOrganItems"
                 />
 
-                <label :for="isResolutionWithMajorityId"
-                  >Beschlussf. qual. Mehrheit</label
-                >
+                <label :for="isResolutionWithMajorityId">
+                  Beschlussf. qual. Mehrheit
+                </label>
                 <RisCheckboxInput
                   :id="isResolutionWithMajorityId"
                   v-model="isResolutionWithMajority"
-                  size="small"
                 />
               </fieldset>
 


### PR DESCRIPTION
- Components that have multiple size variants now default to the smallest variant as this is the one we will need in almost all cases. The other variants are still available, but need to be specified explicitly.
- All size configuration that is now redundant has been removed.
- Additional cleanup regarding docs, v-models, etc. in the affected components (see commit messages for details)