### PR TITLE
Doc updates: Split contributer information into separate doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+
+🇬🇧
+Everyone is welcome to contribute to the development of _RIS Norms_. You can contribute by opening pull requests, providing documentation, answering questions or giving feedback. Please do follow our guidelines and our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+🇩🇪
+Jede:r ist herzlich eingeladen, die Entwicklung von _RIS Norms_ mitzugestalten. Du kannst einen Beitrag leisten, indem du Pull-Requests eröffnest, die Dokumentation erweiterst, Fragen beantwortest oder Feedback gibst. Bitte befolge die Richtlinien und unseren [Verhaltenskodex](CODE_OF_CONDUCT_DE.md).
+
+## Code Contributions
+
+🇬🇧
+Open a pull request with your changes and it will be reviewed by someone from the team. When you submit a pull request, you declare that you have the right to license your contribution to DigitalService and the community. By submitting the patch, you agree that your contributions are licensed under the [GPLv3 license](./LICENSE).
+
+Please make sure that your changes have been tested before submitting a pull request.
+
+🇩🇪
+Nach dem Erstellen eines Pull Requests wird dieser von einer Person aus dem Team überprüft. Wenn du einen Pull Request einreichst, erklärst du dich damit einverstanden, deinen Beitrag an den DigitalService und die Community zu lizenzieren. Durch das Einreichen des Patches erklärst du dich damit einverstanden, dass deine Beiträge unter der [GPLv3-Lizenz](./LICENSE) lizenziert sind.
+
+Bitte stelle sicher, dass deine Änderungen getestet wurden, bevor du einen Pull Request sendest.

--- a/README.md
+++ b/README.md
@@ -10,28 +10,33 @@ This repository contains a web app supporting the Federal Documentation of Statu
 
 The name "RIS Norms" refers to
 
-- "RIS", which is the German acronym for "Information system on the law" (DE: "Rechtsinformationssystem")
+- "RIS", which is the German acronym for "information system on the law" (DE: "Rechtsinformationssystem")
 - "Norms", which makes explicit that within RIS, we're explicitly dealing with federal laws and similar documents (and not, for example, with court verdicts)
 
-# Structure of the Repository
+# Top Level Structure of the Repository
 
+## Code
 This is a mono-repository containing
 
-- [`./frontend`](./frontend) - The main browser-based entry point for users of _RIS-norms_
 - [`./backend`](./backend) - The backend service
-- [`./ldml-extension`](./ldml-extension) - Extensions to the [LDML.de](https://gitlab.opencode.de/bmi/e-gesetzgebung/ldml_de) schema
+- [`./frontend`](./frontend) - The main browser-based entry point for users of _RIS-norms_
+- [`./ldml-extension`](./ldml-extension) - Extensions to the [LegalDocDML.de](https://gitlab.opencode.de/bmi/e-gesetzgebung/ldml_de) schema
+- [`./regex`](./regex/) - A utility for creating regex schemas
 
-Each of the above has its own `README.md` with more details on that component.
+Each of the above has its own `README.md` with more.
 
-# Additional Documentation
-There are two places where documentation can be found:
-- This projects's [`./doc`](./doc) folder, most notably containing information on
+## Sample Data
+- [`./ldml-samples`](./ldml-samples/) contains files in the [LegalDocML.de](https://gitlab.opencode.de/bmi/e-gesetzgebung/ldml_de) format for testing and reference purposes
+
+## Documentation
+- [`./doc`](./doc) contains information on
   -  the domain model
   -  the API specification and
   -  our Architecture Decision Records (ADR)
-- The general [RIS Documentation](https://digitalservicebund.github.io/ris-reports/), especially
-  - the [architecture diagrams](https://digitalservicebund.github.io/ris-reports/docs/architecture/diagrams_list.html)
-  - the backend [JavaDocs](https://digitalservicebund.github.io/ris-reports/docs/backend-code-documentation/norms-java.html)
+
+- Additionally, there is the general [RIS Documentation](https://digitalservicebund.github.io/ris-reports/), which shows the RIS Norms
+  - [architecture diagrams](https://digitalservicebund.github.io/ris-reports/docs/architecture/diagrams_list.html)
+  - backend [JavaDocs](https://digitalservicebund.github.io/ris-reports/docs/backend-code-documentation/norms-java.html)
 
 # Development
 

--- a/README.md
+++ b/README.md
@@ -39,20 +39,4 @@ Please refer to [`DEVELOPING.md`](./DEVELOPING.md) for further details.
 
 # Contributions Welcome!
 
-🇬🇧
-Everyone is welcome to contribute to the development of _RIS Norms_. You can contribute by opening pull requests, providing documentation, answering questions or giving feedback. Please do follow our guidelines and our [Code of Conduct](CODE_OF_CONDUCT.md).
-
-🇩🇪
-Jede:r ist herzlich eingeladen, die Entwicklung von _RIS Norms_ mitzugestalten. Du kannst einen Beitrag leisten, indem du Pull-Requests eröffnest, die Dokumentation erweiterst, Fragen beantwortest oder Feedback gibst. Bitte befolge die Richtlinien und unseren [Verhaltenskodex](CODE_OF_CONDUCT_DE.md).
-
-## Code Contributions
-
-🇬🇧
-Open a pull request with your changes and it will be reviewed by someone from the team. When you submit a pull request, you declare that you have the right to license your contribution to DigitalService and the community. By submitting the patch, you agree that your contributions are licensed under the [GPLv3 license](./LICENSE).
-
-Please make sure that your changes have been tested before submitting a pull request.
-
-🇩🇪
-Nach dem Erstellen eines Pull Requests wird dieser von einer Person aus dem Team überprüft. Wenn du einen Pull Request einreichst, erklärst du dich damit einverstanden, deinen Beitrag an den DigitalService und die Community zu lizenzieren. Durch das Einreichen des Patches erklärst du dich damit einverstanden, dass deine Beiträge unter der [GPLv3-Lizenz](./LICENSE) lizenziert sind.
-
-Bitte stelle sicher, dass deine Änderungen getestet wurden bevor du einen Pull Request sendest.
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for details.


### PR DESCRIPTION
Allows GitHub to show "Contributing" as a community standard.

RISDEV-0000