### PR TITLE
fix: Handle empty XML data to prevent parsing errors in Firefox

### DIFF
--- a/frontend/src/views/AmendingLawArticleEditor.vue
+++ b/frontend/src/views/AmendingLawArticleEditor.vue
@@ -51,6 +51,7 @@ const {
 const currentXml = ref("")
 const articleXml = computed(() => {
   if (!eid.value) return undefined
+  if (!currentXml.value) return undefined
 
   const xmlDocument = xmlStringToDocument(currentXml.value)
   const articleNode = getNodeByEid(xmlDocument, eid.value)


### PR DESCRIPTION
RISDEV-0000