### PR TITLE
Federführung backend + E2E tests

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -20,6 +20,6 @@ fileignoreconfig:
   - filename: doc/adr/0009-renovate.md
     checksum: 172f8d22a6c8114b91ba4e430349c40599d1afa59fb96f49a651c1eac1e551dc
   - filename: backend/src/main/resources/db/data/R__004_2024_108_2024-03-27_Wachstumschancengesetz.sql
-    checksum: 8038341b48b9a08f7aaaa89059f109c62bfab14ab7780644a1abab24c9b111ad
+    checksum: d9a1e669bd6ba2fa591d7b236db975ad106d73f23d67ea2c923b00a7c457b0a4
   - filename: backend/src/main/resources/db/data/R__006_2024_108_2024-03-27_Wachstumschancengesetz-Part-3.sql
     checksum: 8b27438daf6e93b8bf31b49e73ad4c2fd77b0c188634b315b30587443d87e036

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ProprietaryController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ProprietaryController.java
@@ -94,7 +94,8 @@ public class ProprietaryController {
                       proprietarySchema.getArtDerNorm(),
                       proprietarySchema.getNormgeber(),
                       proprietarySchema.getBeschliessendesOrgan(),
-                      proprietarySchema.getQualifizierteMehrheit())));
+                      proprietarySchema.getQualifizierteMehrheit(),
+                      proprietarySchema.getFederfuehrung())));
 
       return ResponseEntity.ok(ProprietaryResponseMapper.fromProprietary(proprietary, atDate));
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ProprietaryResponseMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ProprietaryResponseMapper.java
@@ -30,6 +30,7 @@ public class ProprietaryResponseMapper {
         .normgeber(proprietary.getNormgeber(date).orElse(null))
         .beschliessendesOrgan(proprietary.getBeschliessendesOrgan(date).orElse(null))
         .qualifizierteMehrheit(proprietary.getQualifizierteMehrheit(date).orElse(null))
+        .federfuehrung(proprietary.getFederfuehrung(date).orElse(null))
         .build();
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/ProprietarySchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/ProprietarySchema.java
@@ -18,4 +18,5 @@ public class ProprietarySchema {
   private String normgeber;
   private String beschliessendesOrgan;
   private Boolean qualifizierteMehrheit;
+  private String federfuehrung;
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/UpdateProprietaryFromNormUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/UpdateProprietaryFromNormUseCase.java
@@ -39,6 +39,7 @@ public interface UpdateProprietaryFromNormUseCase {
    * @param normgeber - "Normgeber"
    * @param beschliessendesOrgan - "Beschließendes Organ"
    * @param qualifizierterMehrheit - "Beschlussfassung mit qualifizierter Mehrheit"
+   * @param federfuehrung - "Federführung"
    */
   record Metadata(
       String fna,
@@ -49,5 +50,6 @@ public interface UpdateProprietaryFromNormUseCase {
       String artDerNorm,
       String normgeber,
       String beschliessendesOrgan,
-      Boolean qualifizierterMehrheit) {}
+      Boolean qualifizierterMehrheit,
+      String federfuehrung) {}
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/ProprietaryService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/ProprietaryService.java
@@ -4,6 +4,7 @@ import de.bund.digitalservice.ris.norms.application.port.input.LoadProprietaryFr
 import de.bund.digitalservice.ris.norms.application.port.input.UpdateProprietaryFromNormUseCase;
 import de.bund.digitalservice.ris.norms.application.port.output.LoadNormPort;
 import de.bund.digitalservice.ris.norms.application.port.output.UpdateNormPort;
+import de.bund.digitalservice.ris.norms.domain.entity.MetadatenDe;
 import de.bund.digitalservice.ris.norms.domain.entity.MetadatenDs;
 import de.bund.digitalservice.ris.norms.domain.entity.Norm;
 import de.bund.digitalservice.ris.norms.domain.entity.Proprietary;
@@ -41,25 +42,26 @@ public class ProprietaryService
             .orElseThrow(() -> new NormNotFoundException((query.eli())));
     final Proprietary proprietary = norm.getMeta().getOrCreateProprietary();
     final MetadatenDs metadatenDs = proprietary.getOrCreateMetadatenDs();
+    final MetadatenDe metadatenDe = proprietary.getOrCreateMetadatenDe();
 
     metadatenDs.setSimpleMetadatum(
-        MetadatenDs.SimpleMetadatum.FNA, query.atDate(), query.metadata().fna());
+        MetadatenDs.Metadata.FNA, query.atDate(), query.metadata().fna());
     metadatenDs.setSimpleMetadatum(
-        MetadatenDs.SimpleMetadatum.ART, query.atDate(), query.metadata().art());
+        MetadatenDs.Metadata.ART, query.atDate(), query.metadata().art());
     metadatenDs.setSimpleMetadatum(
-        MetadatenDs.SimpleMetadatum.TYP, query.atDate(), query.metadata().typ());
+        MetadatenDs.Metadata.TYP, query.atDate(), query.metadata().typ());
     metadatenDs.setSimpleMetadatum(
-        MetadatenDs.SimpleMetadatum.SUBTYP, query.atDate(), query.metadata().subtyp());
+        MetadatenDs.Metadata.SUBTYP, query.atDate(), query.metadata().subtyp());
     metadatenDs.setSimpleMetadatum(
-        MetadatenDs.SimpleMetadatum.BEZEICHNUNG_IN_VORLAGE,
+        MetadatenDs.Metadata.BEZEICHNUNG_IN_VORLAGE,
         query.atDate(),
         query.metadata().bezeichnungInVorlage());
     metadatenDs.setSimpleMetadatum(
-        MetadatenDs.SimpleMetadatum.ART_DER_NORM, query.atDate(), query.metadata().artDerNorm());
+        MetadatenDs.Metadata.ART_DER_NORM, query.atDate(), query.metadata().artDerNorm());
     metadatenDs.setSimpleMetadatum(
-        MetadatenDs.SimpleMetadatum.NORMGEBER, query.atDate(), query.metadata().normgeber());
+        MetadatenDs.Metadata.NORMGEBER, query.atDate(), query.metadata().normgeber());
     metadatenDs.setSimpleMetadatum(
-        MetadatenDs.SimpleMetadatum.BESCHLIESSENDES_ORGAN,
+        MetadatenDs.Metadata.BESCHLIESSENDES_ORGAN,
         query.atDate(),
         query.metadata().beschliessendesOrgan());
     metadatenDs.setAttributeOfSimpleMetadatum(
@@ -68,6 +70,8 @@ public class ProprietaryService
         String.valueOf(query.metadata().qualifizierterMehrheit()).equals("null")
             ? "false"
             : String.valueOf(query.metadata().qualifizierterMehrheit()));
