### PR TITLE
Activate backend sentry only on staging

### DIFF
--- a/.github/workflows/backend-jobs.yml
+++ b/.github/workflows/backend-jobs.yml
@@ -61,8 +61,6 @@ jobs:
           distribution: "temurin"
           cache: gradle
       - name: Run unit tests
-        env:
-          SPRING_PROFILES_ACTIVE: testing
         working-directory: ./backend
         run: ./gradlew clean test -x integrationTest
       - name: Send status to Slack
@@ -83,8 +81,6 @@ jobs:
           distribution: "temurin"
           cache: gradle
       - name: Run integration tests
-        env:
-          SPRING_PROFILES_ACTIVE: testing
         working-directory: ./backend
         run: ./gradlew clean integrationTest -x test
       - name: Send status to Slack

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -207,18 +207,19 @@ tasks.named("checkstyleTest").configure {
     enabled = false
 }
 
-sentry {
+if (System.getProperty("spring.profiles.active") == "staging") {
+    sentry {
+        // Generates a JVM (Java, Kotlin, etc.) source bundle and uploads your source code to Sentry.
+        // This enables source context, allowing you to see your source
+        // code as part of your stack traces in Sentry.
+        // includeSourceContext = true
 
-    // Generates a JVM (Java, Kotlin, etc.) source bundle and uploads your source code to Sentry.
-    // This enables source context, allowing you to see your source
-    // code as part of your stack traces in Sentry.
-    // includeSourceContext = true
+        // Temporarily disabled since it didn't work when building with gradle in the docker container
+        includeSourceContext = false
 
-    // Temporarily disabled since it didn't work when building with gradle in the docker container
-    includeSourceContext = false
-
-    org = "digitalservice"
-    projectName = "ris-norms"
-    debug.set(true)
-    authToken = System.getenv("SENTRY_AUTH_TOKEN")
+        org = "digitalservice"
+        projectName = "ris-norms"
+        debug.set(true)
+        authToken = System.getenv("SENTRY_AUTH_TOKEN")
+    }
 }

--- a/backend/src/main/resources/application-testing.yaml
+++ b/backend/src/main/resources/application-testing.yaml
@@ -1,2 +1,0 @@
-sentry:
-  enabled: false


### PR DESCRIPTION
We realized that sentry was sending data from the backend not only in the staging environment, therefore I propose to just activate the sentry plugin in gradle when the spring profile active == staging