### PR TITLE
More consistent metadata-related naming

### DIFF
--- a/frontend/e2e/amending-law-metadata-editor-element.spec.ts
+++ b/frontend/e2e/amending-law-metadata-editor-element.spec.ts
@@ -1,13 +1,13 @@
-import { Proprietary } from "@/types/proprietary"
+import { ElementProprietary } from "@/types/proprietary"
 import { Locator, Page, expect, test } from "@playwright/test"
 
 async function restoreInitialState(page: Page) {
   // TODO: Adjust to match actual data in the seeds. Not strictly necessary but would be better if they match
-  const dataIn1970: Proprietary = {
+  const dataIn1970: ElementProprietary = {
     artDerNorm: "SN",
   }
 
-  const dataIn2023: Proprietary = {
+  const dataIn2023: ElementProprietary = {
     artDerNorm: "ÄN",
   }
 
@@ -258,7 +258,7 @@ test.describe("metadata view", () => {
     )
   }
 
-  async function mockPutResponse(data: Proprietary) {
+  async function mockPutResponse(data: ElementProprietary) {
     await sharedPage.route(
       /\/proprietary\/hauptteil-1_abschnitt-erster_para-6\/2023-12-30/,
       async (route) => {

--- a/frontend/e2e/amending-law-metadata-editor-rahmen.spec.ts
+++ b/frontend/e2e/amending-law-metadata-editor-rahmen.spec.ts
@@ -1,8 +1,8 @@
-import { Proprietary } from "@/types/proprietary"
+import { RahmenProprietary } from "@/types/proprietary"
 import { Locator, Page, expect, test } from "@playwright/test"
 
 async function restoreInitialState(page: Page) {
-  const dataIn1970: Proprietary = {
+  const dataIn1970: RahmenProprietary = {
     fna: "210-5",
     art: "regelungstext",
     typ: "gesetz",
@@ -16,7 +16,7 @@ async function restoreInitialState(page: Page) {
     organisationsEinheit: "Einheit 1",
   }
 
-  const dataIn2023: Proprietary = {
+  const dataIn2023: RahmenProprietary = {
     fna: "310-5",
     art: "regelungstext",
     typ: "gesetz",
@@ -266,7 +266,7 @@ test.describe("metadata view", () => {
     )
   }
 
-  async function mockPutResponse(data: Proprietary) {
+  async function mockPutResponse(data: RahmenProprietary) {
     await sharedPage.route(/\/proprietary\/2023-12-30/, async (route) => {
       if (route.request().method() === "PUT") {
         const response = await route.fetch()

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -78,20 +78,18 @@ const routes: readonly RouteRecordRaw[] = [
   },
   {
     path: `/amending-laws/${createEliPathParameter()}/affected-documents/${createEliPathParameter("affectedDocument")}/edit`,
-    name: "AmendingLawAffectedDocumentEditor",
-    component: () => import("@/views/AmendingLawAffectedDocumentEditor.vue"),
+    name: "AmendingLawMetadataEditor",
+    component: () => import("@/views/AmendingLawMetadataEditor.vue"),
     children: [
       {
         path: ":timeBoundary?",
-        name: "AmendingLawAffectedDocumentRahmenEditor",
-        component: () =>
-          import("@/views/AmendingLawAffectedDocumentRahmenEditor.vue"),
+        name: "AmendingLawMetadataEditorRahmen",
+        component: () => import("@/views/AmendingLawMetadataEditorRahmen.vue"),
       },
       {
         path: ":timeBoundary/:eid",
-        name: "AmendingLawAffectedDocumentElementEditor",
-        component: () =>
-          import("@/views/AmendingLawAffectedDocumentElementEditor.vue"),
+        name: "AmendingLawMetadataEditorElement",
+        component: () => import("@/views/AmendingLawMetadataEditorElement.vue"),
       },
     ],
   },

--- a/frontend/src/services/proprietaryService.spec.ts
+++ b/frontend/src/services/proprietaryService.spec.ts
@@ -1,4 +1,4 @@
-import { Proprietary } from "@/types/proprietary"
+import { ElementProprietary, RahmenProprietary } from "@/types/proprietary"
 import { flushPromises } from "@vue/test-utils"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ref } from "vue"
@@ -11,7 +11,7 @@ describe("proprietaryService", () => {
 
   describe("useProprietaryService", () => {
     it("provides the data from the API", async () => {
-      const fixtures: Proprietary = {
+      const fixtures: RahmenProprietary = {
         fna: "foo",
       }
 
@@ -232,7 +232,7 @@ describe("proprietaryService", () => {
     })
   })
 
-  describe("useGetFrameProprietary", () => {
+  describe("useGetRahmenProprietary", () => {
     beforeEach(() => {
       vi.resetAllMocks()
       vi.resetModules()
@@ -243,9 +243,9 @@ describe("proprietaryService", () => {
         .spyOn(window, "fetch")
         .mockResolvedValue(new Response("{}"))
 
-      const { useGetFrameProprietary } = await import("./proprietaryService")
+      const { useGetRahmenProprietary } = await import("./proprietaryService")
 
-      useGetFrameProprietary("fake/eli/1", { atDate: new Date("2024-05-13") })
+      useGetRahmenProprietary("fake/eli/1", { atDate: new Date("2024-05-13") })
 
       await vi.waitFor(() =>
         expect(fetchSpy).toHaveBeenCalledWith(
@@ -264,10 +264,10 @@ describe("proprietaryService", () => {
         .spyOn(window, "fetch")
         .mockResolvedValue(new Response("{}"))
 
-      const { useGetFrameProprietary } = await import("./proprietaryService")
+      const { useGetRahmenProprietary } = await import("./proprietaryService")
 
       const eli = ref("fake/eli/1")
-      useGetFrameProprietary(eli, { atDate: new Date("2024-05-13") })
+      useGetRahmenProprietary(eli, { atDate: new Date("2024-05-13") })
 
       await vi.waitFor(() => {
         expect(fetchSpy).toHaveBeenCalledWith(
@@ -290,7 +290,7 @@ describe("proprietaryService", () => {
     })
   })
 
-  describe("usePutFrameProprietary", () => {
+  describe("usePutRahmenProprietary", () => {
     beforeEach(() => {
       vi.resetAllMocks()
       vi.resetModules()
@@ -301,10 +301,10 @@ describe("proprietaryService", () => {
         .spyOn(window, "fetch")
         .mockResolvedValue(new Response("{}"))
 
-      const { usePutFrameProprietary } = await import("./proprietaryService")
+      const { usePutRahmenProprietary } = await import("./proprietaryService")
 
-      const data = ref<Proprietary>({ fna: "4711" })
-      const { execute } = usePutFrameProprietary(data, "fake/eli/1", {
+      const data = ref<RahmenProprietary>({ fna: "4711" })
+      const { execute } = usePutRahmenProprietary(data, "fake/eli/1", {
         atDate: new Date("2024-05-13"),
       })
 
@@ -402,7 +402,7 @@ describe("proprietaryService", () => {
 
       const { usePutElementProprietary } = await import("./proprietaryService")
 
-      const data = ref<Proprietary>({ artDerNorm: "SN" })
+      const data = ref<ElementProprietary>({ artDerNorm: "SN" })
       const { execute } = usePutElementProprietary(
         data,
         "fake/eli/1",

--- a/frontend/src/services/proprietaryService.ts
+++ b/frontend/src/services/proprietaryService.ts
@@ -1,4 +1,4 @@
-import { Proprietary } from "@/types/proprietary"
+import { ElementProprietary, RahmenProprietary } from "@/types/proprietary"
 import { UseFetchOptions, UseFetchReturn } from "@vueuse/core"
 import dayjs from "dayjs"
 import { MaybeRefOrGetter, computed, toValue } from "vue"
@@ -35,7 +35,7 @@ export function useProprietaryService(
     atDate: MaybeRefOrGetter<string | Date | undefined>
   },
   fetchOptions: UseFetchOptions = {},
-): UseFetchReturn<Proprietary> {
+): UseFetchReturn<RahmenProprietary | ElementProprietary> {
   const dateAsString = computed(() => {
     const atDateVal = toValue(options?.atDate)
 
@@ -57,23 +57,23 @@ export function useProprietaryService(
     return `/norms/${eliVal}/proprietary/${eidVal ? eidVal + "/" : ""}${dateAsString.value}`
   })
 
-  return useApiFetch<Proprietary>(url, fetchOptions)
+  return useApiFetch<RahmenProprietary>(url, fetchOptions)
 }
 
 /**
  * Convenience shorthand for `useProprietaryService` that sets the correct
- * configuration for getting JSON data of the frame (i.e. whole norm).
+ * configuration for getting JSON data of the frame ("Rahmen", i.e. whole norm).
  *
  * @param eli ELI of the norm
  * @param options Optional additional filters and queries
  * @param [fetchOptions={}] Optional configuration for fetch behavior
  * @returns Reactive fetch wrapper
  */
-export function useGetFrameProprietary(
+export function useGetRahmenProprietary(
   eli: Parameters<typeof useProprietaryService>["0"],
   options: Omit<Parameters<typeof useProprietaryService>["1"], "eid">,
   fetchOptions?: Parameters<typeof useProprietaryService>["2"],
-): ReturnType<typeof useProprietaryService> {
+): UseFetchReturn<RahmenProprietary> {
   return useProprietaryService(
     eli,
     { ...options, eid: null },
@@ -83,19 +83,19 @@ export function useGetFrameProprietary(
 
 /**
  * Convenience shorthand for `useProprietaryService` that sets the correct
- * configuration for putting JSON data of the frame (i.e. whole norm).
+ * configuration for putting JSON data of the frame ("Rahmen", i.e. whole norm).
  *
  * @param eli ELI of the norm
  * @param options Optional additional filters and queries
  * @param [fetchOptions={}] Optional configuration for fetch behavior
  * @returns Reactive fetch wrapper
  */
-export function usePutFrameProprietary(
-  updateData: MaybeRefOrGetter<Proprietary | null>,
+export function usePutRahmenProprietary(
+  updateData: MaybeRefOrGetter<RahmenProprietary | null>,
   eli: Parameters<typeof useProprietaryService>["0"],
   options: Omit<Parameters<typeof useProprietaryService>["1"], "eid">,
   fetchOptions?: Parameters<typeof useProprietaryService>["2"],
-): ReturnType<typeof useProprietaryService> {
+): UseFetchReturn<RahmenProprietary> {
   return useProprietaryService(
     eli,
     { ...options, eid: null },
@@ -120,7 +120,7 @@ export function useGetElementProprietary(
   eid: Parameters<typeof useProprietaryService>["1"]["eid"],
   options: Omit<Parameters<typeof useProprietaryService>["1"], "eid">,
   fetchOptions?: Parameters<typeof useProprietaryService>["2"],
-) {
+): UseFetchReturn<ElementProprietary> {
   return useProprietaryService(
     eli,
     { ...options, eid },
@@ -139,12 +139,12 @@ export function useGetElementProprietary(
  * @returns Reactive fetch wrapper
  */
 export function usePutElementProprietary(
-  updateData: MaybeRefOrGetter<Proprietary | null>,
+  updateData: MaybeRefOrGetter<RahmenProprietary | null>,
   eli: Parameters<typeof useProprietaryService>["0"],
   eid: Parameters<typeof useProprietaryService>["1"]["eid"],
   options: Omit<Parameters<typeof useProprietaryService>["1"], "eid">,
   fetchOptions?: Parameters<typeof useProprietaryService>["2"],
-): ReturnType<typeof useProprietaryService> {
+): UseFetchReturn<ElementProprietary> {
   return useProprietaryService(
     eli,
     { ...options, eid },

--- a/frontend/src/types/proprietary.ts
+++ b/frontend/src/types/proprietary.ts
@@ -1,62 +1,56 @@
 /**
- * Encapsulates metadata that is found in the proprietary section of the
- * document. This includes both metadata that is proprietary to the LDML.de
- * standard and to DigitalService.
+ * Encapsulates metadata related to the frame ("Rahmen") that is found in
+ * the proprietary section of the document. This includes both metadata that
+ * is proprietary to the LDML.de standard and to DigitalService.
  */
-export type Proprietary = {
-  /** FNA (Fundstellennachweis A) of a norm. */
+export type RahmenProprietary = {
+  /** DE "FNA (Fundstellennachweis A)" */
   fna?: string
 
   /**
-   * Type of the norm. Defines the document type when combined with `typ` and
-   * `subtyp`.
+   * Defines the document type when combined with `typ` and `subtyp`. DE "Art"
    */
   art?: string
 
   /**
-   * Type of the document. Defines the document type when combined with `art` and
-   * `subtyp`.
+   * Defines the document type when combined with `art` and `subtyp`. DE "Typ"
    */
   typ?: string
 
   /**
-   * Subtype of the document. Defines the document type when combined with `art` and
-   * `typ`.
+   * Defines the document type when combined with `art` and `typ`. DE "Subtyp"
    */
   subtyp?: string
 
-  /**
-   * Comma-separated values. DE “Art der Norm"
-   */
+  /** Comma-separated values. DE “Art der Norm" */
   artDerNorm?: string
 
-  /**
-   * DE “Bezeichnung gemäß Vorlage"
-   */
+  /** DE “Bezeichnung gemäß Vorlage" */
   bezeichnungInVorlage?: string
 
-  /**
-   * DE “Normgeber"
-   */
+  /** DE “Normgeber" */
   normgeber?: string
 
-  /**
-   * DE “Beschließendes Organ"
-   */
+  /** DE “Beschließendes Organ" */
   beschliessendesOrgan?: string
 
-  /**
-   * DE “Beschlussfassung mit qualifizierter Mehrheit"
-   */
+  /** DE “Beschlussfassung mit qualifizierter Mehrheit" */
   qualifizierteMehrheit?: boolean
 
-  /**
-   * Federführung (authoring department) of the norm.
-   */
+  /**  DE "Federführung" */
   federfuehrung?: string
 
-  /**
-   * Organisationseinheit of the norm.
-   */
+  /** DE "Organisationseinheit" */
   organisationsEinheit?: string
+}
+
+/**
+ * Encapsulates metadata related to individual elements ("Einzelelemente")
+ * that is found in the proprietary section of the document. This includes
+ * both metadata that is proprietary to the LDML.de standard and to
+ * DigitalService.
+ */
+export type ElementProprietary = {
+  /** DE “Art der Norm" */
+  artDerNorm?: string
 }

--- a/frontend/src/views/AmendingLawMetadataEditor.vue
+++ b/frontend/src/views/AmendingLawMetadataEditor.vue
@@ -155,7 +155,7 @@ const {
           <router-link
             v-if="selectedTimeBoundary"
             :to="{
-              name: 'AmendingLawAffectedDocumentRahmenEditor',
+              name: 'AmendingLawMetadataEditorRahmen',
               params: { timeBoundary: selectedTimeBoundary },
             }"
             class="ds-label-01-reg px-16 py-8 hover:bg-blue-200 hover:underline focus:bg-blue-200 focus:underline"
@@ -193,7 +193,7 @@ const {
               v-for="element in elements"
               :key="element.eid"
               :to="{
-                name: 'AmendingLawAffectedDocumentElementEditor',
+                name: 'AmendingLawMetadataEditorElement',
                 params: {
                   eid: element.eid,
                   timeBoundary: selectedTimeBoundary,

--- a/frontend/src/views/AmendingLawMetadataEditorElement.vue
+++ b/frontend/src/views/AmendingLawMetadataEditorElement.vue
@@ -18,7 +18,7 @@ import {
   useGetElementProprietary,
   usePutElementProprietary,
 } from "@/services/proprietaryService"
-import { Proprietary } from "@/types/proprietary"
+import { ElementProprietary } from "@/types/proprietary"
 import { produce } from "immer"
 import { computed, ref, watch } from "vue"
 
@@ -37,7 +37,7 @@ const {
  * API handling                                       *
  * -------------------------------------------------- */
 
-const localData = ref<Proprietary | null>(null)
+const localData = ref<ElementProprietary | null>(null)
 
 const {
   data,

--- a/frontend/src/views/AmendingLawMetadataEditorRahmen.vue
+++ b/frontend/src/views/AmendingLawMetadataEditorRahmen.vue
@@ -29,10 +29,10 @@ import {
 } from "@/lib/proprietary"
 import { useGetNormHtml } from "@/services/normService"
 import {
-  useGetFrameProprietary,
-  usePutFrameProprietary,
+  useGetRahmenProprietary,
+  usePutRahmenProprietary,
 } from "@/services/proprietaryService"
-import { Proprietary } from "@/types/proprietary"
+import { RahmenProprietary } from "@/types/proprietary"
 import { produce } from "immer"
 import { computed, ref, watch } from "vue"
 
@@ -44,13 +44,13 @@ const { actionTeleportTarget } = useHeaderContext()
  * API handling                                       *
  * -------------------------------------------------- */
 
-const localData = ref<Proprietary | null>(null)
+const localData = ref<RahmenProprietary | null>(null)
 
 const {
   data,
   isFetching,
   error: fetchError,
-} = useGetFrameProprietary(affectedDocumentEli, {
+} = useGetRahmenProprietary(affectedDocumentEli, {
   atDate: timeBoundaryAsDate,
 })
 
@@ -64,7 +64,7 @@ const {
   isFinished: hasSaved,
   error: saveError,
   execute: save,
-} = usePutFrameProprietary(
+} = usePutRahmenProprietary(
   localData,
   affectedDocumentEli,
   { atDate: timeBoundaryAsDate },


### PR DESCRIPTION
Refactors various metadata-related code (components, types, services) to be more consistent with other locations in the frontend as well as naming in the backend.

RISDEV-4282