### PR TITLE
404 redirect when time boundary is not found on metadata page

### DIFF
--- a/backend/src/main/resources/db/data/R__002_2023_413_2023-12-29_Nachrichtendienstrechts.sql
+++ b/backend/src/main/resources/db/data/R__002_2023_413_2023-12-29_Nachrichtendienstrechts.sql
@@ -62,6 +62,8 @@ VALUES ('ba44d2ae-0e73-44ba-850a-932ab2fa553f', 'eli/bund/bgbl-1/2023/413/2023-1
                source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
             <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
                source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+            <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="61aebfc7-fb54-406f-b12f-6c9de407ad66" date="2015-06-01"
+               source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
          </akn:lifecycle>
          <akn:analysis eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
             <akn:activeModifications eId="meta-1_analysis-1_activemod-1" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3ac">
@@ -69,9 +71,18 @@ VALUES ('ba44d2ae-0e73-44ba-850a-932ab2fa553f', 'eli/bund/bgbl-1/2023/413/2023-1
                   <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-1_source-1" GUID="8b3e1841-5d63-4400-96ae-214f6ee28db6"
                      href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1" />
                   <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-1_destination-1" GUID="94c1e417-e849-4269-8320-9f0173b39626"
-                     href="eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/hauptteil-1_abschnitt-erster_para-6_abs-3/100-126.xml" /><!-- To check-->
+                     href="eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/hauptteil-1_abschnitt-erster_para-6_abs-3/100-126.xml" />
                   <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-1_gelzeitnachw-1" GUID="6f5eabe9-1102-4d29-9d25-a44643354519"
                      period="#meta-1_geltzeiten-1_geltungszeitgr-1" />
+               </akn:textualMod>
+
+               <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-2" GUID="732433d3-d0e3-43ba-aa1a-5859d108eb46" type="substitution">
+                  <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-2_source-1" GUID="73241841-5d63-4400-96ae-214f6ee28db6"
+                     href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1" />
+                  <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-2_destination-1" GUID="7324e417-e849-4269-8320-9f0173b39626"
+                     href="eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/hauptteil-1_abschnitt-erster_para-2_abs-1/146-194.xml" />
+                  <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-2_gelzeitnachw-1" GUID="7324abe9-1102-4d29-9d25-a44643354519"
+                     period="#meta-1_geltzeiten-1_geltungszeitgr-2" />
                </akn:textualMod>
             </akn:activeModifications>
          </akn:analysis>
@@ -79,6 +90,10 @@ VALUES ('ba44d2ae-0e73-44ba-850a-932ab2fa553f', 'eli/bund/bgbl-1/2023/413/2023-1
             <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
                <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179"
                   refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+            </akn:temporalGroup>
+            <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="05dc897e-cf1c-41d5-a1c7-ea3537990b3a">
+               <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="d73d783a-ee09-404e-9153-4c19e0527702"
+                  refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3"/>
             </akn:temporalGroup>
          </akn:temporalData>
          <!-- Diese Metadaten sind die Konstituenten für die Schematron-Validierung. -->
@@ -147,6 +162,7 @@ VALUES ('ba44d2ae-0e73-44ba-850a-932ab2fa553f', 'eli/bund/bgbl-1/2023/413/2023-1
                            Artikel 1 des Gesetzes vom 19. Dezember 2022 (BGBl. I S. 2632) geändert worden ist</akn:affectedDocument>, wird wie folgt
                         geändert:</akn:p>
                   </akn:intro>
+
                   <!-- Nummer 1 -->
                   <akn:point eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-1" GUID="49983c1a-c952-4ab1-b926-2f414c05da7d">
                      <akn:num eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_bezeichnung-1" GUID="634ddcaa-4851-4656-8b65-f26c8f56d1f1">
@@ -165,6 +181,29 @@ VALUES ('ba44d2ae-0e73-44ba-850a-932ab2fa553f', 'eli/bund/bgbl-1/2023/413/2023-1
                                  GUID="694459c4-ef66-4f87-bb78-a332054a2216" startQuote="„" endQuote="“">am Ende des Kalenderjahres, das dem Jahr der Protokollierung folgt,</akn:quotedText> durch die Wörter <akn:quotedText
                                  eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quottext-2"
                                  GUID="dd25bdb6-4ef4-4ef5-808c-27579b6ae196" startQuote="„" endQuote="“">nach Ablauf von fünf Jahren</akn:quotedText>
+                              ersetzt.</akn:mod>
+                        </akn:p>
+                     </akn:content>
+                  </akn:point>
+
+                  <!-- Nummer 2 -->
+                  <akn:point eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2" GUID="36243c1a-c952-4ab1-b926-2f414c05da7d">
+                     <akn:num eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_bezeichnung-1" GUID="3624dcaa-4851-4656-8b65-f26c8f56d1f1">
+                        <akn:marker eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_bezeichnung-1_zaehlbez-1"
+                           GUID="36245080-1644-4b0f-83f3-2c0b4378f7af" name="1" />2.</akn:num>
+                     <akn:content eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1" GUID="362473be-9df6-47fa-b1ea-1cf6273d82e6">
+                        <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1" GUID="3624ef20-52d5-4baa-9e1a-b2c63cd21ccc">
+                           <akn:mod eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"
+                              GUID="36242f06-6e33-4af8-9f4a-3da67c888510" refersTo="aenderungsbefehl-ersetzen">In <akn:ref
+                                 eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1"
+                                 GUID="3624036a-d7d9-4fa5-b181-c3345caa3206"
+                                 href="eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/hauptteil-1_abschnitt-erster_para-2_abs-1_inhalt-1_text-1/146-194.xml">§
+                              2 Absatz 1 Satz 2</akn:ref>
+                                 werden die Wörter <akn:quotedText
+                                 eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-1"
+                                 GUID="362459c4-ef66-4f87-bb78-a332054a2216" startQuote="„" endQuote="“">Bundesministerium des Innern, für Bau und Heimat</akn:quotedText> durch die Wörter <akn:quotedText
+                                 eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2"
+                                 GUID="3624bdb6-4ef4-4ef5-808c-27579b6ae196" startQuote="„" endQuote="“">Bundesministerium des Innern und für Heimat</akn:quotedText>
                               ersetzt.</akn:mod>
                         </akn:p>
                      </akn:content>
@@ -4488,10 +4527,10 @@ VALUES ('b0f315a1-620b-4eaf-922c-ea46a7d10c8b', 'eli/bund/bgbl-1/1990/s2954/2023
                 </akn:FRBRManifestation>
             </akn:identification>
             <akn:lifecycle source="attributsemantik-noch-undefiniert" GUID="8c8fccc7-8f59-45af-8550-b5725ffd0c82" eId="meta-1_lebzykl-1">
-                <akn:eventRef date="1970-01-01" source="attributsemantik-noch-undefiniert" refersTo="ausfertigung" type="generation"
-                    eId="meta-1_lebzykl-1_ereignis-1" GUID="9c2e7385-3a0f-44c0-aa2d-5db2bf265cf9" />
+                <akn:eventRef date="1970-01-01" source="attributsemantik-noch-undefiniert" refersTo="ausfertigung" type="generation" eId="meta-1_lebzykl-1_ereignis-1" GUID="9c2e7385-3a0f-44c0-aa2d-5db2bf265cf9" />
                 <akn:eventRef date="2023-12-29" source="attributsemantik-noch-undefiniert" refersTo="ausfertigung" type="amendment" eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" />
                 <akn:eventRef date="2023-12-30" source="attributsemantik-noch-undefiniert" refersTo="inkrafttreten" type="amendment" eId="meta-1_lebzykl-1_ereignis-3" GUID="02cf36b3-0ec9-4168-aa06-5c1e88ada720" />
+                <akn:eventRef date="2015-06-01" source="attributsemantik-noch-undefiniert" refersTo="inkrafttreten" type="generation" eId="meta-1_lebzykl-1_ereignis-4" GUID="61aebfc7-fb54-406f-b12f-6c9de407ad66" />
             </akn:lifecycle>
             <akn:analysis eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
                 <akn:passiveModifications eId="meta-1_analysis-1_pasmod-1" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3ac">
@@ -4508,6 +4547,20 @@ VALUES ('b0f315a1-620b-4eaf-922c-ea46a7d10c8b', 'eli/bund/bgbl-1/1990/s2954/2023
                                    GUID="6f5eabe9-1102-4d29-9d25-a44643354519"
                                    period="#meta-1_geltzeiten-1_geltungszeitgr-2"/>
                     </akn:textualMod>
+
+                    <akn:textualMod eId="meta-1_analysis-1_pasmod-2_textualmod-1"
+                                    GUID="372433d3-d0e3-43ba-aa1a-5859d108eb46"
+                                    type="substitution">
+                        <akn:source eId="meta-1_analysis-1_pasmod-2_textualmod-1_source-1"
+                                    GUID="37241841-5d63-4400-96ae-214f6ee28db6"
+                                    href="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"/>
+                        <akn:destination eId="meta-1_analysis-1_pasmod-2_textualmod-1_destination-1"
+                                         GUID="3724e417-e849-4269-8320-9f0173b39626"
+                                         href="#hauptteil-1_abschnitt-erster_para-2_abs-1"/>
+                        <akn:force eId="meta-1_analysis-1_pasmod-2_textualmod-1_gelzeitnachw-1"
+                                   GUID="3724abe9-1102-4d29-9d25-a44643354519"
+                                   period="#meta-1_geltzeiten-1_geltungszeitgr-3"/>
+                    </akn:textualMod>
                 </akn:passiveModifications>
             </akn:analysis>
             <akn:temporalData source="attributsemantik-noch-undefiniert" GUID="9a82ff0d-bf6d-4631-a9f6-2bf2344ba315" eId="meta-1_geltzeiten-1">
@@ -4517,7 +4570,10 @@ VALUES ('b0f315a1-620b-4eaf-922c-ea46a7d10c8b', 'eli/bund/bgbl-1/1990/s2954/2023
                 </akn:temporalGroup>
                 <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
                     <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
-            </akn:temporalGroup>
+                </akn:temporalGroup>
+                <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-3" GUID="7624897e-cf1c-41d5-a1c7-ea3537990b3a">
+                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1" GUID="d73d783a-ee09-404e-9153-4c19e0527702" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4"/>
+                </akn:temporalGroup>
             </akn:temporalData>
             <akn:proprietary eId="meta-1_proprietary-1" GUID="33fc7615-4c37-4101-9184-a14185ee3ec2" source="attributsemantik-noch-undefiniert">
                 <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
@@ -4532,20 +4588,21 @@ VALUES ('b0f315a1-620b-4eaf-922c-ea46a7d10c8b', 'eli/bund/bgbl-1/1990/s2954/2023
                    <meta:gesta>nicht-vorhanden</meta:gesta>
                    <!-- Die vorliegenden Angaben von meta:federfuehrung besitzen keine fachliche Korrektheit. -->
                    <meta:federfuehrung>
-                      <meta:federfuehrend ab="1970-01-01" bis="2023-12-28">BMVg - Bundesministerium der Verteidigung</meta:federfuehrend>
+                      <meta:federfuehrend ab="1970-01-01" bis="2015-06-28">BMVg - Bundesministerium der Verteidigung</meta:federfuehrend>
                       <meta:federfuehrend ab="2023-12-29" bis="unbestimmt">BMI - Bundesministerium des Innern und für Heimat</meta:federfuehrend>
                    </meta:federfuehrung>
                 </meta:legalDocML.de_metadaten>
+
                 <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                    <!-- 1970 -->
-                    <meta:art start="1970-01-01" end="2023-12-29">regelungstext</meta:art>
-                    <meta:typ start="1970-01-01" end="2023-12-29">gesetz</meta:typ>
-                    <meta:subtyp start="1970-01-01" end="2023-12-29">Rechtsverordnung</meta:subtyp>
-                    <meta:artDerNorm start="1970-01-01" end="2023-12-29">SN,ÜN</meta:artDerNorm>
-                    <meta:bezeichnungInVorlage start="1970-01-01" end="2023-12-29">Testbezeichnung nach meiner Vorlage</meta:bezeichnungInVorlage>
-                    <meta:normgeber start="1970-01-01" end="2023-12-29">BEO - Berlin (Ost)</meta:normgeber>
-                    <meta:beschliessendesOrgan start="1970-01-01" end="2023-12-29" qualifizierteMehrheit="true">BMinJ - Bundesministerium der Justiz</meta:beschliessendesOrgan>
-                    <meta:organisationsEinheit start="1970-01-01" end="2023-12-29">Einheit 1</meta:organisationsEinheit>
+                    <!-- 2015 -->
+                    <meta:art start="2015-06-01" end="2023-12-29">regelungstext</meta:art>
+                    <meta:typ start="2015-06-01" end="2023-12-29">gesetz</meta:typ>
+                    <meta:subtyp start="2015-06-01" end="2023-12-29">Rechtsverordnung</meta:subtyp>
+                    <meta:artDerNorm start="2015-06-01" end="2023-12-29">SN,ÜN</meta:artDerNorm>
+                    <meta:bezeichnungInVorlage start="2015-06-01" end="2023-12-29">Testbezeichnung nach meiner Vorlage</meta:bezeichnungInVorlage>
+                    <meta:normgeber start="2015-06-01" end="2023-12-29">BEO - Berlin (Ost)</meta:normgeber>
+                    <meta:beschliessendesOrgan start="2015-06-01" end="2023-12-29" qualifizierteMehrheit="true">BMinJ - Bundesministerium der Justiz</meta:beschliessendesOrgan>
+                    <meta:organisationsEinheit start="2015-06-01" end="2023-12-29">Einheit 1</meta:organisationsEinheit>
 
                     <!-- 2023 -->
                     <meta:fna start="2023-12-30" end="unbestimmt">310-5</meta:fna>

--- a/backend/src/main/resources/db/data/R__007_1001_11_1001-01-01_Mods.sql
+++ b/backend/src/main/resources/db/data/R__007_1001_11_1001-01-01_Mods.sql
@@ -53,47 +53,47 @@ VALUES ('e7abd358-32cb-4fc2-8a1a-b033961f3708', 'eli/bund/bgbl-1/1001/2/1001-02-
           </akn:textualMod>
           <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-2" GUID="fbf0225d-37c3-4603-b851-627ba9f90f30" type="substitution">
             <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-2_source-1" GUID="828bede0-5d47-4f38-812a-5d37bdd92d82" href="#hauptteil-1_para-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"></akn:source>
-            <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-2_destination-1" GUID="66594ba2-0d9a-4680-b1a2-48a134ba013e" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1/hauptteil-1_para-1_abs-1_inhalt-1_text-1/29-36.xml"></akn:destination>
+            <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-2_destination-1" GUID="66594ba2-0d9a-4680-b1a2-48a134ba013e" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1/hauptteil-1_para-1_abs-2_inhalt-1_text-1/29-36.xml"></akn:destination>
             <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-2_gelzeitnachw-1" GUID="6c653919-35ad-47fc-ae34-ce2b175ea298" period="#meta-1_geltzeiten-1_geltungszeitgr-1"></akn:force>
           </akn:textualMod>
           <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-3" GUID="02165fe9-81f8-4306-a9f5-777a46c0c351" type="substitution">
             <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-3_source-1" GUID="89b038cc-f255-4cc5-8f22-0bb0a0e5b998" href="#hauptteil-1_para-1_abs-1_untergl-1_listenelem-3_inhalt-1_text-1_ändbefehl-1"></akn:source>
-            <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-3_destination-1" GUID="98b8c5de-9cfa-4cf6-a3ee-96b6d15331b9" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1/hauptteil-1_para-1_abs-1_inhalt-1_text-1/29-36.xml"></akn:destination>
+            <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-3_destination-1" GUID="98b8c5de-9cfa-4cf6-a3ee-96b6d15331b9" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1/hauptteil-1_para-1_abs-3_inhalt-1_text-1/29-36.xml"></akn:destination>
             <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-3_gelzeitnachw-1" GUID="70fdf551-ceb7-4678-be64-3e3a66d89a18" period="#meta-1_geltzeiten-1_geltungszeitgr-1"></akn:force>
           </akn:textualMod>
           <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-4" GUID="b971343a-e55e-4022-8a5e-843c028598ad" type="substitution">
             <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-4_source-1" GUID="c68e47d1-ef47-4cf8-86f0-2307d4463b82" href="#hauptteil-1_para-1_abs-1_untergl-1_listenelem-4_inhalt-1_text-1_ändbefehl-1"></akn:source>
-            <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-4_destination-1" GUID="338edcbf-f159-46b3-a2d6-f030e56db0dc" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1/hauptteil-1_para-1_abs-1_inhalt-1_text-1/29-36.xml"></akn:destination>
+            <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-4_destination-1" GUID="338edcbf-f159-46b3-a2d6-f030e56db0dc" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1/hauptteil-1_para-1_abs-4_inhalt-1_text-1/29-36.xml"></akn:destination>
             <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-4_gelzeitnachw-1" GUID="1450ed7e-7582-45e1-b87d-415996a6708a" period="#meta-1_geltzeiten-1_geltungszeitgr-1"></akn:force>
           </akn:textualMod>
           <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-5" GUID="f4f28141-ef8c-4f03-a00f-c42f270a7d65" type="substitution">
             <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-5_source-1" GUID="b8a91795-278e-45c9-bfd9-05c2bc601dce" href="#hauptteil-1_para-1_abs-1_untergl-1_listenelem-5_inhalt-1_text-1_ändbefehl-1"></akn:source>
-            <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-5_destination-1" GUID="15d145bc-6276-4ff6-8038-1720d2057856" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1/hauptteil-1_para-1_abs-1_inhalt-1_text-1/29-36.xml"></akn:destination>
+            <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-5_destination-1" GUID="15d145bc-6276-4ff6-8038-1720d2057856" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1/hauptteil-1_para-1_abs-5_inhalt-1_text-1/29-36.xml"></akn:destination>
             <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-5_gelzeitnachw-1" GUID="481379f7-57f8-4fbc-9e40-e682bb3b3620" period="#meta-1_geltzeiten-1_geltungszeitgr-1"></akn:force>
           </akn:textualMod>
           <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-6" GUID="7dedbf83-0a23-4d6e-9775-7490dd17030a" type="substitution">
             <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-6_source-1" GUID="37f758a4-edf7-482e-a60b-42ca741a646a" href="#hauptteil-1_para-1_abs-1_untergl-1_listenelem-6_inhalt-1_text-1_ändbefehl-1"></akn:source>
-            <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-6_destination-1" GUID="61b33a97-5a4a-42bd-8327-2544ab4f2eb5" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1/hauptteil-1_para-1_abs-1_inhalt-1_text-1/29-36.xml"></akn:destination>
+            <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-6_destination-1" GUID="61b33a97-5a4a-42bd-8327-2544ab4f2eb5" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1/hauptteil-1_para-1_abs-6_inhalt-1_text-1/29-36.xml"></akn:destination>
             <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-6_gelzeitnachw-1" GUID="afeb1c64-cb4b-4ff4-923c-f84bfd9c61b3" period="#meta-1_geltzeiten-1_geltungszeitgr-1"></akn:force>
           </akn:textualMod>
           <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-7" GUID="26c21156-f877-40bc-88b2-22c92819e694" type="substitution">
             <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-7_source-1" GUID="20b75521-c023-4769-b759-f04e9eca4b8b" href="#hauptteil-1_para-1_abs-1_untergl-1_listenelem-7_inhalt-1_text-1_ändbefehl-1"></akn:source>
-            <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-7_destination-1" GUID="d176c546-27c7-4ee8-a244-67b4b11bc624" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1/hauptteil-1_para-1_abs-1_inhalt-1_text-1/29-36.xml"></akn:destination>
+            <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-7_destination-1" GUID="d176c546-27c7-4ee8-a244-67b4b11bc624" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1/hauptteil-1_para-1_abs-7_inhalt-1_text-1/29-36.xml"></akn:destination>
             <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-7_gelzeitnachw-1" GUID="f36eec63-c115-477f-b47c-2ccd38311596" period="#meta-1_geltzeiten-1_geltungszeitgr-1"></akn:force>
           </akn:textualMod>
           <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-8" GUID="41e5b919-8db8-4a3b-8521-baf0882ec430" type="substitution">
             <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-8_source-1" GUID="f659a5a6-97fb-4855-8a72-34da38c8942a" href="#hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1"></akn:source>
-            <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-8_destination-1" GUID="0447cf32-ab6c-42ac-b30d-47f9f79555c3" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1/hauptteil-1_para-1_abs-1_inhalt-1_text-1/29-36.xml"></akn:destination>
+            <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-8_destination-1" GUID="0447cf32-ab6c-42ac-b30d-47f9f79555c3" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1/hauptteil-1_para-1_abs-8_inhalt-1_text-1/29-36.xml"></akn:destination>
             <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-8_gelzeitnachw-1" GUID="cb945cd1-1521-4a37-80d7-ef5e3ac91669" period="#meta-1_geltzeiten-1_geltungszeitgr-1"></akn:force>
           </akn:textualMod>
           <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-9" GUID="cb8aae73-3bcf-4abc-99c4-cd19b587b439" type="substitution">
             <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-9_source-1" GUID="dbbbefb3-c857-4024-a03a-264515105be1" href="#hauptteil-1_para-1_abs-1_untergl-1_listenelem-9_inhalt-1_text-1_ändbefehl-1"></akn:source>
-            <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-9_destination-1" GUID="d934e0e5-6ec7-4c84-a911-2923b4a73339" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1/hauptteil-1_para-1_abs-1_inhalt-1_text-1/29-36.xml"></akn:destination>
+            <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-9_destination-1" GUID="d934e0e5-6ec7-4c84-a911-2923b4a73339" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1/hauptteil-1_para-1_abs-9_inhalt-1_text-1/29-36.xml"></akn:destination>
             <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-9_gelzeitnachw-1" GUID="7c76d439-ea69-48aa-b927-a56a8995608b" period="#meta-1_geltzeiten-1_geltungszeitgr-1"></akn:force>
           </akn:textualMod>
           <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-10" GUID="2b00350d-6b68-4a4a-9761-edbe89c0a15f" type="substitution">
             <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-10_source-1" GUID="fbfdf6c4-ee9c-41cc-9cc4-a3a11bd18d3c" href="#hauptteil-1_para-1_abs-1_untergl-1_listenelem-10_inhalt-1_text-1_ändbefehl-1"></akn:source>
-            <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-10_destination-1" GUID="9af11846-3f34-4adb-8e94-d542cd31a735" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1/hauptteil-1_para-1_abs-1_inhalt-1_text-1/29-37.xml"></akn:destination>
+            <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-10_destination-1" GUID="9af11846-3f34-4adb-8e94-d542cd31a735" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1/hauptteil-1_para-1_abs-10_inhalt-1_text-1/29-37.xml"></akn:destination>
             <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-10_gelzeitnachw-1" GUID="cd00feef-9296-4698-9421-f4d2d3ba0d42" period="#meta-1_geltzeiten-1_geltungszeitgr-1"></akn:force>
           </akn:textualMod>
         </akn:activeModifications>

--- a/frontend/e2e/amending-law-metadata-editor-element.spec.ts
+++ b/frontend/e2e/amending-law-metadata-editor-element.spec.ts
@@ -2,7 +2,7 @@ import { ElementProprietary } from "@/types/proprietary"
 import { Locator, Page, expect, test } from "@playwright/test"
 
 async function restoreInitialState(page: Page) {
-  const dataIn1970: ElementProprietary = {
+  const dataIn2015: ElementProprietary = {
     artDerNorm: "SN",
   }
 
@@ -11,8 +11,8 @@ async function restoreInitialState(page: Page) {
   }
 
   await page.request.put(
-    "/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/proprietary/hauptteil-1_abschnitt-erster_para-6/1970-01-01",
-    { data: dataIn1970 },
+    "/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/proprietary/hauptteil-1_abschnitt-erster_para-6/2015-06-01",
+    { data: dataIn2015 },
   )
 
   await page.request.put(
@@ -34,7 +34,7 @@ test.describe("navigate to page", () => {
     )
 
     await page.goto(
-      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/1970-01-01/hauptteil-1_abschnitt-erster_para-6",
+      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/2015-06-01/hauptteil-1_abschnitt-erster_para-6",
     )
 
     // Then
@@ -74,17 +74,23 @@ test.describe("navigate to page", () => {
   test("navigates between elements", async ({ page }) => {
     // Given
     await page.goto(
-      "/amending-laws/eli/bund/bgbl-1/2024/108/2024-03-27/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/2009/s3366/2024-03-27/1/deu/regelungstext-1/edit/1934-10-16/hauptteil-1_para-2",
+      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/2015-06-01/hauptteil-1_abschnitt-erster_para-2",
     )
 
     const heading = page.getByRole("heading", { level: 2 })
-    await expect(heading).toHaveText("§1")
+    await expect(heading).toHaveText("§ 2 Verfassungsschutzbehörden")
 
     // When
-    await page.getByRole("link", { name: "§3a" }).click()
+    await page
+      .getByRole("link", {
+        name: "§ 6 Gegenseitige Unterrichtung der Verfassungsschutzbehörden",
+      })
+      .click()
 
     // Then
-    await expect(heading).toHaveText("§3a")
+    await expect(heading).toHaveText(
+      "§ 6 Gegenseitige Unterrichtung der Verfassungsschutzbehörden",
+    )
   })
 })
 
@@ -116,7 +122,7 @@ test.describe("preview", () => {
   test("shows the preview at different time boundaries", async ({ page }) => {
     // Given
     await page.goto(
-      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/1970-01-01/hauptteil-1_abschnitt-erster_para-6",
+      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/2015-06-01/hauptteil-1_abschnitt-erster_para-6",
     )
 
     const preview = page.getByRole("region", { name: "Vorschau" })
@@ -146,7 +152,7 @@ test.describe("preview", () => {
     )
 
     await page.goto(
-      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/1970-01-01/hauptteil-1_abschnitt-erster_para-6",
+      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/2015-06-01/hauptteil-1_abschnitt-erster_para-6",
     )
 
     const previewRegion = page.getByRole("region", { name: "Vorschau" })
@@ -165,7 +171,7 @@ test.describe("XML view", () => {
   test("displays the XML of the target law with metadata", async ({ page }) => {
     // Given
     await page.goto(
-      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/1970-01-01/hauptteil-1_abschnitt-erster_para-6",
+      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/2015-06-01/hauptteil-1_abschnitt-erster_para-6",
     )
 
     await page.getByRole("tab", { name: "XML" }).click()
@@ -185,7 +191,7 @@ test.describe("XML view", () => {
     await restoreInitialState(page)
 
     await page.goto(
-      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/1970-01-01/hauptteil-1_abschnitt-erster_para-6",
+      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/2015-06-01/hauptteil-1_abschnitt-erster_para-6",
     )
 
     // When
@@ -224,7 +230,7 @@ test.describe("XML view", () => {
     )
 
     await page.goto(
-      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/1970-01-01/hauptteil-1_abschnitt-erster_para-6",
+      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/2015-06-01/hauptteil-1_abschnitt-erster_para-6",
     )
 
     // When
@@ -301,7 +307,7 @@ test.describe("metadata view", () => {
 
     test("displays at different time boundaries", async () => {
       // When
-      await gotoTimeBoundary("1970-01-01")
+      await gotoTimeBoundary("2015-06-01")
 
       // Then
       await expect(artSnRadio).toBeChecked()

--- a/frontend/e2e/amending-law-metadata-editor-element.spec.ts
+++ b/frontend/e2e/amending-law-metadata-editor-element.spec.ts
@@ -199,7 +199,6 @@ test.describe("XML view", () => {
 
     await page.getByRole("button", { name: "Speichern" }).click()
 
-    // Then
     // Check the content of the XML reload call as we currently don't have a
     // good way of checking the actual editor content. This is because
     // CodeMirror uses lazy scrolling and therefore depending on the size of the
@@ -211,8 +210,8 @@ test.describe("XML view", () => {
       )
       .then((response) => response.text())
 
-    // TODO: Verify the changes are included, remove the following assertion
-    expect(textResponse).toBeTruthy()
+    // Then
+    expect(textResponse).toContain("ÜN</meta:artDerNorm")
 
     // Cleanup
     await restoreInitialState(page)

--- a/frontend/e2e/amending-law-metadata-editor-rahmen.spec.ts
+++ b/frontend/e2e/amending-law-metadata-editor-rahmen.spec.ts
@@ -2,7 +2,7 @@ import { RahmenProprietary } from "@/types/proprietary"
 import { Locator, Page, expect, test } from "@playwright/test"
 
 async function restoreInitialState(page: Page) {
-  const dataIn1970: RahmenProprietary = {
+  const dataIn2015: RahmenProprietary = {
     fna: "210-5",
     art: "regelungstext",
     typ: "gesetz",
@@ -31,8 +31,8 @@ async function restoreInitialState(page: Page) {
   }
 
   await page.request.put(
-    "/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/proprietary/1970-01-01",
-    { data: dataIn1970 },
+    "/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/proprietary/2015-06-01",
+    { data: dataIn2015 },
   )
 
   await page.request.put(
@@ -116,7 +116,7 @@ test.describe("preview", () => {
   test("shows the preview at different time boundaries", async ({ page }) => {
     // Given
     await page.goto(
-      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/1970-01-01",
+      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/2015-06-01",
     )
 
     const preview = page.getByRole("region", { name: "Vorschau" })
@@ -168,7 +168,7 @@ test.describe("XML view", () => {
   test("displays the XML of the target law", async ({ page }) => {
     // Given
     await page.goto(
-      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/1970-01-01",
+      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/2015-06-01",
     )
 
     // When
@@ -189,7 +189,7 @@ test.describe("XML view", () => {
     await restoreInitialState(page)
 
     await page.goto(
-      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/1970-01-01",
+      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/2015-06-01",
     )
 
     const editorRegion = page.getByRole("region", {
@@ -236,7 +236,7 @@ test.describe("XML view", () => {
     )
 
     await page.goto(
-      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/1970-01-01",
+      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/2015-06-01",
     )
 
     // When
@@ -299,7 +299,7 @@ test.describe("metadata view", () => {
 
     test("displays at different time boundaries", async () => {
       // When
-      await gotoTimeBoundary("1970-01-01")
+      await gotoTimeBoundary("2015-06-01")
 
       // Then
       await expect(fnaInput).toHaveValue("210-5")
@@ -348,7 +348,7 @@ test.describe("metadata view", () => {
 
     test("displays at different time boundaries", async () => {
       // When
-      await gotoTimeBoundary("1970-01-01")
+      await gotoTimeBoundary("2015-06-01")
 
       // Then
       await expect(documentTypeDropdown).toHaveValue("Rechtsverordnung")
@@ -463,7 +463,7 @@ test.describe("metadata view", () => {
 
     test("displays at different time boundaries", async () => {
       // When
-      await gotoTimeBoundary("1970-01-01")
+      await gotoTimeBoundary("2015-06-01")
 
       // Then
       await expect(artSnCheckbox).toBeChecked()
@@ -524,7 +524,7 @@ test.describe("metadata view", () => {
 
     test("displays at different time boundaries", async () => {
       // When
-      await gotoTimeBoundary("1970-01-01")
+      await gotoTimeBoundary("2015-06-01")
 
       // Then
       await expect(bezeichnungInput).toHaveValue(
@@ -577,7 +577,7 @@ test.describe("metadata view", () => {
 
     test("displays at different time boundaries", async () => {
       // When
-      await gotoTimeBoundary("1970-01-01")
+      await gotoTimeBoundary("2015-06-01")
 
       // Then
       await expect(normgeberDropdown).toHaveValue("BEO - Berlin (Ost)")
@@ -626,7 +626,7 @@ test.describe("metadata view", () => {
 
     test("displays at different time boundaries", async () => {
       // When
-      await gotoTimeBoundary("1970-01-01")
+      await gotoTimeBoundary("2015-06-01")
 
       // Then
       await expect(organDropdown).toHaveValue(
@@ -679,7 +679,7 @@ test.describe("metadata view", () => {
 
     test("displays at different time boundaries", async () => {
       // When
-      await gotoTimeBoundary("1970-01-01")
+      await gotoTimeBoundary("2015-06-01")
 
       // Then
       await expect(qualMehrheitCheckbox).toBeChecked()
@@ -728,7 +728,7 @@ test.describe("metadata view", () => {
 
     test("displays at different time boundaries", async () => {
       // When
-      await gotoTimeBoundary("1970-01-01")
+      await gotoTimeBoundary("2015-06-01")
 
       // Then
       await expect(federfuehrungDropdown).toHaveValue(
@@ -787,7 +787,7 @@ test.describe("metadata view", () => {
 
     test("displays at different time boundaries", async () => {
       // When
-      await gotoTimeBoundary("1970-01-01")
+      await gotoTimeBoundary("2015-06-01")
 
       // Then
       await expect(organisationsEinheitInput).toHaveValue("Einheit 1")

--- a/frontend/e2e/amending-law-metadata-editor.spec.ts
+++ b/frontend/e2e/amending-law-metadata-editor.spec.ts
@@ -23,7 +23,7 @@ test.describe("navigate to page", () => {
     })
 
     await page.goto(
-      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/1970-01-01",
+      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/2023-12-29",
     )
 
     await expect(
@@ -51,7 +51,7 @@ test.describe("navigate to page", () => {
     })
 
     await page.goto(
-      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/1970-01-01",
+      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/2023-12-29",
     )
 
     await expect(page.getByText("404")).toBeVisible()
@@ -63,7 +63,7 @@ test.describe("navigate to page", () => {
 test.describe("sidebar navigation", () => {
   test("shows the elements affected by this amending law", async ({ page }) => {
     await page.goto(
-      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/1970-01-01",
+      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/2015-06-01",
     )
 
     const nav = page.getByRole("complementary", { name: "Inhaltsverzeichnis" })
@@ -72,6 +72,7 @@ test.describe("sidebar navigation", () => {
     await expect(links).toHaveText(
       [
         "Rahmen",
+        "§ 2 Verfassungsschutzbehörden",
         "§ 6 Gegenseitige Unterrichtung der Verfassungsschutzbehörden",
       ],
       { useInnerText: true },
@@ -92,6 +93,7 @@ test.describe("sidebar navigation", () => {
     await expect(links).toHaveText(
       [
         "Rahmen",
+        "§ 2 Verfassungsschutzbehörden",
         "§ 6 Gegenseitige Unterrichtung der Verfassungsschutzbehörden",
       ],
       { useInnerText: true },
@@ -112,7 +114,7 @@ test.describe("sidebar navigation", () => {
     await expect(select).toHaveValue("2023-12-30")
 
     // Time boundaries available as options
-    await expect(options).toHaveText(["30.12.2023"], {
+    await expect(options).toHaveText(["01.06.2015", "30.12.2023"], {
       useInnerText: true,
     })
   })
@@ -138,7 +140,7 @@ test.describe("sidebar navigation", () => {
     )
 
     await page.goto(
-      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/1970-01-01",
+      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/2023-12-30",
     )
 
     await expect(
@@ -157,31 +159,11 @@ test.describe("sidebar navigation", () => {
     )
 
     await page.goto(
-      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/1970-01-01",
+      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/2023-12-30",
     )
 
     await expect(page.getByText("Keine Artikel gefunden.")).toBeVisible()
 
     await page.unrouteAll()
-  })
-
-  test("does not render links when no time boundary is selected", async ({
-    page,
-  }) => {
-    page.route(/timeBoundaries/, async (route) => {
-      await route.fulfill({ json: [], status: 200 })
-    })
-
-    await page.goto(
-      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit",
-    )
-
-    await expect(page.getByText("Keine Zeitgrenze ausgewählt.")).toBeVisible()
-
-    await expect(
-      page
-        .getByRole("complementary", { name: "Inhaltsverzeichnis" })
-        .getByRole("link"),
-    ).toHaveCount(0)
   })
 })

--- a/frontend/e2e/amending-law-metadata-editor.spec.ts
+++ b/frontend/e2e/amending-law-metadata-editor.spec.ts
@@ -32,6 +32,32 @@ test.describe("navigate to page", () => {
 
     await page.unrouteAll()
   })
+
+  test("shows the not found page when attempting to open a date without time boundary", async ({
+    page,
+  }) => {
+    await page.goto(
+      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/1900-01-01",
+    )
+
+    await expect(page.getByText("404")).toBeVisible()
+  })
+
+  test("shows the not found page when timeboundaries are empty", async ({
+    page,
+  }) => {
+    await page.route(/timeBoundaries/, async (route) => {
+      await route.fulfill({ status: 200, json: [] })
+    })
+
+    await page.goto(
+      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/affected-documents/eli/bund/bgbl-1/1990/s2954/2023-12-29/1/deu/regelungstext-1/edit/1970-01-01",
+    )
+
+    await expect(page.getByText("404")).toBeVisible()
+
+    await page.unrouteAll()
+  })
 })
 
 test.describe("sidebar navigation", () => {


### PR DESCRIPTION
Currently the metadata page can be opened with any valid date. This should be changed such that the page ensures that the date is also a valid time boundary, and redirects to the 404 page if it isn't.

Depends on #450 