### PR TITLE
Sensible defaults for fetching behavior

### DIFF
--- a/frontend/src/components/affectedDocuments/RisAffectedDocumentPanel.vue
+++ b/frontend/src/components/affectedDocuments/RisAffectedDocumentPanel.vue
@@ -28,13 +28,7 @@ const props = defineProps<{
   zf0Eli: string
 }>()
 
-const {
-  data: norm,
-  isFetching,
-  error,
-} = useGetNorm(props.eli, undefined, {
-  refetch: true,
-})
+const { data: norm, isFetching, error } = useGetNorm(props.eli)
 
 const tag = computed<"li" | "div">(() => (props.asListItem ? "li" : "div"))
 

--- a/frontend/src/composables/useNormXml.ts
+++ b/frontend/src/composables/useNormXml.ts
@@ -37,17 +37,12 @@ export function useNormXml(
 
   // We want to also update the data with the data returned from the PUT-request.
   const data = ref<string | null>(null)
-  const getNormXml: UseFetchReturn<string> = useGetNormXml(eli, undefined, {
-    refetch: true,
-  })
+  const getNormXml: UseFetchReturn<string> = useGetNormXml(eli)
   watch(getNormXml.data, () => {
     data.value = getNormXml.data.value
   })
 
-  const putNormXml = usePutNormXml(newXml, eli, undefined, {
-    refetch: true,
-    immediate: false,
-  })
+  const putNormXml = usePutNormXml(newXml, eli)
   watch(putNormXml.data, () => {
     data.value = putNormXml.data.value
   })

--- a/frontend/src/services/elementService.spec.ts
+++ b/frontend/src/services/elementService.spec.ts
@@ -179,6 +179,36 @@ describe("useElementsService", () => {
         ),
       )
     })
+
+    it("reloads when parameters change", async () => {
+      const fetchSpy = vi
+        .spyOn(window, "fetch")
+        .mockResolvedValue(new Response("{}"))
+
+      const { useGetElements } = await import("./elementService")
+
+      const eli = ref("fake/eli/1")
+      useGetElements(eli, ["article"])
+
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledWith(
+          "/api/v1/norms/fake/eli/1/elements?type=article",
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              Accept: "application/json",
+            }),
+          }),
+        )
+      })
+
+      eli.value = "fake/eli/2"
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledWith(
+          "/api/v1/norms/fake/eli/2/elements?type=article",
+          expect.any(Object),
+        )
+      })
+    })
   })
 })
 
@@ -359,6 +389,36 @@ describe("useElementService", () => {
         ),
       )
     })
+
+    it("reloads when parameters change", async () => {
+      const fetchSpy = vi
+        .spyOn(window, "fetch")
+        .mockResolvedValue(new Response("{}"))
+
+      const { useGetElement } = await import("./elementService")
+
+      const eli = ref("fake/eli/1")
+      useGetElement(eli, "fake_eid")
+
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledWith(
+          "/api/v1/norms/fake/eli/1/elements/fake_eid?",
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              Accept: "application/json",
+            }),
+          }),
+        )
+      })
+
+      eli.value = "fake/eli/2"
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledWith(
+          "/api/v1/norms/fake/eli/2/elements/fake_eid?",
+          expect.any(Object),
+        )
+      })
+    })
   })
 
   describe("useGetElementHtml", () => {
@@ -384,6 +444,36 @@ describe("useElementService", () => {
           }),
         ),
       )
+    })
+
+    it("reloads when parameters change", async () => {
+      const fetchSpy = vi
+        .spyOn(window, "fetch")
+        .mockResolvedValue(new Response("{}"))
+
+      const { useGetElementHtml } = await import("./elementService")
+
+      const eli = ref("fake/eli/1")
+      useGetElementHtml(eli, "fake_eid")
+
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledWith(
+          "/api/v1/norms/fake/eli/1/elements/fake_eid?",
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              Accept: "text/html",
+            }),
+          }),
+        )
+      })
+
+      eli.value = "fake/eli/2"
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledWith(
+          "/api/v1/norms/fake/eli/2/elements/fake_eid?",
+          expect.any(Object),
+        )
+      })
     })
   })
 })