+    metadatenDe.setSimpleMetadatum(
+        MetadatenDe.Metadata.FEDERFUEHRUNG, query.atDate(), query.metadata().federfuehrung());
 
     updateNormPort.updateNorm(new UpdateNormPort.Command(norm));
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Metadaten.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Metadaten.java
@@ -1,0 +1,170 @@
+package de.bund.digitalservice.ris.norms.domain.entity;
+
+import de.bund.digitalservice.ris.norms.utils.NodeCreator;
+import de.bund.digitalservice.ris.norms.utils.NodeParser;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+interface MetadataInterface {
+  String getXpath();
+}
+
+/**
+ * Abstract class with common functionalities between meta:legalDocML.de_metadaten_ds and
+ * meta:legalDocML.de_metadaten
+ *
+ * @param <T> the concrete enum class implementing {@link MetadataInterface}
+ */
+@Getter
+@AllArgsConstructor
+public abstract class Metadaten<T extends MetadataInterface> {
+
+  private final Node node;
+  private final String startAttribute;
+  private final String endAttribute;
+
+  /**
+   * It returns the value for a xpath at a specific date. If no matching value @start or @end is
+   * found, it will retrieve the value from the node with neither @start nor @end.
+   *
+   * @param simpleMetadatum the enum metadatum
+   * @param date the specific date
+   * @return an optional value, if found.
+   */
+  public Optional<String> getSimpleMetadatum(final T simpleMetadatum, final LocalDate date) {
+    return getSimpleNodeAt(simpleMetadatum, date).map(SimpleProprietary::getValue);
+  }
+
+  /**
+   * Creates or updates a metadata following the xpath with simple value at the specific date. It
+   * sets the @start attribute to the given date. If node not present, it will create a new one and
+   * set also the @end attribute if there is a later fna node. The value would be the @start date of
+   * the next closest FNA minus 1 day. Also, if there is a previous node it will set the @end
+   * attribute to 1 day before of the newly updated/created node. Finally, it will also set the @end
+   * attribute of those nodes with neither @start nor @end attributes.
+   *
+   * @param simpleMetadatum - the simple enum metadatum
+   * @param date - the specific date
+   * @param newValue - the new value to update/create
+   */
+  public void setSimpleMetadatum(
+      final T simpleMetadatum, final LocalDate date, final String newValue) {
+    NodeParser.getNodeFromExpression(
+            String.format(
+                "%s[@%s='%s']", simpleMetadatum.getXpath(), getStartAttribute(), date.toString()),
+            node)
+        .ifPresentOrElse(
+            nodeFound -> nodeFound.setTextContent(newValue),
+            () -> {
+              // 1. Before updating creating new node, get next previous node and next later node
+              final Optional<SimpleProprietary> previousNode =
+                  getNodes(simpleMetadatum.getXpath()).stream()
+                      .filter(f -> f.getStart().isPresent() && f.getStart().get().isBefore(date))
+                      .max(Comparator.comparing(f -> f.getStart().get()));
+              final Optional<SimpleProprietary> nextNode =
+                  getNodes(simpleMetadatum.getXpath()).stream()
+                      .filter(f -> f.getStart().isPresent() && f.getStart().get().isAfter(date))
+                      .min(Comparator.comparing(f -> f.getStart().get()));
+
+              // 2. Create new meta:fna node with the @start value and @end and set @start of next
+              // one
+              createNewNode(simpleMetadatum, newValue, date, nextNode.orElse(null));
+
+              // 3. Then also set @end of a previous one, if present
+              previousNode.ifPresent(
+                  value ->
+                      ((Element) value.getNode())
+                          .setAttribute(getEndAttribute(), date.minusDays(1).toString()));
+
+              // 4. And set @end of nodes without @start and @end to one day before given date
+              getNodes(simpleMetadatum.getXpath()).stream()
+                  .filter(f -> f.getStart().isEmpty() && f.getEnd().isEmpty())
+                  .forEach(
+                      value ->
+                          ((Element) value.getNode())
+                              .setAttribute(getEndAttribute(), date.minusDays(1).toString()));
+            });
+  }
+
+  /**
+   * Retrieves all nodes of the specific metadatum.
+   *
+   * @param xpath of the node
+   * @return list of all metadata as {@link SimpleProprietary}
+   */
+  public List<SimpleProprietary> getNodes(final String xpath) {
+    return NodeParser.getNodesFromExpression(xpath, node).stream()
+        .map(SimpleProprietary::new)
+        .toList();
+  }
+
+  protected Optional<SimpleProprietary> getSimpleNodeAt(
+      final T simpleMetadatum, final LocalDate date) {
+    final List<SimpleProprietary> valuesWithoutStartAndEnd =
+        getNodes(simpleMetadatum.getXpath()).stream()
+            .filter(f -> f.getStart().isEmpty() && f.getEnd().isEmpty())
+            .toList();
+
+    final List<SimpleProprietary> valuesWithStartOrAndEnd =
+        getNodes(simpleMetadatum.getXpath()).stream()
+            .filter(f -> f.getStart().isPresent() || f.getEnd().isPresent())
+            .filter(
+                f ->
+                    f.getStart()
+                        .map(start -> date.isEqual(start) || date.isAfter(start))
+                        .orElse(true))
+            .filter(
+                f -> f.getEnd().map(end -> date.isEqual(end) || date.isBefore(end)).orElse(true))
+            .toList();
+    if (!valuesWithStartOrAndEnd.isEmpty()) {
+      return valuesWithStartOrAndEnd.stream().findFirst();
+    } else {
+      return valuesWithoutStartAndEnd.stream().findFirst();
+    }
+  }
+
+  private void createNewNode(
+      final T metadatum,
+      final String newValue,
+      final LocalDate date,
+      final SimpleProprietary nextNode) {
+
+    Node parentNode = node;
+    final String[] pathElements = metadatum.getXpath().replace("./", "").split("/");
+
+    for (int i = 0; i < pathElements.length; i++) {
+      final String elementName = pathElements[i];
+      final boolean isLastElement = i == pathElements.length - 1;
+
+      if (isLastElement) {
+        // Create and set the new element
+        final Element newElement =
+            NodeCreator.createElement(String.format("meta:%s", elementName), parentNode);
+        newElement.setTextContent(newValue);
+        newElement.setAttribute(getStartAttribute(), date.toString());
+
+        if (nextNode != null && nextNode.getStart().isPresent()) {
+          final LocalDate nextStart = nextNode.getStart().get().minusDays(1);
+          newElement.setAttribute(getEndAttribute(), nextStart.toString());
+        } else {
+          newElement.setAttribute(getEndAttribute(), "unbestimmt");
+        }
+      } else {
+        // Get or create child node
+        final Optional<Node> childNode =
+            NodeParser.getNodeFromExpression("./%s".formatted(elementName), parentNode);
+        if (childNode.isPresent()) {
+          parentNode = childNode.get();
+        } else {
+          parentNode = NodeCreator.createElement(String.format("meta:%s", elementName), parentNode);
+        }
+      }
+    }
+  }
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Metadaten.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Metadaten.java
@@ -130,13 +130,13 @@ public abstract class Metadaten<T extends MetadataInterface> {
   }
 
   private void createNewNode(
-      final T metadatum,
+      final T simpleMetadatum,
       final String newValue,
       final LocalDate date,
       final SimpleProprietary nextNode) {
 
     Node parentNode = node;
-    final String[] pathElements = metadatum.getXpath().replace("./", "").split("/");
+    final String[] pathElements = simpleMetadatum.getXpath().replace("./", "").split("/");
 
     for (int i = 0; i < pathElements.length; i++) {
       final String elementName = pathElements[i];

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/MetadatenDe.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/MetadatenDe.java
@@ -2,17 +2,40 @@ package de.bund.digitalservice.ris.norms.domain.entity;
 
 import de.bund.digitalservice.ris.norms.utils.NodeParser;
 import java.util.Optional;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.experimental.SuperBuilder;
 import org.w3c.dom.Node;
 
 /** Class representing the meta:legalDocML.de_metadaten */
 @Getter
-@SuperBuilder(toBuilder = true)
-@AllArgsConstructor
-public class MetadatenDe {
-  private final Node node;
+public class MetadatenDe extends Metadaten<MetadatenDe.Metadata> {
+
+  @Builder
+  public MetadatenDe(final Node node) {
+    super(node, "ab", "bis");
+  }
+
+  /**
+   * The list of all simple metadata within the meta:legalDocML.de_metadaten block. Single and
+   * nested properties.
+   */
+  public enum Metadata implements MetadataInterface {
+    FNA("./fna"),
+    ART("./art"),
+    TYP("./typ"),
+    FEDERFUEHRUNG("./federfuehrung/federfuehrend");
+
+    private final String xpath;
+
+    Metadata(final String xpath) {
+      this.xpath = xpath;
+    }
+
+    @Override
+    public String getXpath() {
+      return this.xpath;
+    }
+  }
 
   /**
    * Returns the FNA ("Fundstellennachweis A") of the norm.
@@ -20,7 +43,7 @@ public class MetadatenDe {
    * @return FNA or empty if it doesn't exist.
    */
   public Optional<String> getFna() {
-    return NodeParser.getValueFromExpression("./fna", node);
+    return NodeParser.getValueFromExpression(Metadata.FNA.xpath, getNode());
   }
 
   /**
@@ -29,7 +52,7 @@ public class MetadatenDe {
    * @return Art or empty if it doesn't exist.
    */
   public Optional<String> getArt() {
-    return NodeParser.getValueFromExpression("./art", node);
+    return NodeParser.getValueFromExpression(Metadata.ART.xpath, getNode());
   }
 
   /**
@@ -38,6 +61,6 @@ public class MetadatenDe {
    * @return Typ or empty if it doesn't exist.
    */
   public Optional<String> getTyp() {
-    return NodeParser.getValueFromExpression("./typ", node);
+    return NodeParser.getValueFromExpression(Metadata.TYP.xpath, getNode());
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/MetadatenDs.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/MetadatenDs.java
@@ -1,25 +1,25 @@
 package de.bund.digitalservice.ris.norms.domain.entity;
 
-import de.bund.digitalservice.ris.norms.utils.NodeCreator;
-import de.bund.digitalservice.ris.norms.utils.NodeParser;
 import java.time.LocalDate;
-import java.util.*;
-import lombok.AllArgsConstructor;
+import java.util.Optional;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.experimental.SuperBuilder;
-import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 /** Class representing the meta:legalDocML.de_metadaten_ds */
 @Getter
-@SuperBuilder(toBuilder = true)
-@AllArgsConstructor
-public class MetadatenDs {
+public class MetadatenDs extends Metadaten<MetadatenDs.Metadata> {
 
-  private final Node node;
+  @Builder
+  public MetadatenDs(final Node node) {
+    super(node, "start", "end");
+  }
 
-  /** The list of all simple metadata. They consist of a single string property. */
-  public enum SimpleMetadatum {
+  /**
+   * The list of all simple metadata within the meta:legalDocML.de_metadaten_ds block. They consist
+   * of a single string property.
+   */
+  public enum Metadata implements MetadataInterface {
     FNA("./fna"),
     ART("./art"),
     TYP("./typ"),
@@ -31,38 +31,30 @@ public class MetadatenDs {
 
     private final String xpath;
 
-    SimpleMetadatum(final String xpath) {
+    Metadata(final String xpath) {
       this.xpath = xpath;
+    }
+
+    @Override
+    public String getXpath() {
+      return this.xpath;
     }
   }
 
   /**
-   * The list of all attribute. They consist of the enum {@link SimpleMetadatum} they belong to and
-   * its name.
+   * The list of all attribute. They consist of the enum {@link Metadata} they belong to and its
+   * name.
    */
   public enum Attribute {
-    QUALIFIZIERTE_MEHRHEIT(SimpleMetadatum.BESCHLIESSENDES_ORGAN, "qualifizierteMehrheit");
+    QUALIFIZIERTE_MEHRHEIT(Metadata.BESCHLIESSENDES_ORGAN, "qualifizierteMehrheit");
 
-    private final SimpleMetadatum simpleMetadatum;
+    private final Metadata simpleMetadatum;
     private final String name;
 
-    Attribute(final SimpleMetadatum simpleMetadatum, final String name) {
+    Attribute(final Metadata simpleMetadatum, final String name) {
       this.simpleMetadatum = simpleMetadatum;
       this.name = name;
     }
-  }
-
-  /**
-   * It returns the value for a xpath at a specific date. If no matching value @start or @end is
-   * found, it will retrieve the value from the node with neither @start nor @end.
-   *
-   * @param simpleMetadatum the enum metadatum
-   * @param date the specific date
-   * @return an optional value, if found.
-   */
-  public Optional<String> getSimpleMetadatum(
-      final SimpleMetadatum simpleMetadatum, final LocalDate date) {
-    return getSimpleNodeAt(simpleMetadatum, date).map(SimpleProprietary::getValue);
   }
 
   /**
@@ -74,70 +66,9 @@ public class MetadatenDs {
    * @return an optional string value of the attribute, if found
    */
   public Optional<String> getAttributeOfSimpleMetadatumAt(
-      final Attribute attribute, final LocalDate date) {
+      final MetadatenDs.Attribute attribute, final LocalDate date) {
     return getSimpleNodeAt(attribute.simpleMetadatum, date)
         .flatMap(m -> m.getAttribute(attribute.name));
-  }
-
-  /**
-   * Creates or updates a metadata with simple value at the specific date. It sets the @start
-   * attribute to the given date. If node not present, it will create a new one and set also
-   * the @end attribute if there is a later fna node. The value would be the @start date of the next
-   * closest FNA minus 1 day. Also, if there is a previous node it will set the @end attribute to 1
-   * day before of the newly updated/created node. Finally, it will also set the @end attribute of
-   * those nodes with neither @start nor @end attributes.
-   *
-   * @param simpleMetadatum - the simple enum metadatum
-   * @param date - the specific date
-   * @param newValue - the new value to update/create
-   */
-  public void setSimpleMetadatum(
-      final SimpleMetadatum simpleMetadatum, final LocalDate date, final String newValue) {
-    NodeParser.getNodeFromExpression(
-            String.format("%s[@start='%s']", simpleMetadatum.xpath, date.toString()), node)
-        .ifPresentOrElse(
-            fnaNode -> fnaNode.setTextContent(newValue),
-            () -> {
-              // 1. Check if we have later FNAs and get the next closest one
-              final Optional<SimpleProprietary> nextNode =
-                  getNodes(simpleMetadatum.xpath).stream()
-                      .filter(f -> f.getStart().isPresent() && f.getStart().get().isAfter(date))
-                      .min(Comparator.comparing(f -> f.getStart().get()));
-
-              // 2. Check if we have previous FNAs and get the next closest one
-              final Optional<SimpleProprietary> previousNode =
-                  getNodes(simpleMetadatum.xpath).stream()
-                      .filter(f -> f.getStart().isPresent() && f.getStart().get().isBefore(date))
-                      .max(Comparator.comparing(f -> f.getStart().get()));
-
-              // 3. Create new meta:fna node with the @start value and optional @end
-              final Element newFnaElement =
-                  NodeCreator.createElement(
-                      String.format("meta:%s", simpleMetadatum.xpath.replace("./", "")), node);
-              newFnaElement.setTextContent(newValue);
-              newFnaElement.setAttribute("start", date.toString());
-              if (nextNode.isPresent() && nextNode.get().getStart().isPresent()) {
-                final LocalDate nextStart = nextNode.get().getStart().get().minusDays(1);
-                newFnaElement.setAttribute("end", nextStart.toString());
-              } else {
-                newFnaElement.setAttribute("end", "unbestimmt");
-              }
-
-              // 4. Then also set @end of a previous one, if present
-              previousNode.ifPresent(
-                  value ->
-                      ((Element) value.getNode())
-                          .setAttribute("end", date.minusDays(1).toString()));
-
-              // 5. And finally set @end of nodes without @start and @end to one day before given
-              // date
-              getNodes(simpleMetadatum.xpath).stream()
-                  .filter(f -> f.getStart().isEmpty() && f.getEnd().isEmpty())
-                  .forEach(
-                      value ->
-                          ((Element) value.getNode())
-                              .setAttribute("end", date.minusDays(1).toString()));
-            });
   }
 
   /**
@@ -148,7 +79,7 @@ public class MetadatenDs {
    * @param newValue the new value
    */
   public void setAttributeOfSimpleMetadatum(
-      final Attribute attribute, final LocalDate date, final String newValue) {
+      final MetadatenDs.Attribute attribute, final LocalDate date, final String newValue) {
     getSimpleNodeAt(attribute.simpleMetadatum, date)
         .ifPresent(
             m -> {
@@ -158,42 +89,5 @@ public class MetadatenDs {
                 m.setAttribute(attribute.name, newValue);
               }
             });
-  }
-
-  /**
-   * Retrieves all nodes of the specific metadatum.
-   *
-   * @param xpath of the node
-   * @return list of all metadata as {@link SimpleProprietary}
-   */
-  public List<SimpleProprietary> getNodes(final String xpath) {
-    return NodeParser.getNodesFromExpression(xpath, node).stream()
-        .map(SimpleProprietary::new)
-        .toList();
-  }
-
-  private Optional<SimpleProprietary> getSimpleNodeAt(
-      final SimpleMetadatum simpleMetadatum, final LocalDate date) {
-    final List<SimpleProprietary> valuesWithoutStartAndEnd =
-        getNodes(simpleMetadatum.xpath).stream()
-            .filter(f -> f.getStart().isEmpty() && f.getEnd().isEmpty())
-            .toList();
-
-    final List<SimpleProprietary> valuesWithStartOrAndEnd =
-        getNodes(simpleMetadatum.xpath).stream()
-            .filter(f -> f.getStart().isPresent() || f.getEnd().isPresent())
-            .filter(
-                f ->
-                    f.getStart()
-                        .map(start -> date.isEqual(start) || date.isAfter(start))
-                        .orElse(true))
-            .filter(
-                f -> f.getEnd().map(end -> date.isEqual(end) || date.isBefore(end)).orElse(true))
-            .toList();
-    if (!valuesWithStartOrAndEnd.isEmpty()) {
-      return valuesWithStartOrAndEnd.stream().findFirst();
-    } else {
-      return valuesWithoutStartAndEnd.stream().findFirst();
-    }
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Proprietary.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Proprietary.java
@@ -30,6 +30,23 @@ public class Proprietary {
   }
 
   /**
+   * Retrieves the {@link MetadatenDe} instance from the {@link Proprietary}.
+   *
+   * @return the retrieved {@link MetadatenDe} or the newly created one.
+   */
+  public MetadatenDe getOrCreateMetadatenDe() {
+    return NodeParser.getNodeFromExpression("./legalDocML.de_metadaten", node)
+        .map(MetadatenDe::new)
+        .orElseGet(
+            () -> {
+              final var newElement =
+                  NodeCreator.createElement("meta:legalDocML.de_metadaten", node);
+              newElement.setAttribute("xmlns:meta", "http://Metadaten.LegalDocML.de/1.6/");
+              return new MetadatenDe(newElement);
+            });
+  }
+
+  /**
    * Retrieves the optional {@link MetadatenDs} instance from the {@link Proprietary}.
    *
    * @return an optional with a {@link MetadatenDs}
@@ -74,7 +91,7 @@ public class Proprietary {
    */
   public Optional<String> getFna(final LocalDate date) {
     return getMetadatenDs()
-        .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.SimpleMetadatum.FNA, date))
+        .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.FNA, date))
         .or(this::getFna);
   }
 
@@ -91,7 +108,7 @@ public class Proprietary {
    */
   public Optional<String> getArt(final LocalDate date) {
     return getMetadatenDs()
-        .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.SimpleMetadatum.ART, date))
+        .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.ART, date))
         .or(this::getArt);
   }
 
@@ -108,7 +125,7 @@ public class Proprietary {
    */
   public Optional<String> getTyp(final LocalDate date) {
     return getMetadatenDs()
-        .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.SimpleMetadatum.TYP, date))
+        .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.TYP, date))
         .or(this::getTyp);
   }
 
@@ -119,8 +136,7 @@ public class Proprietary {
    * @return Subtyp or empty if it doesn't exist.
    */
   public Optional<String> getSubtyp(final LocalDate date) {
-    return getMetadatenDs()
-        .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.SimpleMetadatum.SUBTYP, date));
+    return getMetadatenDs().flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.SUBTYP, date));
   }
 
   /**
@@ -132,8 +148,7 @@ public class Proprietary {
    */
   public Optional<String> getBezeichnungInVorlage(final LocalDate date) {
     return getMetadatenDs()
-        .flatMap(
-            m -> m.getSimpleMetadatum(MetadatenDs.SimpleMetadatum.BEZEICHNUNG_IN_VORLAGE, date));
+        .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.BEZEICHNUNG_IN_VORLAGE, date));
   }
 
   /**
@@ -145,7 +160,7 @@ public class Proprietary {
    */
   public Optional<String> getArtDerNorm(final LocalDate date) {
     return getMetadatenDs()
-        .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.SimpleMetadatum.ART_DER_NORM, date));
+        .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.ART_DER_NORM, date));
   }
 
   /**
@@ -156,7 +171,7 @@ public class Proprietary {
    */
   public Optional<String> getNormgeber(final LocalDate date) {
     return getMetadatenDs()
-        .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.SimpleMetadatum.NORMGEBER, date));
+        .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.NORMGEBER, date));
   }
 
   /**
@@ -168,8 +183,7 @@ public class Proprietary {
    */
   public Optional<String> getBeschliessendesOrgan(final LocalDate date) {
     return getMetadatenDs()
-        .flatMap(
-            m -> m.getSimpleMetadatum(MetadatenDs.SimpleMetadatum.BESCHLIESSENDES_ORGAN, date));
+        .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.BESCHLIESSENDES_ORGAN, date));
   }
 
   /**
@@ -186,5 +200,17 @@ public class Proprietary {
                 m.getAttributeOfSimpleMetadatumAt(
                         MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, date)
                     .map(Boolean::parseBoolean));
+  }
+
+  /**
+   * Returns the ("Beschließendes Organ") of the document from the MetadatenDs block at a specific
+   * date.
+   *
+   * @param date the specific date of the time boundary.
+   * @return "Beschließendes Organ" or empty if it doesn't exist.
+   */
+  public Optional<String> getFederfuehrung(final LocalDate date) {
+    return getMetadatenDe()
+        .flatMap(m -> m.getSimpleMetadatum(MetadatenDe.Metadata.FEDERFUEHRUNG, date));
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/SimpleProprietary.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/SimpleProprietary.java
@@ -26,21 +26,45 @@ public class SimpleProprietary {
   }
 
   /**
-   * Retrieves the value of the start attribute, which is mandatory
+   * Retrieves the value of the optional @start attribute
    *
-   * @return the start value in {@link LocalDate}
+   * @return the optional value of @start in {@link LocalDate}
    */
   public Optional<LocalDate> getStart() {
-    return NodeParser.getValueFromExpression("./@start", node).map(LocalDate::parse);
+    return NodeParser.getValueFromExpression("./@start", node)
+        .map(LocalDate::parse)
+        .or(this::getAb);
   }
 
   /**
-   * Retrieves the value of the end attribute, which is optional
+   * Retrieves the value of the optional @ab attribute
    *
-   * @return the optional value of end in {@link LocalDate}
+   * @return the optional value of @ab in {@link LocalDate}
+   */
+  public Optional<LocalDate> getAb() {
+    return NodeParser.getValueFromExpression("./@ab", node).map(LocalDate::parse);
+  }
+
+  /**
+   * Retrieves the value of the optional @end attribute
+   *
+   * @return the optional value of @end in {@link LocalDate}
    */
   public Optional<LocalDate> getEnd() {
-    return NodeParser.getValueFromExpression("./@end", node)
+    return getEndOrBis("end").or(this::getBis);
+  }
+
+  /**
+   * Retrieves the value of the optional @bis attribute
+   *
+   * @return the optional value of @bis in {@link LocalDate}
+   */
+  public Optional<LocalDate> getBis() {
+    return getEndOrBis("bis");
+  }
+
+  private Optional<LocalDate> getEndOrBis(final String attributeName) {
+    return NodeParser.getValueFromExpression("./@%s".formatted(attributeName), node)
         .map(
             m -> {
               if (m.equals("unbestimmt")) {

--- a/backend/src/main/resources/db/data/R__002_2023_413_2023-12-29_Nachrichtendienstrechts.sql
+++ b/backend/src/main/resources/db/data/R__002_2023_413_2023-12-29_Nachrichtendienstrechts.sql
@@ -6884,6 +6884,7 @@ VALUES ('b0f315a1-620b-4eaf-922c-ea46a7d10c8b', 'eli/bund/bgbl-1/1990/s2954/2023
                    <meta:gesta>nicht-vorhanden</meta:gesta>
                    <!-- Die vorliegenden Angaben von meta:federfuehrung besitzen keine fachliche Korrektheit. -->
                    <meta:federfuehrung>
+                      <meta:federfuehrend ab="1970-01-01" bis="2023-12-28">BMVg - Bundesministerium der Verteidigung</meta:federfuehrend>
                       <meta:federfuehrend ab="2023-12-29" bis="unbestimmt">Bundesministerium des Innern und für Heimat</meta:federfuehrend>
                    </meta:federfuehrung>
                 </meta:legalDocML.de_metadaten>

--- a/backend/src/main/resources/db/data/R__004_2024_108_2024-03-27_Wachstumschancengesetz.sql
+++ b/backend/src/main/resources/db/data/R__004_2024_108_2024-03-27_Wachstumschancengesetz.sql
@@ -1631,8 +1631,10 @@ VALUES ('5d84cd1d-3575-4a03-bb6c-f17834e392fe', 'eli/bund/bgbl-1/2009/s3366/2024
                     <meta:gesta>nicht-vorhanden</meta:gesta>
                     <!-- Die vorliegenden Angaben von meta:federfuehrung besitzen keine fachliche Korrektheit. -->
                     <meta:federfuehrung>
-                        <meta:federfuehrend ab="1934-10-16" bis="unbestimmt">Bundesministerium für Finanzen
-                        </meta:federfuehrend>
+                        <meta:federfuehrend ab="1934-10-16" bis="2009-10-07">BMF - Bundesministerium der Finanzen</meta:federfuehrend>
+                        <meta:federfuehrend ab="2009-10-08" bis="2022-12-31">BMWSB - Bundesministerium für Wohnen, Stadtentwicklung und Bauwesen</meta:federfuehrend>
+                        <meta:federfuehrend ab="2023-01-01" bis="2023-12-23">BMDV - Bundesministerium für Digitales und Verkehr</meta:federfuehrend>
+                        <meta:federfuehrend ab="2023-12-24" bis="unbestimmt">BMG - Bundesministerium für Gesundheit</meta:federfuehrend>
                     </meta:federfuehrung>
                 </meta:legalDocML.de_metadaten>
                  <!-- Metadaten vom DS definiert -->

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/ProprietaryServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/ProprietaryServiceTest.java
@@ -88,7 +88,7 @@ class ProprietaryServiceTest {
                           eli,
                           LocalDate.now(),
                           new UpdateProprietaryFromNormUseCase.Metadata(
-                              "fna", null, null, null, null, null, null, null, null))))
+                              "fna", null, null, null, null, null, null, null, null, null))))
           // then
           .isInstanceOf(NormNotFoundException.class);
     }
