### PR TITLE
Disable breadcrumbs pointing to the current route

### DIFF
--- a/frontend/src/components/controls/RisHeader.vue
+++ b/frontend/src/components/controls/RisHeader.vue
@@ -104,13 +104,13 @@ provide(HeaderContextProvider, {
 
 const backbuttonTo = computed(() => {
   if (props.backDestination === "breadcrumb-back") {
-    const current = router.resolve(router.currentRoute.value)
+    const current = router.resolve(router.currentRoute.value).fullPath
 
     return allBreadcrumbs.value
       .filter((i) => Boolean(i.to))
       .findLast((i) => {
         // @ts-expect-error `to` is not undefined, trust me
-        const resolved = router.resolve(i.to)
+        const resolved = router.resolve(i.to).fullPath
         return resolved !== current
       })?.to
   } else if (props.backDestination === "history-back") {
@@ -228,12 +228,18 @@ export function useHeaderContext() {
           :key="crumb.key"
           class="ds-body-01-reg after:mx-8 after:inline-block after:text-gray-700 after:content-['/'] last-of-type:after:hidden"
         >
-          <RouterLink
-            v-if="crumb.to"
-            :to="crumb.to"
-            class="ds-link-01-bold underline"
-          >
-            {{ toValue(crumb.title) }}
+          <RouterLink v-if="crumb.to" v-slot="link" :to="crumb.to" custom>
+            <a
+              v-if="!link.isExactActive"
+              class="ds-link-01-bold underline"
+              :href="link.href"
+              @click="link.navigate()"
+            >
+              {{ toValue(crumb.title) }}
+            </a>
+            <span v-else data-testid="current-route-breadcrumb">
+              {{ toValue(crumb.title) }}
+            </span>
           </RouterLink>
           <span v-else data-testid="text-only-breadcrumb">
             {{ toValue(crumb.title) }}

--- a/frontend/src/views/AmendingLawOverview.vue
+++ b/frontend/src/views/AmendingLawOverview.vue
@@ -1,19 +1,13 @@
 <script setup lang="ts">
 import RisLawPreview from "@/components/RisLawPreview.vue"
 import RisCallout from "@/components/controls/RisCallout.vue"
-import { useHeaderContext } from "@/components/controls/RisHeader.vue"
 import RisLoadingSpinner from "@/components/controls/RisLoadingSpinner.vue"
 import { useEliPathParameter } from "@/composables/useEliPathParameter"
 import { useGetNormHtml } from "@/services/normService"
-import { onUnmounted } from "vue"
 
 const eli = useEliPathParameter()
 
 const { isFetching, error, data: amendingLawHtml } = useGetNormHtml(eli)
-
-const { pushBreadcrumb } = useHeaderContext()
-const cleanupBreadcrumbs = pushBreadcrumb({ title: "Verkündung" })
-onUnmounted(() => cleanupBreadcrumbs())
 </script>
 
 <template>


### PR DESCRIPTION
Fixes an issue where some breadcrumbs would just link to the current page again.

RISDEV-0000