--- a/frontend/src/services/elementService.ts
+++ b/frontend/src/services/elementService.ts
@@ -62,7 +62,11 @@ export const useGetElements: typeof useElementsService = (
   types,
   options,
   fetchOptions,
-) => useElementsService(eli, types, options, fetchOptions).json()
+) =>
+  useElementsService(eli, types, options, {
+    refetch: true,
+    ...fetchOptions,
+  }).json()
 
 /* -------------------------------------------------- *
  * Individual elements                                *
@@ -124,7 +128,11 @@ export const useGetElement: typeof useElementService = (
   eid,
   options,
   fetchOptions,
-) => useElementService(eli, eid, options, fetchOptions).json()
+) =>
+  useElementService(eli, eid, options, {
+    refetch: true,
+    ...fetchOptions,
+  }).json()
 
 /**
  * Convenience shorthand for `useElementService` that sets the correct
@@ -143,6 +151,7 @@ export function useGetElementHtml(
   fetchOptions: Parameters<typeof useElementService>["3"] = {},
 ): UseFetchReturn<string> {
   return useElementService(eli, eid, options, {
+    refetch: true,
     ...fetchOptions,
     beforeFetch(c) {
       c.options.headers = { ...c.options.headers, Accept: "text/html" }

--- a/frontend/src/services/normService.ts
+++ b/frontend/src/services/normService.ts
@@ -64,7 +64,7 @@ export const useGetNorm: typeof useNormService = (
   options,
   fetchOptions,
 ) => {
-  return useNormService(eli, options, fetchOptions).json()
+  return useNormService(eli, options, { refetch: true, ...fetchOptions }).json()
 }
 
 /**
@@ -82,6 +82,7 @@ export function useGetNormHtml(
   fetchOptions?: Parameters<typeof useNormService>["2"],
 ): UseFetchReturn<string> {
   return useNormService(eli, options, {
+    refetch: true,
     ...fetchOptions,
     beforeFetch(c) {
       c.options.headers = { ...c.options.headers, Accept: "text/html" }
@@ -104,6 +105,7 @@ export function useGetNormXml(
   fetchOptions?: Parameters<typeof useNormService>["2"],
 ): UseFetchReturn<string> & PromiseLike<UseFetchReturn<string>> {
   return useNormService(eli, options, {
+    refetch: true,
     ...fetchOptions,
     beforeFetch(c) {
       c.options.headers = { ...c.options.headers, Accept: "application/xml" }
@@ -128,6 +130,8 @@ export function usePutNormXml(
   fetchOptions?: Parameters<typeof useNormService>["2"],
 ): UseFetchReturn<string> {
   return useNormService(eli, options, {
+    refetch: true,
+    immediate: false,
     ...fetchOptions,
     beforeFetch(c) {
       c.options.headers = {

--- a/frontend/src/services/proprietaryService.ts
+++ b/frontend/src/services/proprietaryService.ts
@@ -57,7 +57,8 @@ export const useGetProprietary: typeof useProprietaryService = (
   eli,
   options,
   fetchOptions,
-) => useProprietaryService(eli, options, fetchOptions).json()
+) =>
+  useProprietaryService(eli, options, { refetch: true, ...fetchOptions }).json()
 
 /**
  * Convenience shorthand for `useProprietaryService` that sets the correct
@@ -74,7 +75,11 @@ export function usePutProprietary(
   options: Parameters<typeof useProprietaryService>["1"],
   fetchOptions?: Parameters<typeof useProprietaryService>["2"],
 ): ReturnType<typeof useProprietaryService> {
-  return useProprietaryService(eli, options, fetchOptions)
+  return useProprietaryService(eli, options, {
+    immediate: false,
+    refetch: true,
+    ...fetchOptions,
+  })
     .json()
     .put(updateData)
 }

--- a/frontend/src/views/AmendingLaw.vue
+++ b/frontend/src/views/AmendingLaw.vue
@@ -37,11 +37,7 @@ const menuItems: LevelOneMenuItem[] = [
 ]
 
 const eli = useEliPathParameter()
-const {
-  data: amendingLaw,
-  isFetching,
-  error,
-} = useGetNorm(eli, undefined, { refetch: true })
+const { data: amendingLaw, isFetching, error } = useGetNorm(eli)
 
 const { alerts, hideAlert } = useAlerts()
 </script>

--- a/frontend/src/views/AmendingLawAffectedDocumentEditor.vue
+++ b/frontend/src/views/AmendingLawAffectedDocumentEditor.vue
@@ -18,7 +18,7 @@ const {
   data: amendingLaw,
   isFetching: amendingLawIsLoading,
   error: amendingLawError,
-} = useGetNorm(amendingLawEli, undefined)
+} = useGetNorm(amendingLawEli)
 
 /* -------------------------------------------------- *
  * Sidebar                                            *

--- a/frontend/src/views/AmendingLawAffectedDocumentElementEditor.vue
+++ b/frontend/src/views/AmendingLawAffectedDocumentElementEditor.vue
@@ -19,9 +19,7 @@ const {
   data: element,
   isFetching: elementIsLoading,
   error: elementError,
-} = useGetElement(affectedDocumentEli, elementEid, undefined, {
-  refetch: true,
-})
+} = useGetElement(affectedDocumentEli, elementEid)
 
 /* -------------------------------------------------- *
  * XML + HTML preview                                 *
@@ -37,12 +35,9 @@ const {
   data: render,
   isFetching: renderIsLoading,
   error: renderError,
-} = useGetElementHtml(
-  affectedDocumentEli,
-  elementEid,
-  { at: timeBoundaryAsDate },
-  { refetch: true },
-)
+} = useGetElementHtml(affectedDocumentEli, elementEid, {
+  at: timeBoundaryAsDate,
+})
 </script>
 
 <template>

--- a/frontend/src/views/AmendingLawAffectedDocumentRahmenEditor.vue
+++ b/frontend/src/views/AmendingLawAffectedDocumentRahmenEditor.vue
@@ -51,11 +51,7 @@ const {
   data,
   isFetching,
   error: fetchError,
-} = useGetProprietary(
-  affectedDocumentEli,
-  { atDate: timeBoundaryAsDate },
-  { refetch: true },
-)
+} = useGetProprietary(affectedDocumentEli, { atDate: timeBoundaryAsDate })
 
 watch(data, (newData) => {
   localData.value = newData
@@ -288,11 +284,7 @@ const {
   data: render,
   isFetching: renderIsLoading,
   error: renderError,
-} = useGetNormHtml(
-  affectedDocumentEli,
-  { at: timeBoundaryAsDate },
-  { refetch: true },
-)
+} = useGetNormHtml(affectedDocumentEli, { at: timeBoundaryAsDate })
 </script>
 
 <template>

--- a/frontend/src/views/AmendingLawArticleEditor.vue
+++ b/frontend/src/views/AmendingLawArticleEditor.vue
@@ -28,7 +28,7 @@ const {
   data: amendingLaw,
   isFetching: isFetchingAmendingLaw,
   error: loadAmendingLawError,
-} = useGetNorm(eli, undefined, { refetch: true })
+} = useGetNorm(eli)
 const selectedMod = useModEidPathParameter()
 
 const identifier = computed<LawElementIdentifier | undefined>(() =>


### PR DESCRIPTION
Changes the default configuration of useFetch for all services such that:

- Get: Load immediately, refetch automatically
- Put: Don't load immediately, refetch automatically

RISDEV-3808