@@ -109,7 +109,7 @@ class ProprietaryServiceTest {
                   eli,
                   date,
                   new UpdateProprietaryFromNormUseCase.Metadata(
-                      "fna", null, null, null, null, null, null, null, null)));
+                      "fna", null, null, null, null, null, null, null, null, null)));
 
       // then
       assertThat(result).isInstanceOf(Proprietary.class);
@@ -140,7 +140,8 @@ class ProprietaryServiceTest {
                       "SN,ÄN,ÜN",
                       "DEU",
                       "Bundestag",
-                      true)));
+                      true,
+                      "BMJ - Bundesministerium der Justiz")));
 
       // then
       assertThat(result).isInstanceOf(Proprietary.class);
@@ -153,6 +154,7 @@ class ProprietaryServiceTest {
       assertThat(result.getNormgeber(date)).contains("DEU");
       assertThat(result.getBeschliessendesOrgan(date)).contains("Bundestag");
       assertThat(result.getQualifizierteMehrheit(date)).contains(true);
+      assertThat(result.getFederfuehrung(date)).contains("BMJ - Bundesministerium der Justiz");
     }
 
     @Test
@@ -171,7 +173,7 @@ class ProprietaryServiceTest {
                   eli,
                   date,
                   new UpdateProprietaryFromNormUseCase.Metadata(
-                      null, null, null, null, null, null, null, null, null)));
+                      null, null, null, null, null, null, null, null, null, null)));
 
       // then
       assertThat(result).isInstanceOf(Proprietary.class);
