### PR TITLE
Risdev-4559 string index out of bounds exception range 0 1 out of bounds for length 0

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineService.java
@@ -152,12 +152,14 @@ public class TimeMachineService implements ApplyPassiveModificationsUseCase {
     if (mod.containsRef()) {
       final Node secondQuotedTextNode = mod.getSecondQuotedText().get();
 
-      // Get the target node's current text content and remove unnecessary whitespaces, for the
+      // Get the target node's current text content and remove unnecessary
+      // whitespaces, for the
       // character counting from mod to work
       final String targetText = targetNode.getTextContent().trim().replaceAll("\\s+", " ");
       if (targetText.length() == 0) return;
 
-      // Get the start and end index of the old text, within the cleaned old text of the target node
+      // Get the start and end index of the old text, within the cleaned old text of
+      // the target node
       final int startIndex = targetText.indexOf(oldText);
       final int endIndex = startIndex + oldText.length();
 
@@ -176,7 +178,8 @@ public class TimeMachineService implements ApplyPassiveModificationsUseCase {
         targetNode.appendChild(beforeTextNode);
       }
 
-      // Import content of quotedText from amending law (which include akn:refs) using importNode
+      // Import content of quotedText from amending law (which include akn:refs) using
+      // importNode
       // because of different documents
       NodeParser.nodeListToList(secondQuotedTextNode.getChildNodes())
           .forEach(

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineService.java
@@ -161,8 +161,8 @@ public class TimeMachineService implements ApplyPassiveModificationsUseCase {
       final int endIndex = startIndex + oldText.length();
 
       // Split the text into three parts: before, replacement, after
-      final String beforeText = targetText.substring(0, startIndex);
-      final String afterText = targetText.substring(endIndex + 1);
+      final String beforeText = targetText.length() > 0 ? targetText.substring(0, startIndex) : "";
+      final String afterText = targetText.length() > 0 ? targetText.substring(endIndex + 1) : "";
 
       // Clear the target node's content
       while (targetNode.hasChildNodes()) {

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineService.java
@@ -156,7 +156,7 @@ public class TimeMachineService implements ApplyPassiveModificationsUseCase {
       // whitespaces, for the
       // character counting from mod to work
       final String targetText = targetNode.getTextContent().trim().replaceAll("\\s+", " ");
-      if (targetText.length() == 0) return;
+      if (targetText.isEmpty()) return;
 
       // Get the start and end index of the old text, within the cleaned old text of
       // the target node

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineService.java
@@ -155,14 +155,15 @@ public class TimeMachineService implements ApplyPassiveModificationsUseCase {
       // Get the target node's current text content and remove unnecessary whitespaces, for the
       // character counting from mod to work
       final String targetText = targetNode.getTextContent().trim().replaceAll("\\s+", " ");
+      if (targetText.length() == 0) return;
 
       // Get the start and end index of the old text, within the cleaned old text of the target node
       final int startIndex = targetText.indexOf(oldText);
       final int endIndex = startIndex + oldText.length();
 
       // Split the text into three parts: before, replacement, after
-      final String beforeText = targetText.length() > 0 ? targetText.substring(0, startIndex) : "";
-      final String afterText = targetText.length() > 0 ? targetText.substring(endIndex + 1) : "";
+      final String beforeText = targetText.substring(0, startIndex);
+      final String afterText = targetText.substring(endIndex + 1);
 
       // Clear the target node's content
       while (targetNode.hasChildNodes()) {

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineService.java
@@ -152,14 +152,12 @@ public class TimeMachineService implements ApplyPassiveModificationsUseCase {
     if (mod.containsRef()) {
       final Node secondQuotedTextNode = mod.getSecondQuotedText().get();
 
-      // Get the target node's current text content and remove unnecessary
-      // whitespaces, for the
+      // Get the target node's current text content and remove unnecessary whitespaces, for the
       // character counting from mod to work
       final String targetText = targetNode.getTextContent().trim().replaceAll("\\s+", " ");
       if (targetText.isEmpty()) return;
 
-      // Get the start and end index of the old text, within the cleaned old text of
-      // the target node
+      // Get the start and end index of the old text, within the cleaned old text of the target node
       final int startIndex = targetText.indexOf(oldText);
       final int endIndex = startIndex + oldText.length();
 
@@ -178,8 +176,7 @@ public class TimeMachineService implements ApplyPassiveModificationsUseCase {
         targetNode.appendChild(beforeTextNode);
       }
 
-      // Import content of quotedText from amending law (which include akn:refs) using
-      // importNode
+      // Import content of quotedText from amending law (which include akn:refs) using importNode
       // because of different documents
       NodeParser.nodeListToList(secondQuotedTextNode.getChildNodes())
           .forEach(

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineServiceTest.java
@@ -34,24 +34,24 @@ class TimeMachineServiceTest {
               .document(
                   XmlMapper.toDocument(
                       """
-                                            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                                            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                                               <akn:act name="regelungstext">
-                                                  <!-- Metadaten -->
-                                                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                                        <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                                            <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
-                                                            <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
-                                                            <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
-                                                         </akn:FRBRWork>
-                                                    </akn:identification>
-                                                  </akn:meta>
-                                               </akn:act>
-                                            </akn:akomaNtoso>
-                                            """))
+                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                         <akn:act name="regelungstext">
+                            <!-- Metadaten -->
+                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                                  <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                                      <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                                      <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                                      <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                                   </akn:FRBRWork>
+                              </akn:identification>
+                            </akn:meta>
+                         </akn:act>
+                      </akn:akomaNtoso>
+                      """))
               .build();
 
       // when
@@ -137,18 +137,18 @@ class TimeMachineServiceTest {
       assertThat(changedNodeValue.get())
           .isEqualToIgnoringWhitespace(
               """
-                                    Das Bundesamt für Verfassungsschutz trifft für die gemeinsamen Dateien die technischen und organisatorischen Maßnahmen
-                                                                    entsprechend §
-                                                                    64 des Bundesdatenschutzgesetzes. Es hat bei jedem Zugriff für Zwecke der Datenschutzkontrolle den Zeitpunkt, die
-                                                                    Angaben, die die
-                                                                    Feststellung der abgefragten Datensätze ermöglichen, sowie die abfragende Stelle zu protokollieren. Die Auswertung der
-                                                                    Protokolldaten
-                                                                    ist nach dem Stand der Technik zu gewährleisten. Die protokollierten Daten dürfen nur für Zwecke der
-                                                                    Datenschutzkontrolle, der
-                                                                    Datensicherung oder zur Sicherstellung eines ordnungsgemäßen Betriebs der Datenverarbeitungsanlage verwendet werden.
-                                                                    Die
-                                                                    Protokolldaten sind nach Ablauf von fünf Jahren zu löschen.
-                                    """);
+                              Das Bundesamt für Verfassungsschutz trifft für die gemeinsamen Dateien die technischen und organisatorischen Maßnahmen
+                                                              entsprechend §
+                                                              64 des Bundesdatenschutzgesetzes. Es hat bei jedem Zugriff für Zwecke der Datenschutzkontrolle den Zeitpunkt, die
+                                                              Angaben, die die
+                                                              Feststellung der abgefragten Datensätze ermöglichen, sowie die abfragende Stelle zu protokollieren. Die Auswertung der
+                                                              Protokolldaten
+                                                              ist nach dem Stand der Technik zu gewährleisten. Die protokollierten Daten dürfen nur für Zwecke der
+                                                              Datenschutzkontrolle, der
+                                                              Datensicherung oder zur Sicherstellung eines ordnungsgemäßen Betriebs der Datenverarbeitungsanlage verwendet werden.
+                                                              Die
+                                                              Protokolldaten sind nach Ablauf von fünf Jahren zu löschen.
+                              """);
     }
 
     @Test
@@ -286,9 +286,9 @@ class TimeMachineServiceTest {
       final Node expectedNode =
           XmlMapper.toNode(
               """
-                            <?xml version="1.0" encoding="UTF-8"?><akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" GUID="0ba9a471-e9ef-44c4-b5da-f69f068a4483" eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1">entgegen § 9 Absatz 1 <akn:ref GUID="514f37b3-5f75-4ee4-a110-6bad8c5a46c3" eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ref-1" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1">Satz 2</akn:ref>, Absatz 2 oder 3
-                                                                    Kennezichen eines verbotenen Vereins oder einer Ersatzorganisation verwendet,</akn:p>
-                                            """);
+<?xml version="1.0" encoding="UTF-8"?><akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" GUID="0ba9a471-e9ef-44c4-b5da-f69f068a4483" eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1">entgegen § 9 Absatz 1 <akn:ref GUID="514f37b3-5f75-4ee4-a110-6bad8c5a46c3" eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ref-1" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1">Satz 2</akn:ref>, Absatz 2 oder 3
+                                        Kennezichen eines verbotenen Vereins oder einer Ersatzorganisation verwendet,</akn:p>
+                """);
 
       when(normService.loadNorm(any())).thenReturn(Optional.of(amendingLaw));
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineServiceTest.java
@@ -5,10 +5,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import de.bund.digitalservice.ris.norms.application.port.input.ApplyPassiveModificationsUseCase;
+import de.bund.digitalservice.ris.norms.application.service.TimeMachineService.ModData;
+import de.bund.digitalservice.ris.norms.domain.entity.Mod;
 import de.bund.digitalservice.ris.norms.domain.entity.Norm;
 import de.bund.digitalservice.ris.norms.domain.entity.NormFixtures;
 import de.bund.digitalservice.ris.norms.utils.NodeParser;
 import de.bund.digitalservice.ris.norms.utils.XmlMapper;
+import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.Set;
@@ -34,24 +37,24 @@ class TimeMachineServiceTest {
               .document(
                   XmlMapper.toDocument(
                       """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                  <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                      <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
-                                      <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
-                                      <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
-                                   </akn:FRBRWork>
-                              </akn:identification>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                      """))
+                                            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+                                            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                                               <akn:act name="regelungstext">
+                                                  <!-- Metadaten -->
+                                                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                                                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                                                        <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                                                            <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                                                            <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                                                            <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                                                         </akn:FRBRWork>
+                                                    </akn:identification>
+                                                  </akn:meta>
+                                               </akn:act>
+                                            </akn:akomaNtoso>
+                                            """))
               .build();
 
       // when
@@ -137,18 +140,18 @@ class TimeMachineServiceTest {
       assertThat(changedNodeValue.get())
           .isEqualToIgnoringWhitespace(
               """
-                              Das Bundesamt für Verfassungsschutz trifft für die gemeinsamen Dateien die technischen und organisatorischen Maßnahmen
-                                                              entsprechend §
-                                                              64 des Bundesdatenschutzgesetzes. Es hat bei jedem Zugriff für Zwecke der Datenschutzkontrolle den Zeitpunkt, die
-                                                              Angaben, die die
-                                                              Feststellung der abgefragten Datensätze ermöglichen, sowie die abfragende Stelle zu protokollieren. Die Auswertung der
-                                                              Protokolldaten
-                                                              ist nach dem Stand der Technik zu gewährleisten. Die protokollierten Daten dürfen nur für Zwecke der
-                                                              Datenschutzkontrolle, der
-                                                              Datensicherung oder zur Sicherstellung eines ordnungsgemäßen Betriebs der Datenverarbeitungsanlage verwendet werden.
-                                                              Die
-                                                              Protokolldaten sind nach Ablauf von fünf Jahren zu löschen.
-                              """);
+                                    Das Bundesamt für Verfassungsschutz trifft für die gemeinsamen Dateien die technischen und organisatorischen Maßnahmen
+                                                                    entsprechend §
+                                                                    64 des Bundesdatenschutzgesetzes. Es hat bei jedem Zugriff für Zwecke der Datenschutzkontrolle den Zeitpunkt, die
+                                                                    Angaben, die die
+                                                                    Feststellung der abgefragten Datensätze ermöglichen, sowie die abfragende Stelle zu protokollieren. Die Auswertung der
+                                                                    Protokolldaten
+                                                                    ist nach dem Stand der Technik zu gewährleisten. Die protokollierten Daten dürfen nur für Zwecke der
+                                                                    Datenschutzkontrolle, der
+                                                                    Datensicherung oder zur Sicherstellung eines ordnungsgemäßen Betriebs der Datenverarbeitungsanlage verwendet werden.
+                                                                    Die
+                                                                    Protokolldaten sind nach Ablauf von fünf Jahren zu löschen.
+                                    """);
     }
 
     @Test
@@ -286,9 +289,9 @@ class TimeMachineServiceTest {
       final Node expectedNode =
           XmlMapper.toNode(
               """
-<?xml version="1.0" encoding="UTF-8"?><akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" GUID="0ba9a471-e9ef-44c4-b5da-f69f068a4483" eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1">entgegen § 9 Absatz 1 <akn:ref GUID="514f37b3-5f75-4ee4-a110-6bad8c5a46c3" eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ref-1" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1">Satz 2</akn:ref>, Absatz 2 oder 3
-                                        Kennezichen eines verbotenen Vereins oder einer Ersatzorganisation verwendet,</akn:p>
-                """);
+                            <?xml version="1.0" encoding="UTF-8"?><akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" GUID="0ba9a471-e9ef-44c4-b5da-f69f068a4483" eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1">entgegen § 9 Absatz 1 <akn:ref GUID="514f37b3-5f75-4ee4-a110-6bad8c5a46c3" eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ref-1" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1">Satz 2</akn:ref>, Absatz 2 oder 3
+                                                                    Kennezichen eines verbotenen Vereins oder einer Ersatzorganisation verwendet,</akn:p>
+                                            """);
 
       when(normService.loadNorm(any())).thenReturn(Optional.of(amendingLaw));
 
@@ -309,6 +312,89 @@ class TimeMachineServiceTest {
               .ignoreWhitespace()
               .build();
       assertThat(diff.hasDifferences()).isFalse();
+    }
+  }
+
+  @Nested
+  class applyQuotedText {
+    @Test
+    void applyQuotedTextOnNodeEmptyAfterRemovingWhitespace() throws Exception {
+      // given
+      //     final String quotedTextMod = """
+      //   <akn:mod eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"
+      //         GUID="148c2f06-6e33-4af8-9f4a-3da67c888510"
+      //         refersTo="aenderungsbefehl-ersetzen">In <akn:ref
+      // eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1"
+      //            GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206"
+      //
+      // href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml">§ 20 Absatz 1 Satz 2</akn:ref> wird
+      //   die Angabe <akn:quotedText
+      // eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-1"
+      //                   GUID="694459c4-ef66-4f87-bb78-a332054a2216"
+      //                   startQuote="„"
+      //                   endQuote="“">§ 9 Abs. 1 Satz 2, Abs. 2</akn:quotedText> durch die
+      //   Wörter <akn:quotedText
+      // eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2"
+      //                   GUID="dd25bdb6-4ef4-4ef5-808c-27579b6ae196"
+      //                   startQuote="„"
+      //                   endQuote="“">§ 9 Absatz 1 Satz 2, Absatz 2 oder 3</akn:quotedText>
+      //   ersetzt.</akn:mod>
+      //   """;
+
+      final String quotedTextMod =
+          """
+                    <akn:mod
+                                            eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"
+                                            GUID="148c2f06-6e33-4af8-9f4a-3da67c888510"
+                                            refersTo="aenderungsbefehl-ersetzen">In <akn:ref
+                                            eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1"
+                                            GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206"
+                                            href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34.xml">
+                                        § 20 Absatz 1 Satz 2
+                                    </akn:ref> wird
+                                        die Angabe <akn:quotedText
+                                                eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-1"
+                                                GUID="694459c4-ef66-4f87-bb78-a332054a2216"
+                                                startQuote="„"
+                                                endQuote="“">§ 9 Abs. 1 Satz 2, Abs. 2
+                                        </akn:quotedText> durch die
+                                        Wörter
+                                        <akn:quotedText
+                                                eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2"
+                                                GUID="dd25bdb6-4ef4-4ef5-808c-27579b6ae196"
+                                                startQuote="„"
+                                                endQuote="“">§ 9 Absatz 1 <akn:ref GUID="514f37b3-5f75-4ee4-a110-6bad8c5a46c3"
+                                                                                   eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2_ref-1"
+                                                                                   href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1">Satz 2</akn:ref>, Absatz 2 oder 3
+                                        </akn:quotedText>
+                                        ersetzt.
+                                    </akn:mod>
+                    """;
+      final Mod mod = Mod.builder().node(XmlMapper.toNode(quotedTextMod)).build();
+      final ModData modData = new ModData(null, null, mod);
+      final Optional<Node> targetNode =
+          Optional.of(
+              XmlMapper.toNode(
+                  """
+                            <?xml version="1.0" encoding="UTF-8"?>
+                            <akn:p
+                                xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                GUID="0ba9a471-e9ef-44c4-b5da-f69f068a4483"
+                                eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1"
+                            ></akn:p>
+                                            """)); // will be modified when applying the quoted text
+
+      // obtaining the private method using reflection
+      Method applyQuotedTextPrivateMethod =
+          TimeMachineService.class.getDeclaredMethod("applyQuotedText", ModData.class, Node.class);
+      applyQuotedTextPrivateMethod.setAccessible(true);
+
+      // when
+      applyQuotedTextPrivateMethod.invoke(timeMachineService, modData, targetNode.get());
+
+      // then
+      assertThat(targetNode).isPresent();
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineServiceTest.java
@@ -317,6 +317,8 @@ class TimeMachineServiceTest {
 
   @Nested
   class applyQuotedText {
+    // NOTE: we're testing a private method, here. This should be an exception. If
+    // you feel like you need it, too, please talk to the team first.
     @Test
     void applyQuotedTextOnNodeEmptyAfterRemovingWhitespace() throws Exception {
       final String quotedTextMod =
@@ -350,10 +352,8 @@ class TimeMachineServiceTest {
                     """;
       final Mod mod = Mod.builder().node(XmlMapper.toNode(quotedTextMod)).build();
       final ModData modData = new ModData(null, null, mod);
-      final Optional<Node> targetNode =
-          Optional.of(
-              XmlMapper.toNode(
-                  """
+      final String nodeString =
+          """
                                     <?xml version="1.0" encoding="UTF-8"?>
                                     <akn:p
                                         xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
@@ -361,7 +361,14 @@ class TimeMachineServiceTest {
                                         GUID="0ba9a471-e9ef-44c4-b5da-f69f068a4483"
                                         eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1"
                                     ></akn:p>
-                                                    """)); // will be modified when applying the quoted text
+                                                    """;
+      final Node targetNode =
+          XmlMapper.toNode(nodeString); // will be modified when applying the quoted text
+      final Node unchangedTargetNodeClone =
+          XmlMapper.toNode(nodeString); // used for comparison after applying method
+
+      // NOTE: we're testing a private method, here. This should be an exception. If
+      // you feel like you need it, too, please talk to the team first.
 
       // obtaining the private method using reflection
       Method applyQuotedTextPrivateMethod =
@@ -369,12 +376,13 @@ class TimeMachineServiceTest {
       applyQuotedTextPrivateMethod.setAccessible(true);
 
       // when
-      applyQuotedTextPrivateMethod.invoke(timeMachineService, modData, targetNode.get());
+      applyQuotedTextPrivateMethod.invoke(timeMachineService, modData, targetNode);
 
       // then
-      // TODO: assert the actual change made, not just that the function threw an
-      // exception
-      assertThat(targetNode).isPresent();
+      assertThat(
+              XmlMapper.toString(unchangedTargetNodeClone)
+                  .equals(XmlMapper.toString(unchangedTargetNodeClone)))
+          .isTrue();
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineServiceTest.java
@@ -354,18 +354,19 @@ class TimeMachineServiceTest {
       final ModData modData = new ModData(null, null, mod);
       final String nodeString =
           """
-                                    <?xml version="1.0" encoding="UTF-8"?>
-                                    <akn:p
-                                        xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                        GUID="0ba9a471-e9ef-44c4-b5da-f69f068a4483"
-                                        eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1"
-                                    ></akn:p>
-                                                    """;
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <akn:p
+                        xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        GUID="0ba9a471-e9ef-44c4-b5da-f69f068a4483"
+                        eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1"
+                    ></akn:p>
+                                    """;
       final Node targetNode =
           XmlMapper.toNode(nodeString); // will be modified when applying the quoted text
       final Node unchangedTargetNodeClone =
-          XmlMapper.toNode(nodeString); // used for comparison after applying method
+          XmlMapper.toNode(nodeString); // used for comparison after applying
+      // method
 
       // NOTE: we're testing a private method, here. This should be an exception. If
       // you feel like you need it, too, please talk to the team first.
@@ -379,10 +380,8 @@ class TimeMachineServiceTest {
       applyQuotedTextPrivateMethod.invoke(timeMachineService, modData, targetNode);
 
       // then
-      assertThat(
-              XmlMapper.toString(unchangedTargetNodeClone)
-                  .equals(XmlMapper.toString(unchangedTargetNodeClone)))
-          .isTrue();
+      assertThat(XmlMapper.toString(unchangedTargetNodeClone))
+          .isEqualTo(XmlMapper.toString(unchangedTargetNodeClone));
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineServiceTest.java
@@ -323,9 +323,16 @@ class TimeMachineServiceTest {
 
       when(normService.loadNorm(any())).thenReturn(Optional.of(amendingLaw));
 
-      // when then
+      // when
       timeMachineService.applyPassiveModifications(
           new ApplyPassiveModificationsUseCase.Query(norm, Instant.MAX));
+
+      // then
+      final Optional<Node> updatedNode =
+          NodeParser.getNodeFromExpression(
+              "//*[@eId=\"hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1\"]",
+              norm.getDocument());
+      assertThat(updatedNode).isPresent();
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineServiceTest.java
@@ -319,28 +319,6 @@ class TimeMachineServiceTest {
   class applyQuotedText {
     @Test
     void applyQuotedTextOnNodeEmptyAfterRemovingWhitespace() throws Exception {
-      // given
-      //     final String quotedTextMod = """
-      //   <akn:mod eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"
-      //         GUID="148c2f06-6e33-4af8-9f4a-3da67c888510"
-      //         refersTo="aenderungsbefehl-ersetzen">In <akn:ref
-      // eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1"
-      //            GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206"
-      //
-      // href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml">§ 20 Absatz 1 Satz 2</akn:ref> wird
-      //   die Angabe <akn:quotedText
-      // eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-1"
-      //                   GUID="694459c4-ef66-4f87-bb78-a332054a2216"
-      //                   startQuote="„"
-      //                   endQuote="“">§ 9 Abs. 1 Satz 2, Abs. 2</akn:quotedText> durch die
-      //   Wörter <akn:quotedText
-      // eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2"
-      //                   GUID="dd25bdb6-4ef4-4ef5-808c-27579b6ae196"
-      //                   startQuote="„"
-      //                   endQuote="“">§ 9 Absatz 1 Satz 2, Absatz 2 oder 3</akn:quotedText>
-      //   ersetzt.</akn:mod>
-      //   """;
-
       final String quotedTextMod =
           """
                     <akn:mod
@@ -376,14 +354,14 @@ class TimeMachineServiceTest {
           Optional.of(
               XmlMapper.toNode(
                   """
-                            <?xml version="1.0" encoding="UTF-8"?>
-                            <akn:p
-                                xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                GUID="0ba9a471-e9ef-44c4-b5da-f69f068a4483"
-                                eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1"
-                            ></akn:p>
-                                            """)); // will be modified when applying the quoted text
+                                    <?xml version="1.0" encoding="UTF-8"?>
+                                    <akn:p
+                                        xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                        GUID="0ba9a471-e9ef-44c4-b5da-f69f068a4483"
+                                        eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1"
+                                    ></akn:p>
+                                                    """)); // will be modified when applying the quoted text
 
       // obtaining the private method using reflection
       Method applyQuotedTextPrivateMethod =
@@ -394,6 +372,8 @@ class TimeMachineServiceTest {
       applyQuotedTextPrivateMethod.invoke(timeMachineService, modData, targetNode.get());
 
       // then
+      // TODO: assert the actual change made, not just that the function threw an
+      // exception
       assertThat(targetNode).isPresent();
     }
   }


### PR DESCRIPTION
Return early if targetNode is empty.

Returning early may not be the best way to handle this kind of error, but it follows the pattern of other pieces of code in that function (e.g. line 146: 
`if (mod.getSecondQuotedText().isEmpty()
        || mod.getOldText().isEmpty()
        || mod.getNewText().isEmpty()) return;`

Fixes RISDEV-4559