@@ -184,6 +186,7 @@ class ProprietaryServiceTest {
       assertThat(result.getNormgeber(date)).contains("");
       assertThat(result.getBeschliessendesOrgan(date)).contains("");
       assertThat(result.getQualifizierteMehrheit(date)).isEmpty();
+      assertThat(result.getFederfuehrung(date)).contains("");
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/MetadatenDeTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/MetadatenDeTest.java
@@ -1,0 +1,211 @@
+package de.bund.digitalservice.ris.norms.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.bund.digitalservice.ris.norms.utils.XmlMapper;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+
+class MetadatenDeTest {
+
+  @Test
+  void getFna() {
+    final MetadatenDe metadatenDe =
+        MetadatenDe.builder()
+            .node(
+                XmlMapper.toNode(
+                    """
+                                <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+                                    <meta:fna>111-11-1</meta:fna>
+                                </meta:legalDocML.de_metadaten>
+                            """))
+            .build();
+
+    assertThat(metadatenDe.getFna()).contains("111-11-1");
+  }
+
+  @Test
+  void getFnaEmpty() {
+    final MetadatenDe metadatenDe =
+        MetadatenDe.builder()
+            .node(
+                XmlMapper.toNode(
+                    """
+                                                <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+                                                </meta:legalDocML.de_metadaten>
+                                            """))
+            .build();
+
+    assertThat(metadatenDe.getFna()).isEmpty();
+  }
+
+  @Test
+  void getArt() {
+    final MetadatenDe metadatenDe =
+        MetadatenDe.builder()
+            .node(
+                XmlMapper.toNode(
+                    """
+                                                <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+                                                    <meta:art>test art</meta:art>
+                                                </meta:legalDocML.de_metadaten>
+                                            """))
+            .build();
+
+    assertThat(metadatenDe.getArt()).contains("test art");
+  }
+
+  @Test
+  void getArtEmpty() {
+    final MetadatenDe metadatenDe =
+        MetadatenDe.builder()
+            .node(
+                XmlMapper.toNode(
+                    """
+                                                <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+                                                </meta:legalDocML.de_metadaten>
+                                            """))
+            .build();
+
+    assertThat(metadatenDe.getArt()).isEmpty();
+  }
+
+  @Test
+  void getTyp() {
+    final MetadatenDe metadatenDe =
+        MetadatenDe.builder()
+            .node(
+                XmlMapper.toNode(
+                    """
+                                                <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+                                                    <meta:typ>typi1</meta:typ>
+                                                </meta:legalDocML.de_metadaten>
+                                            """))
+            .build();
+
+    assertThat(metadatenDe.getTyp()).contains("typi1");
+  }
+
+  @Test
+  void getTypEmpty() {
+    final MetadatenDe metadatenDe =
+        MetadatenDe.builder()
+            .node(
+                XmlMapper.toNode(
+                    """
+                                                                <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+                                                                </meta:legalDocML.de_metadaten>
+                                                            """))
+            .build();
+
+    assertThat(metadatenDe.getTyp()).isEmpty();
+  }
+
+  @Test
+  void getFederfuehrung() {
+    final MetadatenDe metadatenDe =
+        MetadatenDe.builder()
+            .node(
+                XmlMapper.toNode(
+                    """
+                                        <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+                                            <meta:federfuehrung>
+                                                <meta:federfuehrend ab="2022-12-01" bis="unbestimmt">Bundesministerium des Innern und für Heimat</meta:federfuehrend>
+                                                <meta:federfuehrend ab="2002-10-01" bis="2022-11-30">Bundesministerium der Justiz</meta:federfuehrend>
+                                            </meta:federfuehrung>
+                                        </meta:legalDocML.de_metadaten>
+                                        """))
+            .build();
+
+    assertThat(
+            metadatenDe.getSimpleMetadatum(
+                MetadatenDe.Metadata.FEDERFUEHRUNG, LocalDate.parse("1990-01-01")))
+        .isEmpty();
+    assertThat(
+            metadatenDe.getSimpleMetadatum(
+                MetadatenDe.Metadata.FEDERFUEHRUNG, LocalDate.parse("2002-10-01")))
+        .contains("Bundesministerium der Justiz");
+    assertThat(
+            metadatenDe.getSimpleMetadatum(
+                MetadatenDe.Metadata.FEDERFUEHRUNG, LocalDate.parse("2022-12-01")))
+        .contains("Bundesministerium des Innern und für Heimat");
+    assertThat(
+            metadatenDe.getSimpleMetadatum(
+                MetadatenDe.Metadata.FEDERFUEHRUNG, LocalDate.parse("2024-06-18")))
+        .contains("Bundesministerium des Innern und für Heimat");
+  }
+
+  @Test
+  void getFederfuehrungNotPresent() {
+    final MetadatenDe metadatenDe =
+        MetadatenDe.builder()
+            .node(
+                XmlMapper.toNode(
+                    """
+                                                                <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+                                                                </meta:legalDocML.de_metadaten>
+                                                            """))
+            .build();
+
+    assertThat(metadatenDe.getSimpleMetadatum(MetadatenDe.Metadata.FEDERFUEHRUNG, LocalDate.MAX))
+        .isEmpty();
+  }
+
+  @Test
+  void setFederfuehrungUpdate() {
+    final MetadatenDe metadatenDe =
+        MetadatenDe.builder()
+            .node(
+                XmlMapper.toNode(
+                    """
+                                                                        <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+                                                                            <meta:federfuehrung>
+                                                                                <meta:federfuehrend ab="2022-12-01" bis="unbestimmt">Bundesministerium des Innern und für Heimat</meta:federfuehrend>
+                                                                                <meta:federfuehrend ab="2002-10-01" bis="2022-11-30">Bundesministerium der Justiz</meta:federfuehrend>
+                                                                            </meta:federfuehrung>
+                                                                        </meta:legalDocML.de_metadaten>
+                                                                        """))
+            .build();
+
+    final LocalDate atDate = LocalDate.parse("2002-10-01");
+    assertThat(metadatenDe.getSimpleMetadatum(MetadatenDe.Metadata.FEDERFUEHRUNG, atDate))
+        .contains("Bundesministerium der Justiz");
+    assertThat(metadatenDe.getNodes(MetadatenDe.Metadata.FEDERFUEHRUNG.getXpath())).hasSize(2);
+
+    metadatenDe.setSimpleMetadatum(
+        MetadatenDe.Metadata.FEDERFUEHRUNG, atDate, "test federfuehrung");
+
+    assertThat(metadatenDe.getSimpleMetadatum(MetadatenDe.Metadata.FEDERFUEHRUNG, atDate))
+        .contains("test federfuehrung");
+    assertThat(metadatenDe.getNodes(MetadatenDe.Metadata.FEDERFUEHRUNG.getXpath())).hasSize(2);
+  }
+
+  @Test
+  void setFederfuehrungCreate() {
+    final MetadatenDe metadatenDe =
+        MetadatenDe.builder()
+            .node(
+                XmlMapper.toNode(
+                    """
+                                                        <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+                                                            <meta:federfuehrung>
+                                                                <meta:federfuehrend ab="2022-12-01" bis="unbestimmt">Bundesministerium des Innern und für Heimat</meta:federfuehrend>
+                                                                <meta:federfuehrend ab="2002-10-01" bis="2022-11-30">Bundesministerium der Justiz</meta:federfuehrend>
+                                                            </meta:federfuehrung>
+                                                        </meta:legalDocML.de_metadaten>
+                                                        """))
+            .build();
+
+    final LocalDate atDate = LocalDate.parse("1990-01-01");
+    assertThat(metadatenDe.getSimpleMetadatum(MetadatenDe.Metadata.FEDERFUEHRUNG, atDate))
+        .isEmpty();
+    assertThat(metadatenDe.getNodes(MetadatenDe.Metadata.FEDERFUEHRUNG.getXpath())).hasSize(2);
+
+    metadatenDe.setSimpleMetadatum(
+        MetadatenDe.Metadata.FEDERFUEHRUNG, atDate, "test federfuehrung");
+
+    assertThat(metadatenDe.getSimpleMetadatum(MetadatenDe.Metadata.FEDERFUEHRUNG, atDate))
+        .contains("test federfuehrung");
+    assertThat(metadatenDe.getNodes(MetadatenDe.Metadata.FEDERFUEHRUNG.getXpath())).hasSize(3);
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/MetadatenDsTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/MetadatenDsTest.java
@@ -30,43 +30,34 @@ class MetadatenDsTest {
             .build();
 
     assertThat(
-            metadatenDs.getSimpleMetadatum(
-                MetadatenDs.SimpleMetadatum.FNA, LocalDate.parse("1980-01-01")))
+            metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, LocalDate.parse("1980-01-01")))
         .isEmpty();
 
     assertThat(
-            metadatenDs.getSimpleMetadatum(
-                MetadatenDs.SimpleMetadatum.FNA, LocalDate.parse("1990-01-01")))
+            metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, LocalDate.parse("1990-01-01")))
         .contains("111-11-1");
     assertThat(
-            metadatenDs.getSimpleMetadatum(
-                MetadatenDs.SimpleMetadatum.FNA, LocalDate.parse("1992-01-01")))
+            metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, LocalDate.parse("1992-01-01")))
         .contains("111-11-1");
     assertThat(
-            metadatenDs.getSimpleMetadatum(
-                MetadatenDs.SimpleMetadatum.FNA, LocalDate.parse("1994-12-31")))
+            metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, LocalDate.parse("1994-12-31")))
         .contains("111-11-1");
 
     assertThat(
-            metadatenDs.getSimpleMetadatum(
-                MetadatenDs.SimpleMetadatum.FNA, LocalDate.parse("1995-01-01")))
+            metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, LocalDate.parse("1995-01-01")))
         .contains("222-22-2");
     assertThat(
-            metadatenDs.getSimpleMetadatum(
-                MetadatenDs.SimpleMetadatum.FNA, LocalDate.parse("1998-01-01")))
+            metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, LocalDate.parse("1998-01-01")))
         .contains("222-22-2");
     assertThat(
-            metadatenDs.getSimpleMetadatum(
-                MetadatenDs.SimpleMetadatum.FNA, LocalDate.parse("2000-12-31")))
+            metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, LocalDate.parse("2000-12-31")))
         .contains("222-22-2");
 
     assertThat(
-            metadatenDs.getSimpleMetadatum(
-                MetadatenDs.SimpleMetadatum.FNA, LocalDate.parse("2001-01-01")))
+            metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, LocalDate.parse("2001-01-01")))
         .contains("333-33-3");
     assertThat(
-            metadatenDs.getSimpleMetadatum(
-                MetadatenDs.SimpleMetadatum.FNA, LocalDate.parse("2024-01-01")))
+            metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, LocalDate.parse("2024-01-01")))
         .contains("333-33-3");
   }
 
@@ -92,19 +83,20 @@ class MetadatenDsTest {
             .build();
 
     final LocalDate newDate = LocalDate.parse("1990-01-01");
-    assertThat(metadatenDs.getNodes("./fna")).hasSize(3);
-    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.SimpleMetadatum.FNA, newDate))
+    assertThat(metadatenDs.getNodes(MetadatenDs.Metadata.FNA.getXpath())).hasSize(3);
+    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate))
         .contains("111-11-1");
 
-    metadatenDs.setSimpleMetadatum(MetadatenDs.SimpleMetadatum.FNA, newDate, updateValue);
+    metadatenDs.setSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate, updateValue);
 
-    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.SimpleMetadatum.FNA, newDate))
+    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate))
         .contains(expectedValue);
-    assertThat(metadatenDs.getNodes("./fna")).hasSize(3);
+    assertThat(metadatenDs.getNodes(MetadatenDs.Metadata.FNA.getXpath())).hasSize(3);
   }
 
   @Test
   void setFnaAtDateCreateWithoutEnd() {
+
     final MetadatenDs metadatenDs =
         MetadatenDs.builder()
             .node(
@@ -117,16 +109,16 @@ class MetadatenDsTest {
 
     final LocalDate newDate = LocalDate.parse("1980-01-01");
 
-    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.SimpleMetadatum.FNA, newDate)).isEmpty();
-    assertThat(metadatenDs.getNodes("./fna")).isEmpty();
+    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate)).isEmpty();
+    assertThat(metadatenDs.getNodes(MetadatenDs.Metadata.FNA.getXpath())).isEmpty();
 
-    metadatenDs.setSimpleMetadatum(MetadatenDs.SimpleMetadatum.FNA, newDate, "000-00-0");
+    metadatenDs.setSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate, "000-00-0");
 
-    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.SimpleMetadatum.FNA, newDate))
+    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate))
         .contains("000-00-0");
-    assertThat(metadatenDs.getNodes("./fna")).hasSize(1);
+    assertThat(metadatenDs.getNodes(MetadatenDs.Metadata.FNA.getXpath())).hasSize(1);
 
-    metadatenDs.getNodes("./fna").stream()
+    metadatenDs.getNodes(MetadatenDs.Metadata.FNA.getXpath()).stream()
         .filter(f -> f.getStart().isPresent() && f.getStart().get().isEqual(newDate))
         .findFirst()
         .map(m -> assertThat(m.getEnd()).contains(LocalDate.MAX));
@@ -148,16 +140,16 @@ class MetadatenDsTest {
             .build();
 
     final LocalDate newDate = LocalDate.parse("1980-01-01");
-    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.SimpleMetadatum.FNA, newDate)).isEmpty();
-    assertThat(metadatenDs.getNodes("./fna")).hasSize(3);
+    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate)).isEmpty();
+    assertThat(metadatenDs.getNodes(MetadatenDs.Metadata.FNA.getXpath())).hasSize(3);
 
-    metadatenDs.setSimpleMetadatum(MetadatenDs.SimpleMetadatum.FNA, newDate, "000-00-0");
+    metadatenDs.setSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate, "000-00-0");
 
-    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.SimpleMetadatum.FNA, newDate))
+    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate))
         .contains("000-00-0");
-    assertThat(metadatenDs.getNodes("./fna")).hasSize(4);
+    assertThat(metadatenDs.getNodes(MetadatenDs.Metadata.FNA.getXpath())).hasSize(4);
 
-    metadatenDs.getNodes("./fna").stream()
+    metadatenDs.getNodes(MetadatenDs.Metadata.FNA.getXpath()).stream()
         .filter(f -> f.getStart().isPresent() && f.getStart().get().isEqual(newDate))
         .findFirst()
         .map(m -> assertThat(m.getEnd()).contains(LocalDate.parse("1989-12-31")));
@@ -179,15 +171,16 @@ class MetadatenDsTest {
             .build();
 
     final LocalDate newDate = LocalDate.parse("2005-01-01");
-    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.SimpleMetadatum.FNA, newDate))
+    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate))
         .contains("333-33-3");
-    assertThat(metadatenDs.getNodes("./fna")).hasSize(3);
+    assertThat(metadatenDs.getNodes(MetadatenDs.Metadata.FNA.getXpath())).hasSize(3);
 
-    metadatenDs.setSimpleMetadatum(MetadatenDs.SimpleMetadatum.FNA, newDate, "000-00-0");
+    metadatenDs.setSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate, "000-00-0");
 
-    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.SimpleMetadatum.FNA, newDate))
+    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate))
         .contains("000-00-0");
-    final List<SimpleProprietary> fnaValues = metadatenDs.getNodes("./fna");
+    final List<SimpleProprietary> fnaValues =
+        metadatenDs.getNodes(MetadatenDs.Metadata.FNA.getXpath());
     assertThat(fnaValues).hasSize(4);
 
     fnaValues.stream()
@@ -222,42 +215,42 @@ class MetadatenDsTest {
 
     assertThat(
             metadatenDs.getSimpleMetadatum(
-                MetadatenDs.SimpleMetadatum.SUBTYP, LocalDate.parse("1980-01-01")))
+                MetadatenDs.Metadata.SUBTYP, LocalDate.parse("1980-01-01")))
         .contains("subtyp0");
 
     assertThat(
             metadatenDs.getSimpleMetadatum(
-                MetadatenDs.SimpleMetadatum.SUBTYP, LocalDate.parse("1990-01-01")))
+                MetadatenDs.Metadata.SUBTYP, LocalDate.parse("1990-01-01")))
         .contains("subtyp1");
     assertThat(
             metadatenDs.getSimpleMetadatum(
-                MetadatenDs.SimpleMetadatum.SUBTYP, LocalDate.parse("1992-01-01")))
+                MetadatenDs.Metadata.SUBTYP, LocalDate.parse("1992-01-01")))
         .contains("subtyp1");
     assertThat(
             metadatenDs.getSimpleMetadatum(
-                MetadatenDs.SimpleMetadatum.SUBTYP, LocalDate.parse("1994-12-31")))
+                MetadatenDs.Metadata.SUBTYP, LocalDate.parse("1994-12-31")))
         .contains("subtyp1");
 
     assertThat(
             metadatenDs.getSimpleMetadatum(
-                MetadatenDs.SimpleMetadatum.SUBTYP, LocalDate.parse("1995-01-01")))
+                MetadatenDs.Metadata.SUBTYP, LocalDate.parse("1995-01-01")))
         .contains("subtyp2");
     assertThat(
             metadatenDs.getSimpleMetadatum(
-                MetadatenDs.SimpleMetadatum.SUBTYP, LocalDate.parse("1998-01-01")))
+                MetadatenDs.Metadata.SUBTYP, LocalDate.parse("1998-01-01")))
         .contains("subtyp2");
     assertThat(
             metadatenDs.getSimpleMetadatum(
-                MetadatenDs.SimpleMetadatum.SUBTYP, LocalDate.parse("2000-12-31")))
+                MetadatenDs.Metadata.SUBTYP, LocalDate.parse("2000-12-31")))
         .contains("subtyp2");
 
     assertThat(
             metadatenDs.getSimpleMetadatum(
-                MetadatenDs.SimpleMetadatum.SUBTYP, LocalDate.parse("2001-01-01")))
+                MetadatenDs.Metadata.SUBTYP, LocalDate.parse("2001-01-01")))
         .contains("subtyp3");
     assertThat(
             metadatenDs.getSimpleMetadatum(
-                MetadatenDs.SimpleMetadatum.SUBTYP, LocalDate.parse("2024-01-01")))
+                MetadatenDs.Metadata.SUBTYP, LocalDate.parse("2024-01-01")))
         .contains("subtyp3");
   }
 
@@ -275,13 +268,13 @@ class MetadatenDsTest {
             .build();
 
     final LocalDate newDate = LocalDate.parse("2005-01-01");
-    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.SimpleMetadatum.SUBTYP, newDate))
+    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.SUBTYP, newDate))
         .contains("subtyp0");
     assertThat(metadatenDs.getNodes("./subtyp")).hasSize(1);
 
-    metadatenDs.setSimpleMetadatum(MetadatenDs.SimpleMetadatum.SUBTYP, newDate, "subtyp1");
+    metadatenDs.setSimpleMetadatum(MetadatenDs.Metadata.SUBTYP, newDate, "subtyp1");
 
-    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.SimpleMetadatum.SUBTYP, newDate))
+    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.SUBTYP, newDate))
         .contains("subtyp1");
     final List<SimpleProprietary> subtypValues = metadatenDs.getNodes("./subtyp");
     assertThat(subtypValues).hasSize(2);
@@ -291,9 +284,7 @@ class MetadatenDsTest {
         .findFirst()
         .map(m -> assertThat(m.getEnd()).contains(LocalDate.MAX));
 
-    assertThat(
-            metadatenDs.getSimpleMetadatum(
-                MetadatenDs.SimpleMetadatum.SUBTYP, newDate.minusDays(1)))
+    assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.SUBTYP, newDate.minusDays(1)))
         .contains("subtyp0");
   }
 

--- a/frontend/e2e/amending-laws-affected-document-editor.spec.ts
+++ b/frontend/e2e/amending-laws-affected-document-editor.spec.ts
@@ -457,6 +457,7 @@ test.describe("XML preview", () => {
           normgeber: "BEO - Berlin (Ost)",
           beschliessendesOrgan: "BMinJ - Bundesministerium der Justiz",
           qualifizierteMehrheit: true,
+          federfuehrung: "BMVg - Bundesministerium der Verteidigung",
         }),
       },
     )
@@ -542,6 +543,9 @@ test.describe("metadata reading", () => {
     await expect(
       editorRegion.getByLabel("Beschlussf. qual. Mehrheit"),
     ).toBeChecked()
+    await expect(editorRegion.getByLabel("Federführung")).toHaveValue(
+      "BMVg - Bundesministerium der Verteidigung",
+    )
   })
 
   test("displays metadata on the frame at different time boundaries", async ({
@@ -584,6 +588,9 @@ test.describe("metadata reading", () => {
     await expect(
       editorRegion.getByLabel("Beschlussf. qual. Mehrheit"),
     ).not.toBeChecked()
+    await expect(editorRegion.getByLabel("Federführung")).toHaveValue(
+      "BMF - Bundesministerium der Finanzen",
+    )
 
     const dropdown = page.getByRole("combobox", { name: "Zeitgrenze" })
     dropdown.selectOption("2009-10-08")
@@ -611,6 +618,9 @@ test.describe("metadata reading", () => {
     await expect(
       editorRegion.getByLabel("Beschlussf. qual. Mehrheit"),
     ).toBeChecked()
+    await expect(editorRegion.getByLabel("Federführung")).toHaveValue(
+      "BMWSB - Bundesministerium für Wohnen, Stadtentwicklung und Bauwesen",
+    )
 
     dropdown.selectOption("2023-01-01")
     await page.waitForResponse((response) =>
@@ -636,6 +646,9 @@ test.describe("metadata reading", () => {
     await expect(
       editorRegion.getByLabel("Beschlussf. qual. Mehrheit"),
     ).not.toBeChecked()
+    await expect(editorRegion.getByLabel("Federführung")).toHaveValue(
+      "BMDV - Bundesministerium für Digitales und Verkehr",
+    )
 
     dropdown.selectOption("2023-12-24")
     await page.waitForResponse((response) =>
@@ -662,6 +675,9 @@ test.describe("metadata reading", () => {
     await expect(
       editorRegion.getByLabel("Beschlussf. qual. Mehrheit"),
     ).toBeChecked()
+    await expect(editorRegion.getByLabel("Federführung")).toHaveValue(
+      "BMG - Bundesministerium für Gesundheit",
+    )
   })
 
   test("displays an error if the data could not be loaded for the whole document", async ({
@@ -882,12 +898,11 @@ test.describe("metadata editing", () => {
     await qualMehrheit.check()
 
     // Federführung
-    // TODO: Enable once backend is ready
-    // const federfuehrungDropdown = page.getByRole("combobox", {
-    //   name: "Federführung",
-    // })
-    // await expect(federfuehrungDropdown).toHaveValue("ADD VALUE HERE")
-    // await federfuehrungDropdown.selectOption("BKAmt - Bundeskanzleramt")
+    const federfuehrungDropdown = page.getByRole("combobox", {
+      name: "Federführung",
+    })
+    await expect(federfuehrungDropdown).toHaveValue("")
+    await federfuehrungDropdown.selectOption("BKAmt - Bundeskanzleramt")
 
     await page.getByRole("button", { name: "Metadaten speichern" }).click()
     await saved
@@ -905,8 +920,7 @@ test.describe("metadata editing", () => {
       "BReg - Bundesregierung",
     )
     await expect(qualMehrheit).toBeChecked()
-    // TODO: Enable once backend is ready
-    // await expect(federfuehrungDropdown).toHaveValue("BKAmt - Bundeskanzleramt")
+    await expect(federfuehrungDropdown).toHaveValue("BKAmt - Bundeskanzleramt")
 
     // Reset the data
     await page.request.put(
@@ -926,8 +940,7 @@ test.describe("metadata editing", () => {
           normgeber: null,
           beschliessendesOrgan: null,
           qualifizierteMehrheit: null,
-          // TODO: Enable once backend is ready
-          // federfuehrung: null,
+          federfuehrung: null,
         }),
       },
     )
@@ -954,6 +967,7 @@ test.describe("metadata editing", () => {
             normgeber: "BesR - Besatzungsrecht",
             beschliessendesOrgan: "BMinG - Bundesministerium für Gesundheit",
             qualifizierteMehrheit: false,
+            federfuehrung: "AA - Auswärtiges Amt",
           },
         })
       else route.continue()
@@ -1018,6 +1032,12 @@ test.describe("metadata editing", () => {
     })
     await expect(qualMehrheit).toBeChecked()
 
+    // Federführung
+    const federfuehrungDropdown = page.getByRole("combobox", {
+      name: "Federführung",
+    })
+    await expect(federfuehrungDropdown).toHaveValue("")
+
     await page.getByRole("button", { name: "Metadaten speichern" }).click()
 
     await expect(fnaTextbox).toHaveValue("600-1")
@@ -1031,6 +1051,7 @@ test.describe("metadata editing", () => {
       "BMinG - Bundesministerium für Gesundheit",
     )
     await expect(qualMehrheit).not.toBeChecked()
+    await expect(federfuehrungDropdown).toHaveValue("AA - Auswärtiges Amt")
 
     await page.unrouteAll()
   })


### PR DESCRIPTION
While adding the get/set for "Federführung" I realized that we need the functionalities that were till now implemented only for `MetadatenDs` also accessible in `MetadatenDe`.

Therefore I decided to create an abstract class `Metadaten` that is extended by the other two, having this way the common functionalities at one place (getting/setting values of metadata) and with a generic so that we can pass the concrete enum class with the different metadata.

Also added two variables to the abstract class `startAttribute` and `endAttribute` which are initialized by the construtor/builder of the child classes so use the correct attributes naming depending on the Metadaten-Block (Ds or De).

In addition I have extended the method for setting a metadatum so that we can also automatically cope with nested nodes like `./federfuehrung/federfuehrend`, so that the parent node is first retrieved (or created) and looping to the depth till we find the last child node that should get the text content.

The constructors in MetadatenDs and MetadatenDe with the @Builder annotation (after removing the @SuperBuilder at the class level) is needed in order to not having to specify every time in the tests `startAttribute` and `endAttribute` 