### PR TITLE
Do not delete whitespaces when reference detection

### DIFF
--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/ReferenceServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/ReferenceServiceTest.java
@@ -106,7 +106,6 @@ class ReferenceServiceTest {
     final Diff diff =
         DiffBuilder.compare(Input.from(XmlMapper.toDocument(result)))
             .withTest(Input.from(norm.getDocument()))
-            .ignoreWhitespace()
             .build();
     assertThat(diff.hasDifferences()).isFalse();
   }
@@ -129,7 +128,6 @@ class ReferenceServiceTest {
     final Diff diff =
         DiffBuilder.compare(Input.from(XmlMapper.toDocument(result)))
             .withTest(Input.from(norm.getDocument()))
-            .ignoreWhitespace()
             .build();
     assertThat(diff.hasDifferences()).isFalse();
   }
@@ -156,7 +154,6 @@ class ReferenceServiceTest {
     final Diff diff =
         DiffBuilder.compare(Input.from(XmlMapper.toDocument(result)))
             .withTest(Input.from(expectedUpdatedNorm.getDocument()))
-            .ignoreWhitespace()
             .withAttributeFilter(attribute -> !attribute.getName().equals("GUID"))
             .build();
     assertThat(diff.hasDifferences()).isFalse();

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ReferenceControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ReferenceControllerIntegrationTest.java
@@ -75,7 +75,9 @@ class ReferenceControllerIntegrationTest extends BaseIntegrationTest {
         .andExpect(
             xpath(
                     "//quotedStructure//heading[@eId='hauptteil-1_para-2_überschrift-1']/ref[2]/text()")
-                .string("Verordnung (EG) Nr. 1035/2001"))
+                .string(
+                    "Verordnung (EG) Nr.\n"
+                        + "                                                        1035/2001"))
         .andExpect(
             xpath(
                     "//quotedText[@eId='hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2']/ref/@eId")

--- a/backend/src/test/resources/de/bund/digitalservice/ris/norms/domain/entity/NormWithReferencesFound.xml
+++ b/backend/src/test/resources/de/bund/digitalservice/ris/norms/domain/entity/NormWithReferencesFound.xml
@@ -145,29 +145,66 @@
                                             <akn:paragraph GUID="c0a4c9d2-dc0d-4b59-be88-7663f1e32bae" eId="hauptteil-1_para-2_abs-1">
                                                 <akn:content GUID="0f24a464-a987-4eab-be22-2badb8cc3321" eId="hauptteil-1_para-2_abs-1_inhalt-1">
 
-                                                    <akn:heading GUID="e696f540-586c-4725-ae49-654bb28918ab" eId="hauptteil-1_para-2_überschrift-1"><akn:ref GUID="0c74e59b-83df-42ca-890f-6822b554d395" eId="hauptteil-1_para-2_überschrift-1_ref-1" href="">§ 5</akn:ref> Durchsetzung bestimmter Vorschriften der <akn:ref GUID="26aef77a-c7e3-4584-8d9b-f0a7334551c6" eId="hauptteil-1_para-2_überschrift-1_ref-2" href="">Verordnung (EG) Nr. 1035/2001</akn:ref></akn:heading>
-                                                    <akn:p eId="hauptteil-1_para-2_text-1">Ordnungswidrig im Sinne des <akn:ref GUID="5e8ca5d8-aa6a-402a-9edf-d3b3c34b7232" eId="hauptteil-1_para-2_text-1_ref-1" href="">§ 18 Absatz 2 Nummer 11 Buchstabe a des Seefischereigesetzes</akn:ref> handelt, wer vorsätzlich oder fahrlässig entgegen <akn:ref GUID="c034998e-74ec-493c-b1f0-5cf538763ca0" eId="hauptteil-1_para-2_text-1_ref-2" href="">Artikel 17</akn:ref> der <akn:ref GUID="cb3e331b-d53b-4560-8508-257abf75a446" eId="hauptteil-1_para-2_text-1_ref-3" href="">Verordnung (EG) Nr. 1035/2001 des Rates vom 22. Mai 2001 zur Einführung einer Fangdokumentationsregelung für Dissostichus spp. (ABl. L 145 vom 31.5.2001, S. 1)</akn:ref>, die zuletzt durch die <akn:ref GUID="fade07d4-d573-4343-90a4-12b946deb815" eId="hauptteil-1_para-2_text-1_ref-4" href="">Verordnung (EG) Nr. 1368/2006 (ABl. L 253 vom 16.9.2006, S. 1)</akn:ref> geändert worden ist, Dissostichus spp. einführt oder ausführt.</akn:p>
+                                                    <akn:heading GUID="e696f540-586c-4725-ae49-654bb28918ab" eId="hauptteil-1_para-2_überschrift-1">
+                                                        <akn:ref GUID="3cffdc68-2ad7-44b7-896b-7f38daaacc6f" eId="hauptteil-1_para-2_überschrift-1_ref-1" href="">§ 5</akn:ref> Durchsetzung bestimmter Vorschriften der <akn:ref GUID="dd2ab5f8-8302-432d-9afd-4ff3f1d814f0" eId="hauptteil-1_para-2_überschrift-1_ref-2" href="">Verordnung (EG) Nr.
+                                                        1035/2001</akn:ref>
+                                                    </akn:heading>
+                                                    <akn:p eId="hauptteil-1_para-2_text-1">
+                                                        Ordnungswidrig im Sinne des <akn:ref GUID="99a87f86-ca14-4175-9a83-56b0dc40d973" eId="hauptteil-1_para-2_text-1_ref-1" href="">§ 18 Absatz 2 Nummer 11 Buchstabe a
+                                                        des Seefischereigesetzes</akn:ref> handelt, wer vorsätzlich oder
+                                                        fahrlässig entgegen <akn:ref GUID="d8b05b1e-e669-481d-a627-5423a64b5082" eId="hauptteil-1_para-2_text-1_ref-2" href="">Artikel 17</akn:ref> der <akn:ref GUID="90880faa-e57a-4a9e-9b67-02eb0fec24c8" eId="hauptteil-1_para-2_text-1_ref-3" href="">Verordnung (EG) Nr. 1035/2001
+                                                        des Rates vom 22. Mai 2001 zur Einführung einer
+                                                        Fangdokumentationsregelung für Dissostichus spp. (ABl. L 145 vom
+                                                        31.5.2001, S. 1)</akn:ref>, die zuletzt durch die <akn:ref GUID="2d239eb0-c089-4c66-9804-7fecfe97eb06" eId="hauptteil-1_para-2_text-1_ref-4" href="">Verordnung (EG) Nr.
+                                                        1368/2006 (ABl. L 253 vom 16.9.2006, S. 1)</akn:ref> geändert worden ist,
+                                                        Dissostichus spp. einführt oder ausführt.
+                                                    </akn:p>
                                                 </akn:content>
                                             </akn:paragraph>
                                             <akn:paragraph GUID="c0a4c9d2-dc0d-4b59-be88-7663f1e32bae" eId="hauptteil-2_para-2_abs-1">
                                                 <akn:content GUID="0f24a464-a987-4eab-be22-2badb8cc3321" eId="hauptteil-2_para-2_abs-1_inhalt-1">
 
-                                                    <akn:heading GUID="e696f540-586c-4725-ae49-654bb28918ab" eId="hauptteil-2_para-2_überschrift-1"><akn:ref GUID="6cca8ee5-143c-4c64-baa7-c061855267bd" eId="hauptteil-2_para-2_überschrift-1_ref-1" href="">§ 6</akn:ref> Durchsetzung bestimmter Vorschriften der <akn:ref GUID="1ca5e591-61b5-465c-bc42-a2595f204716" eId="hauptteil-2_para-2_überschrift-1_ref-2" href="">Verordnung (EG) Nr. 2056/2001</akn:ref></akn:heading>
-                                                    <akn:p eId="hauptteil-2_para-2_text-1">Ordnungswidrig im Sinne des <akn:ref GUID="4ba0437c-73f7-4369-90c2-4d790113a68b" eId="hauptteil-2_para-2_text-1_ref-1" href="">§ 18 Absatz 2 Nummer 11 Buchstabe a des Seefischereigesetzes</akn:ref> handelt, wer gegen die <akn:ref GUID="4ad6bd24-2bce-4a00-ac43-5de4b5998f0d" eId="hauptteil-2_para-2_text-1_ref-2" href="">Verordnung (EG) Nr. 2056/2001 der Kommission vom 19. Oktober 2001 mit zusätzlichen technischen Maßnahmen zur Wiederauffüllung der Kabeljaubestände in der Nordsee und westlich von Schottland (ABl. L 277 vom 20.10.2001, S. 13)</akn:ref>, die durch die <akn:ref GUID="d744ef4c-4933-43b2-b294-8d3b60c85af5" eId="hauptteil-2_para-2_text-1_ref-3" href="">Durchführungsverordnung (EU) 2015/1897 (ABl. L 277 vom 22.10.2015, S. 11)</akn:ref> geändert worden ist, verstößt, indem er vorsätzlich oder fahrlässig<akn:point>
-                                                        <akn:num>1.</akn:num>
-                                                        <akn:p eId="hauptteil-2_para-2_überschrift-1_point_1">entgegen <akn:ref GUID="5746364d-d4c2-4838-832f-9e81a428a6bd" eId="hauptteil-2_para-2_überschrift-1_point_1_ref-1" href="">Artikel 4 Nummer 5</akn:ref> ein dort genanntes Netz mitführt oder ausbringt,</akn:p>
-                                                    </akn:point>
+                                                    <akn:heading GUID="e696f540-586c-4725-ae49-654bb28918ab" eId="hauptteil-2_para-2_überschrift-1">
+                                                        <akn:ref GUID="2c1e90e3-e790-4877-8f24-0c29c80d3bb5" eId="hauptteil-2_para-2_überschrift-1_ref-1" href="">§ 6</akn:ref> Durchsetzung bestimmter Vorschriften der <akn:ref GUID="179230e3-b77b-4f4c-85c2-1dd88bdb8c4a" eId="hauptteil-2_para-2_überschrift-1_ref-2" href="">Verordnung (EG) Nr.
+                                                        2056/2001</akn:ref>
+                                                    </akn:heading>
+                                                    <akn:p eId="hauptteil-2_para-2_text-1">
+                                                        Ordnungswidrig im Sinne des <akn:ref GUID="e1c4beca-b14d-406b-985f-ef6b6171504c" eId="hauptteil-2_para-2_text-1_ref-1" href="">§ 18 Absatz 2 Nummer 11 Buchstabe a
+                                                        des Seefischereigesetzes</akn:ref> handelt, wer gegen die <akn:ref GUID="333f773d-9fea-4ed4-a5c8-a255d677938e" eId="hauptteil-2_para-2_text-1_ref-2" href="">Verordnung (EG)
+                                                        Nr. 2056/2001 der Kommission vom 19. Oktober 2001 mit
+                                                        zusätzlichen technischen Maßnahmen zur Wiederauffüllung der
+                                                        Kabeljaubestände in der Nordsee und westlich von Schottland
+                                                        (ABl. L 277 vom 20.10.2001, S. 13)</akn:ref>, die durch die
+                                                        <akn:ref GUID="9edba3e1-37aa-4da2-88a6-1c1d13bf967e" eId="hauptteil-2_para-2_text-1_ref-3" href="">Durchführungsverordnung (EU) 2015/1897 (ABl. L 277 vom
+                                                        22.10.2015, S. 11)</akn:ref> geändert worden ist, verstößt, indem er
+                                                        vorsätzlich oder fahrlässig
+                                                        <akn:point>
+                                                            <akn:num>1.</akn:num>
+                                                            <akn:p eId="hauptteil-2_para-2_überschrift-1_point_1">
+                                                                entgegen <akn:ref GUID="efccddf0-47ad-4bc2-9073-56e2d546509c" eId="hauptteil-2_para-2_überschrift-1_point_1_ref-1" href="">Artikel 4 Nummer 5</akn:ref> ein dort genanntes Netz
+                                                                mitführt oder ausbringt,
+                                                            </akn:p>
+                                                        </akn:point>
                                                         <akn:point>
                                                             <akn:num>2.</akn:num>
-                                                            <akn:p eId="hauptteil-2_para-2_überschrift-1_point_2">entgegen <akn:ref GUID="3ab031ac-1e68-4ebc-91a9-4c2849518538" eId="hauptteil-2_para-2_überschrift-1_point_2_ref-1" href="">Artikel 5 Absatz 1 oder 2 Satz 1</akn:ref> oder <akn:ref GUID="7c3aa6b5-eaf3-4e51-9cd5-3bd677701a7f" eId="hauptteil-2_para-2_überschrift-1_point_2_ref-2" href="">Artikel 8 Absatz 1 Satz 1</akn:ref> ein dort genanntes Netz einsetzt,</akn:p>
+                                                            <akn:p eId="hauptteil-2_para-2_überschrift-1_point_2">
+                                                                entgegen <akn:ref GUID="bab315a3-cf6b-4c02-aefa-274bdc5b2178" eId="hauptteil-2_para-2_überschrift-1_point_2_ref-1" href="">Artikel 5 Absatz 1 oder 2 Satz 1</akn:ref> oder <akn:ref GUID="52e62557-aefb-4207-9c0a-b3dbd54619d2" eId="hauptteil-2_para-2_überschrift-1_point_2_ref-2" href="">Artikel 8
+                                                                Absatz 1 Satz 1</akn:ref> ein dort genanntes Netz einsetzt,
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>3.</akn:num>
-                                                            <akn:p eId="hauptteil-2_para-2_überschrift-1_point_3">entgegen <akn:ref GUID="f29addff-dbb8-4703-86ed-d77016a0f54e" eId="hauptteil-2_para-2_überschrift-1_point_3_ref-1" href="">Artikel 5 Absatz 3 Satz 1</akn:ref> eine dort genannte Baumkurre mitführt oder einsetzt oder</akn:p>
+                                                            <akn:p eId="hauptteil-2_para-2_überschrift-1_point_3">
+                                                                entgegen <akn:ref GUID="6b5bf761-d6e5-454a-985c-46f312829a5d" eId="hauptteil-2_para-2_überschrift-1_point_3_ref-1" href="">Artikel 5 Absatz 3 Satz 1</akn:ref> eine dort genannte
+                                                                Baumkurre mitführt oder einsetzt oder
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>4.</akn:num>
-                                                            <akn:p eId="hauptteil-2_para-2_überschrift-1_point_4">entgegen <akn:ref GUID="73e2a835-807d-4d81-8151-6e1cbf243855" eId="hauptteil-2_para-2_überschrift-1_point_4_ref-1" href="">Artikel 6 Absatz 1</akn:ref> eine dort genannte Baumkurre einsetzt.</akn:p>
+                                                            <akn:p eId="hauptteil-2_para-2_überschrift-1_point_4">
+                                                                entgegen <akn:ref GUID="e363e060-3f1d-4336-99cd-ed63cfd7db1e" eId="hauptteil-2_para-2_überschrift-1_point_4_ref-1" href="">Artikel 6 Absatz 1</akn:ref> eine dort genannte Baumkurre
+                                                                einsetzt.
+                                                            </akn:p>
                                                         </akn:point>
                                                     </akn:p>
                                                 </akn:content>
@@ -175,26 +212,58 @@
                                             <akn:paragraph GUID="c0a4c9d2-dc0d-4b59-be88-7663f1e32bae" eId="hauptteil-3_para-2_abs-1">
                                                 <akn:content GUID="0f24a464-a987-4eab-be22-2badb8cc3321" eId="hauptteil-3_para-2_abs-1_inhalt-1">
 
-                                                    <akn:heading GUID="e696f540-586c-4725-ae49-654bb28918ab" eId="hauptteil-3_para-2_überschrift-1"><akn:ref GUID="7c290eb6-fe23-4bc5-8900-80d90952a40f" eId="hauptteil-3_para-2_überschrift-1_ref-1" href="">§ 7</akn:ref> Durchsetzung bestimmter Vorschriften der <akn:ref GUID="c2220255-8ba4-4c8a-81c8-dd29b115690b" eId="hauptteil-3_para-2_überschrift-1_ref-2" href="">Verordnung (EG) Nr. 494/2002</akn:ref></akn:heading>
-                                                    <akn:p eId="hauptteil-3_para-2_text-1">Ordnungswidrig im Sinne des <akn:ref GUID="19137f28-9a6d-43a8-891a-b3d13b70bd39" eId="hauptteil-3_para-2_text-1_ref-1" href="">§ 18 Absatz 2 Nummer 11 Buchstabe a des Seefischereigesetzes</akn:ref> handelt, wer gegen die <akn:ref GUID="ba1808ff-c35c-4a90-ad79-6ead84906384" eId="hauptteil-3_para-2_text-1_ref-2" href="">Verordnung (EG) Nr. 494/2002 der Kommission vom 19. März 2002 mit zusätzlichen technischen Maßnahmen zur Wiederauffüllung des Seehechtsbestands in den ICES-Gebieten III, IV, V, VI und VII sowie VIII a, b, d, e (ABl. L 77 vom 20.3.2002, S. 8)</akn:ref>, die durch die <akn:ref GUID="6962fb8d-faad-488f-85fe-b3433cbcb74d" eId="hauptteil-3_para-2_text-1_ref-3" href="">Durchführungsverordnung (EU) 2015/1867 (ABl. L 275 vom 20.10.2015, S. 20)</akn:ref> geändert worden ist, verstößt, indem er vorsätzlich oder fahrlässig<akn:point>
-                                                        <akn:num>1.</akn:num>
-                                                        <akn:p eId="hauptteil-3_para-2_überschrift-1_point_1">entgegen <akn:ref GUID="f914c8d9-1e0b-462f-986a-c875558756cd" eId="hauptteil-3_para-2_überschrift-1_point_1_ref-1" href="">Artikel 3</akn:ref> ein dort genanntes Netz oder ein dort genanntes Netzteil verwendet,</akn:p>
-                                                    </akn:point>
+                                                    <akn:heading GUID="e696f540-586c-4725-ae49-654bb28918ab" eId="hauptteil-3_para-2_überschrift-1">
+                                                        <akn:ref GUID="3d3c531b-fc9b-4ee8-92c0-b239a70b8ce4" eId="hauptteil-3_para-2_überschrift-1_ref-1" href="">§ 7</akn:ref> Durchsetzung bestimmter Vorschriften der <akn:ref GUID="7826f56b-7f40-4ce8-b891-f7e7fba40cb6" eId="hauptteil-3_para-2_überschrift-1_ref-2" href="">Verordnung (EG) Nr.
+                                                        494/2002</akn:ref>
+                                                    </akn:heading>
+                                                    <akn:p eId="hauptteil-3_para-2_text-1">
+                                                        Ordnungswidrig im Sinne des <akn:ref GUID="4ec5b77c-4484-4770-be0f-8a8e498239dd" eId="hauptteil-3_para-2_text-1_ref-1" href="">§ 18 Absatz 2 Nummer 11 Buchstabe a
+                                                        des Seefischereigesetzes</akn:ref> handelt, wer gegen die <akn:ref GUID="73d3497c-13f5-4cc8-9690-9a2335722856" eId="hauptteil-3_para-2_text-1_ref-2" href="">Verordnung (EG)
+                                                        Nr. 494/2002 der Kommission vom 19. März 2002 mit zusätzlichen
+                                                        technischen Maßnahmen zur Wiederauffüllung des Seehechtsbestands
+                                                        in den ICES-Gebieten III, IV, V, VI und VII sowie VIII a, b, d,
+                                                        e (ABl. L 77 vom 20.3.2002, S. 8)</akn:ref>, die durch die
+                                                        <akn:ref GUID="f6d0e4dd-5635-461e-863a-80e0d7f7ecb1" eId="hauptteil-3_para-2_text-1_ref-3" href="">Durchführungsverordnung (EU) 2015/1867 (ABl. L 275 vom
+                                                        20.10.2015, S. 20)</akn:ref> geändert worden ist, verstößt, indem er
+                                                        vorsätzlich oder fahrlässig
+                                                        <akn:point>
+                                                            <akn:num>1.</akn:num>
+                                                            <akn:p eId="hauptteil-3_para-2_überschrift-1_point_1">
+                                                                entgegen <akn:ref GUID="2df4315b-ded4-4d72-8f45-44b955902b32" eId="hauptteil-3_para-2_überschrift-1_point_1_ref-1" href="">Artikel 3</akn:ref> ein dort genanntes Netz oder ein dort
+                                                                genanntes Netzteil verwendet,
+                                                            </akn:p>
+                                                        </akn:point>
                                                         <akn:point>
                                                             <akn:num>2.</akn:num>
-                                                            <akn:p eId="hauptteil-3_para-2_überschrift-1_point_2">entgegen <akn:ref GUID="10dee3de-c67a-4584-86dd-9915f679d04c" eId="hauptteil-3_para-2_überschrift-1_point_2_ref-1" href="">Artikel 4</akn:ref> Satz 1 eine dort genannte Baumkurre mitführt oder ausbringt,</akn:p>
+                                                            <akn:p eId="hauptteil-3_para-2_überschrift-1_point_2">
+                                                                entgegen <akn:ref GUID="b596ac1e-7d07-42d6-84cb-3c3dc547e47d" eId="hauptteil-3_para-2_überschrift-1_point_2_ref-1" href="">Artikel 4</akn:ref> Satz 1 eine dort genannte Baumkurre
+                                                                mitführt oder ausbringt,
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>3.</akn:num>
-                                                            <akn:p eId="hauptteil-3_para-2_überschrift-1_point_3">entgegen <akn:ref GUID="443daa30-e334-4ee8-a00f-4f9aa8875da8" eId="hauptteil-3_para-2_überschrift-1_point_3_ref-1" href="">Artikel 5 Absatz 2 Satz 1</akn:ref> erster oder zweiter Gedankenstrich oder <akn:ref GUID="363a5bc0-1cd5-4bc0-b2d0-e9680fec66fd" eId="hauptteil-3_para-2_überschrift-1_point_3_ref-2" href="">Artikel 6 Absatz 1 oder 2</akn:ref> ein dort genanntes Netz oder eine dort genannte Baumkurre einsetzt oder zu Wasser lässt,</akn:p>
+                                                            <akn:p eId="hauptteil-3_para-2_überschrift-1_point_3">
+                                                                entgegen <akn:ref GUID="9733b9a7-b807-4700-959f-d0ccf0f097ea" eId="hauptteil-3_para-2_überschrift-1_point_3_ref-1" href="">Artikel 5 Absatz 2 Satz 1</akn:ref> erster oder zweiter
+                                                                Gedankenstrich oder <akn:ref GUID="0070a087-dae3-47f2-a076-aa8b7843825c" eId="hauptteil-3_para-2_überschrift-1_point_3_ref-2" href="">Artikel 6 Absatz 1 oder 2</akn:ref> ein dort
+                                                                genanntes Netz oder eine dort genannte Baumkurre
+                                                                einsetzt oder zu Wasser lässt,
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>4.</akn:num>
-                                                            <akn:p eId="hauptteil-3_para-2_überschrift-1_point_4">entgegen <akn:ref GUID="29d573ab-173e-400e-b6ef-9345f74d5dde" eId="hauptteil-3_para-2_überschrift-1_point_4_ref-1" href="">Artikel 5 Absatz 2 Satz 2 erster Gedankenstrich</akn:ref> oder Satz 3 erster Gedankenstrich Fischfang betreibt oder</akn:p>
+                                                            <akn:p eId="hauptteil-3_para-2_überschrift-1_point_4">
+                                                                entgegen <akn:ref GUID="755341d7-fef5-4946-907e-89aafaff3772" eId="hauptteil-3_para-2_überschrift-1_point_4_ref-1" href="">Artikel 5 Absatz 2 Satz 2 erster Gedankenstrich</akn:ref>
+                                                                oder Satz 3 erster Gedankenstrich Fischfang betreibt
+                                                                oder
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>5.</akn:num>
-                                                            <akn:p eId="hauptteil-3_para-2_überschrift-1_point_5">entgegen <akn:ref GUID="9d9998bc-5403-4022-bbce-b906e0a618f4" eId="hauptteil-3_para-2_überschrift-1_point_5_ref-1" href="">Artikel 5 Absatz 2 Satz 2 zweiter Gedankenstrich</akn:ref> oder Satz 3 zweiter Gedankenstrich ein dort genanntes Fanggerät zu Wasser lässt oder ausbringt.</akn:p>
+                                                            <akn:p eId="hauptteil-3_para-2_überschrift-1_point_5">
+                                                                entgegen <akn:ref GUID="7d5bb221-df23-48c3-afa9-880949f68922" eId="hauptteil-3_para-2_überschrift-1_point_5_ref-1" href="">Artikel 5 Absatz 2 Satz 2 zweiter
+                                                                Gedankenstrich</akn:ref> oder Satz 3 zweiter Gedankenstrich ein
+                                                                dort genanntes Fanggerät zu Wasser lässt oder ausbringt.
+                                                            </akn:p>
                                                         </akn:point>
                                                     </akn:p>
                                                 </akn:content>
@@ -202,14 +271,31 @@
                                             <akn:paragraph GUID="c0a4c9d2-dc0d-4b59-be88-7663f1e32bae" eId="hauptteil-4_para-2_abs-1">
                                                 <akn:content GUID="0f24a464-a987-4eab-be22-2badb8cc3321" eId="hauptteil-4_para-2_abs-1_inhalt-1">
 
-                                                    <akn:heading GUID="e696f540-586c-4725-ae49-654bb28918ab" eId="hauptteil-4_para-2_überschrift-1"><akn:ref GUID="e49436e9-c212-46b0-983b-64bed7baaa1b" eId="hauptteil-4_para-2_überschrift-1_ref-1" href="">§ 8</akn:ref> Durchsetzung bestimmter Vorschriften der <akn:ref GUID="533a2735-cf10-4a40-ba48-85810301ccbe" eId="hauptteil-4_para-2_überschrift-1_ref-2" href="">Verordnung (EG) Nr. 1185/2003</akn:ref></akn:heading>
-                                                    <akn:p eId="hauptteil-4_para-2_text-1">Ordnungswidrig im Sinne des <akn:ref GUID="5d9c6cdd-71cf-4f45-ac77-364bf3eb9c45" eId="hauptteil-4_para-2_text-1_ref-1" href="">§ 18 Absatz 2 Nummer 11 Buchstabe a des Seefischereigesetzes</akn:ref> handelt, wer gegen die <akn:ref GUID="1e3e0d6d-3822-4e6d-9ea4-e193a41cde3e" eId="hauptteil-4_para-2_text-1_ref-2" href="">Verordnung (EG) Nr. 1185/2003 des Rates vom 26. Juni 2003 über das Abtrennen von Haifischflossen an Bord von Schiffen (ABl. L 167 vom 4.7.2003, S. 1)</akn:ref>, die durch die <akn:ref GUID="28268695-3460-4066-a843-32ad57c7e26a" eId="hauptteil-4_para-2_text-1_ref-3" href="">Verordnung (EU) Nr. 605/2013 (ABl. L 181 vom 29.6.2013, S. 1)</akn:ref> geändert worden ist, verstößt, indem er vorsätzlich oder fahrlässig<akn:point>
-                                                        <akn:num>1.</akn:num>
-                                                        <akn:p eId="hauptteil-4_para-2_überschrift-1_point_1">entgegen <akn:ref GUID="a1c77411-1bf3-47a8-b1e7-c477da836410" eId="hauptteil-4_para-2_überschrift-1_point_1_ref-1" href="">Artikel 3 Absatz 1</akn:ref> eine Haifischflosse abtrennt, mitführt, umlädt oder anlandet oder</akn:p>
-                                                    </akn:point>
+                                                    <akn:heading GUID="e696f540-586c-4725-ae49-654bb28918ab" eId="hauptteil-4_para-2_überschrift-1">
+                                                        <akn:ref GUID="532ef98e-f54a-47d7-96f6-ef54a9d301dd" eId="hauptteil-4_para-2_überschrift-1_ref-1" href="">§ 8</akn:ref> Durchsetzung bestimmter Vorschriften der <akn:ref GUID="53c89f61-d3f8-4682-a4e8-a920fc0b9017" eId="hauptteil-4_para-2_überschrift-1_ref-2" href="">Verordnung (EG) Nr.
+                                                        1185/2003</akn:ref>
+                                                    </akn:heading>
+                                                    <akn:p eId="hauptteil-4_para-2_text-1">
+                                                        Ordnungswidrig im Sinne des <akn:ref GUID="1e483882-3c04-4226-9675-d377d1eef517" eId="hauptteil-4_para-2_text-1_ref-1" href="">§ 18 Absatz 2 Nummer 11 Buchstabe a
+                                                        des Seefischereigesetzes</akn:ref> handelt, wer gegen die <akn:ref GUID="09a2d956-81a5-4fbc-93ff-6ebf81a8ed2b" eId="hauptteil-4_para-2_text-1_ref-2" href="">Verordnung (EG)
+                                                        Nr. 1185/2003 des Rates vom 26. Juni 2003 über das Abtrennen von
+                                                        Haifischflossen an Bord von Schiffen (ABl. L 167 vom 4.7.2003,
+                                                        S. 1)</akn:ref>, die durch die <akn:ref GUID="4ccd39ef-af85-4305-950a-c6092b7880ce" eId="hauptteil-4_para-2_text-1_ref-3" href="">Verordnung (EU) Nr. 605/2013 (ABl. L 181
+                                                        vom 29.6.2013, S. 1)</akn:ref> geändert worden ist, verstößt, indem er
+                                                        vorsätzlich oder fahrlässig
+                                                        <akn:point>
+                                                            <akn:num>1.</akn:num>
+                                                            <akn:p eId="hauptteil-4_para-2_überschrift-1_point_1">
+                                                                entgegen <akn:ref GUID="3362df5a-2fc5-477c-955b-5fc40570aa5f" eId="hauptteil-4_para-2_überschrift-1_point_1_ref-1" href="">Artikel 3 Absatz 1</akn:ref> eine Haifischflosse
+                                                                abtrennt, mitführt, umlädt oder anlandet oder
+                                                            </akn:p>
+                                                        </akn:point>
                                                         <akn:point>
                                                             <akn:num>2.</akn:num>
-                                                            <akn:p eId="hauptteil-4_para-2_überschrift-1_point_2">entgegen <akn:ref GUID="1daac689-d2e3-4463-b4e6-2070c5f5ae09" eId="hauptteil-4_para-2_überschrift-1_point_2_ref-1" href="">Artikel 3 Absatz 2</akn:ref> eine Haifischflosse kauft oder zum Verkauf anbietet.</akn:p>
+                                                            <akn:p eId="hauptteil-4_para-2_überschrift-1_point_2">
+                                                                entgegen <akn:ref GUID="216a684c-5358-4a00-bae3-a5f3cc6b397a" eId="hauptteil-4_para-2_überschrift-1_point_2_ref-1" href="">Artikel 3 Absatz 2</akn:ref> eine Haifischflosse kauft
+                                                                oder zum Verkauf anbietet.
+                                                            </akn:p>
                                                         </akn:point>
                                                     </akn:p>
                                                 </akn:content>
@@ -217,18 +303,39 @@
                                             <akn:paragraph GUID="c0a4c9d2-dc0d-4b59-be88-7663f1e32bae" eId="hauptteil-5_para-2_abs-1">
                                                 <akn:content GUID="0f24a464-a987-4eab-be22-2badb8cc3321" eId="hauptteil-5_para-2_abs-1_inhalt-1">
 
-                                                    <akn:heading GUID="e696f540-586c-4725-ae49-654bb28918ab" eId="hauptteil-5_para-2_überschrift-1"><akn:ref GUID="3d79f7e7-fe55-4326-aba2-04e8bfafe664" eId="hauptteil-5_para-2_überschrift-1_ref-1" href="">§ 9</akn:ref> Durchsetzung bestimmter Vorschriften der <akn:ref GUID="23b1e1fd-4c62-4cf3-a2da-212c2e5e70cc" eId="hauptteil-5_para-2_überschrift-1_ref-2" href="">Verordnung (EG) Nr. 1984/2003</akn:ref></akn:heading>
-                                                    <akn:p eId="hauptteil-5-para-2_text-1">Ordnungswidrig im Sinne des <akn:ref GUID="700fdf43-2880-4e46-84e0-5cf257cd121b" eId="hauptteil-5-para-2_text-1_ref-1" href="">§ 18 Absatz 2 Nummer 11 Buchstabe a des Seefischereigesetzes</akn:ref> handelt, wer gegen die <akn:ref GUID="b68edc0f-b344-40f8-aa7a-61563864bc96" eId="hauptteil-5-para-2_text-1_ref-2" href="">Verordnung (EG) Nr. 1984/2003 des Rates vom 8. April 2003 über eine Regelung zur statistischen Erfassung von Schwertfisch und Großaugenthun in der Gemeinschaft (ABl. L 295 vom 13.11.2003, S. 1)</akn:ref>, die zuletzt durch die <akn:ref GUID="035a6b5e-08e1-4024-82fe-2f81ddf485d8" eId="hauptteil-5-para-2_text-1_ref-3" href="">Verordnung (EU) 2022/2343 (ABl. L 311 vom 2.12.2022, S. 1)</akn:ref> geändert worden ist, verstößt, indem er vorsätzlich oder fahrlässig<akn:point>
-                                                        <akn:num>1.</akn:num>
-                                                        <akn:p eId="hauptteil-5_para-2_überschrift-1_point_1">entgegen <akn:ref GUID="274a713f-1052-4b92-8664-9c025c2bf7e9" eId="hauptteil-5_para-2_überschrift-1_point_1_ref-1" href="">Artikel 4 Absatz 5</akn:ref> Fisch einer dort genannten Art einführt,</akn:p>
-                                                    </akn:point>
+                                                    <akn:heading GUID="e696f540-586c-4725-ae49-654bb28918ab" eId="hauptteil-5_para-2_überschrift-1">
+                                                        <akn:ref GUID="886738b6-ed00-4682-a3f6-fa4ef59bc26d" eId="hauptteil-5_para-2_überschrift-1_ref-1" href="">§ 9</akn:ref> Durchsetzung bestimmter Vorschriften der <akn:ref GUID="2f212cfc-e5b7-479c-ad25-e3f8b4cb7e82" eId="hauptteil-5_para-2_überschrift-1_ref-2" href="">Verordnung (EG) Nr.
+                                                        1984/2003</akn:ref>
+                                                    </akn:heading>
+                                                    <akn:p eId="hauptteil-5-para-2_text-1">
+                                                        Ordnungswidrig im Sinne des <akn:ref GUID="f23e9802-ed5c-477f-8ea0-aa67499df5fa" eId="hauptteil-5-para-2_text-1_ref-1" href="">§ 18 Absatz 2 Nummer 11 Buchstabe a
+                                                        des Seefischereigesetzes</akn:ref> handelt, wer gegen die <akn:ref GUID="2e915c67-4612-48a1-aa69-ddafd3cfc550" eId="hauptteil-5-para-2_text-1_ref-2" href="">Verordnung (EG)
+                                                        Nr. 1984/2003 des Rates vom 8. April 2003 über eine Regelung zur
+                                                        statistischen Erfassung von Schwertfisch und Großaugenthun in
+                                                        der Gemeinschaft (ABl. L 295 vom 13.11.2003, S. 1)</akn:ref>, die zuletzt
+                                                        durch die <akn:ref GUID="7aeb9bfe-1d06-4939-9002-78311252cb1d" eId="hauptteil-5-para-2_text-1_ref-3" href="">Verordnung (EU) 2022/2343 (ABl. L 311 vom 2.12.2022,
+                                                        S. 1)</akn:ref> geändert worden ist, verstößt, indem er vorsätzlich oder
+                                                        fahrlässig
+                                                        <akn:point>
+                                                            <akn:num>1.</akn:num>
+                                                            <akn:p eId="hauptteil-5_para-2_überschrift-1_point_1">
+                                                                entgegen <akn:ref GUID="b0a788cd-49b6-4c94-87b5-7be91980355d" eId="hauptteil-5_para-2_überschrift-1_point_1_ref-1" href="">Artikel 4 Absatz 5</akn:ref> Fisch einer dort genannten
+                                                                Art einführt,
+                                                            </akn:p>
+                                                        </akn:point>
                                                         <akn:point>
                                                             <akn:num>2.</akn:num>
-                                                            <akn:p eId="hauptteil-5_para-2_überschrift-1_point_2">entgegen <akn:ref GUID="0e87573d-c492-4d2c-84c3-2997c5933c8a" eId="hauptteil-5_para-2_überschrift-1_point_2_ref-1" href="">Artikel 5 Absatz 5</akn:ref> Fisch einer dort genannten Art ausführt oder</akn:p>
+                                                            <akn:p eId="hauptteil-5_para-2_überschrift-1_point_2">
+                                                                entgegen <akn:ref GUID="86c7be07-66c5-4060-99f6-4aee4eb5797b" eId="hauptteil-5_para-2_überschrift-1_point_2_ref-1" href="">Artikel 5 Absatz 5</akn:ref> Fisch einer dort genannten
+                                                                Art ausführt oder
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>3.</akn:num>
-                                                            <akn:p eId="hauptteil-5_para-2_überschrift-1_point_3">entgegen <akn:ref GUID="2d8c88bd-c538-4ac2-8e9f-04bebfb10e4d" eId="hauptteil-5_para-2_überschrift-1_point_3_ref-1" href="">Artikel 6 Absatz 6</akn:ref> Fisch einer dort genannten Art wieder ausführt oder einführt.</akn:p>
+                                                            <akn:p eId="hauptteil-5_para-2_überschrift-1_point_3">
+                                                                entgegen <akn:ref GUID="0802b2cd-4d62-480c-b729-9de165d5539e" eId="hauptteil-5_para-2_überschrift-1_point_3_ref-1" href="">Artikel 6 Absatz 6</akn:ref> Fisch einer dort genannten
+                                                                Art wieder ausführt oder einführt.
+                                                            </akn:p>
                                                         </akn:point>
                                                     </akn:p>
                                                 </akn:content>
@@ -236,74 +343,141 @@
                                             <akn:paragraph GUID="c0a4c9d2-dc0d-4b59-be88-7663f1e32bae" eId="hauptteil-6_para-2_abs-1">
                                                 <akn:content GUID="0f24a464-a987-4eab-be22-2badb8cc3321" eId="hauptteil-6_para-2_abs-1_inhalt-1">
 
-                                                    <akn:heading GUID="e696f540-586c-4725-ae49-654bb28918ab" eId="hauptteil-6_para-2_überschrift-1"><akn:ref GUID="1d8d736f-bdd2-4453-a378-b9e64418a81e" eId="hauptteil-6_para-2_überschrift-1_ref-1" href="">§ 10</akn:ref> Durchsetzung bestimmter Vorschriften der <akn:ref GUID="68c5e21e-ca95-40bc-9aab-56213b217a56" eId="hauptteil-6_para-2_überschrift-1_ref-2" href="">Verordnung (EG) Nr. 600/2004</akn:ref></akn:heading>
-                                                    <akn:p eId="hauptteil-6_para-2_text-1">Ordnungswidrig im Sinne des <akn:ref GUID="76cfcb23-a811-42ec-9079-31bba87f1cde" eId="hauptteil-6_para-2_text-1_ref-1" href="">§ 18 Absatz 2 Nummer 11 Buchstabe a des Seefischereigesetzes</akn:ref> handelt, wer gegen die <akn:ref GUID="514ddeb3-21c4-4e7b-b661-d8e6ee278ac9" eId="hauptteil-6_para-2_text-1_ref-2" href="">Verordnung (EG) Nr. 600/2004 des Rates vom 22. März 2004 mit technischen Maßnahmen für die Fischerei im Bereich des Übereinkommens über die Erhaltung der lebenden Meeresschätze der Antarktis (ABl. L 97 vom 1.4.2004, S. 1)</akn:ref> verstößt, indem er vorsätzlich oder fahrlässig<akn:point>
-                                                        <akn:num>1.</akn:num>
-                                                        <akn:p eId="hauptteil-6_para-2_überschrift-1_point_1">als Kapitän entgegen <akn:ref GUID="0bca288f-d737-4103-86df-b399e71253af" eId="hauptteil-6_para-2_überschrift-1_point_1_ref-1" href="">Artikel 3 Absatz 1</akn:ref>, 2, 3 Satz 1, Absatz 4 oder 6 eine Fischerei ausübt,</akn:p>
-                                                    </akn:point>
+                                                    <akn:heading GUID="e696f540-586c-4725-ae49-654bb28918ab" eId="hauptteil-6_para-2_überschrift-1">
+                                                        <akn:ref GUID="663fade3-7432-43a6-8af7-d08d9e357248" eId="hauptteil-6_para-2_überschrift-1_ref-1" href="">§ 10</akn:ref> Durchsetzung bestimmter Vorschriften der <akn:ref GUID="795073b5-a9c8-478c-a277-576aa5966c68" eId="hauptteil-6_para-2_überschrift-1_ref-2" href="">Verordnung (EG)
+                                                        Nr. 600/2004</akn:ref>
+                                                    </akn:heading>
+                                                    <akn:p eId="hauptteil-6_para-2_text-1">
+                                                        Ordnungswidrig im Sinne des <akn:ref GUID="6dc9736b-9daf-4883-b10b-34cd7db8df40" eId="hauptteil-6_para-2_text-1_ref-1" href="">§ 18 Absatz 2 Nummer 11 Buchstabe a
+                                                        des Seefischereigesetzes</akn:ref> handelt, wer gegen die <akn:ref GUID="64065434-a69f-4851-bb90-886af756bd2f" eId="hauptteil-6_para-2_text-1_ref-2" href="">Verordnung (EG)
+                                                        Nr. 600/2004 des Rates vom 22. März 2004 mit technischen
+                                                        Maßnahmen für die Fischerei im Bereich des Übereinkommens über
+                                                        die Erhaltung der lebenden Meeresschätze der Antarktis (ABl. L
+                                                        97 vom 1.4.2004, S. 1)</akn:ref> verstößt, indem er vorsätzlich oder
+                                                        fahrlässig
+                                                        <akn:point>
+                                                            <akn:num>1.</akn:num>
+                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_1">
+                                                                als Kapitän entgegen <akn:ref GUID="78ae2a97-7fd4-4f2e-a668-efe2c425772b" eId="hauptteil-6_para-2_überschrift-1_point_1_ref-1" href="">Artikel 3 Absatz 1</akn:ref>, 2, 3 Satz 1,
+                                                                Absatz 4 oder 6 eine Fischerei ausübt,
+                                                            </akn:p>
+                                                        </akn:point>
                                                         <akn:point>
                                                             <akn:num>2.</akn:num>
-                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_2">als Kapitän entgegen <akn:ref GUID="8dcb5fc1-e0ef-4f3c-9391-ffaf7079df13" eId="hauptteil-6_para-2_überschrift-1_point_2_ref-1" href="">Artikel 4 Absatz 1</akn:ref> ein dort genanntes Netz oder eine Snurrewade einsetzt,</akn:p>
+                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_2">
+                                                                als Kapitän entgegen <akn:ref GUID="a3842d53-c3a9-493c-8e08-5b5a78c9736f" eId="hauptteil-6_para-2_überschrift-1_point_2_ref-1" href="">Artikel 4 Absatz 1</akn:ref> ein dort
+                                                                genanntes Netz oder eine Snurrewade einsetzt,
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>3.</akn:num>
-                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_3">entgegen <akn:ref GUID="33bc32b5-728e-4341-a93c-6b5a5782887e" eId="hauptteil-6_para-2_überschrift-1_point_3_ref-1" href="">Artikel 4 Absatz 2</akn:ref> eine Vorrichtung verwendet,</akn:p>
+                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_3">
+                                                                entgegen <akn:ref GUID="0415190d-6336-4643-9be0-be807ffc0800" eId="hauptteil-6_para-2_überschrift-1_point_3_ref-1" href="">Artikel 4 Absatz 2</akn:ref> eine Vorrichtung verwendet,
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>4.</akn:num>
-                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_4">als Kapitän entgegen <akn:ref GUID="cf2b29d3-2f1f-46da-a18a-eba0462e7174" eId="hauptteil-6_para-2_überschrift-1_point_4_ref-1" href="">Artikel 6 Absatz 1 Satz 1</akn:ref> zweiter Halbsatz einen Krebs nicht unverzüglich freilässt,</akn:p>
+                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_4">
+                                                                als Kapitän entgegen <akn:ref GUID="350facd5-c47b-478d-9d61-ee3ed01fb336" eId="hauptteil-6_para-2_überschrift-1_point_4_ref-1" href="">Artikel 6 Absatz 1 Satz 1</akn:ref> zweiter
+                                                                Halbsatz einen Krebs nicht unverzüglich freilässt,
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>5.</akn:num>
-                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_5">entgegen <akn:ref GUID="9e2df8ce-7cc3-4b96-b25c-2f2eab50fd41" eId="hauptteil-6_para-2_überschrift-1_point_5_ref-1" href="">Artikel 7 Absatz 1 Unterabsatz 1 oder 2</akn:ref> einen Verpackungsgurt verwendet,</akn:p>
+                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_5">
+                                                                entgegen <akn:ref GUID="35e8ce44-b078-4c10-86b9-ced44f7c9d92" eId="hauptteil-6_para-2_überschrift-1_point_5_ref-1" href="">Artikel 7 Absatz 1 Unterabsatz 1 oder 2</akn:ref> einen
+                                                                Verpackungsgurt verwendet,
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>6.</akn:num>
-                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_6">als Kapitän entgegen <akn:ref GUID="a5aeef99-244c-4e73-8e5c-299ba0c922f9" eId="hauptteil-6_para-2_überschrift-1_point_6_ref-1" href="">Artikel 7 Absatz 3</akn:ref> erster Halbsatz Plastikrückstände nicht an Bord aufbewahrt,</akn:p>
+                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_6">
+                                                                als Kapitän entgegen <akn:ref GUID="34709405-8b8e-4f42-9047-518ba0b99844" eId="hauptteil-6_para-2_überschrift-1_point_6_ref-1" href="">Artikel 7 Absatz 3</akn:ref> erster Halbsatz
+                                                                Plastikrückstände nicht an Bord aufbewahrt,
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>7.</akn:num>
-                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_7">als Kapitän entgegen <akn:ref GUID="a5188325-497a-4442-87e2-9707403e6a50" eId="hauptteil-6_para-2_überschrift-1_point_7_ref-1" href="">Artikel 8 Absatz 1 Satz 3</akn:ref> einen Köder verwendet,</akn:p>
+                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_7">
+                                                                als Kapitän entgegen <akn:ref GUID="9c7969c2-abbb-475c-97b6-2e6938be1df1" eId="hauptteil-6_para-2_überschrift-1_point_7_ref-1" href="">Artikel 8 Absatz 1 Satz 3</akn:ref> einen
+                                                                Köder verwendet,
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>8.</akn:num>
-                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_8">entgegen <akn:ref GUID="05233b17-f6fc-48f7-afac-a34ed7fccc90" eId="hauptteil-6_para-2_überschrift-1_point_8_ref-1" href="">Artikel 8 Absatz 2 Satz 1</akn:ref> eine Langleine ausbringt,</akn:p>
+                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_8">
+                                                                entgegen <akn:ref GUID="a9ba9c0e-7a25-4856-9e72-ccf37c6ad9d1" eId="hauptteil-6_para-2_überschrift-1_point_8_ref-1" href="">Artikel 8 Absatz 2 Satz 1</akn:ref> eine Langleine
+                                                                ausbringt,
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>9.</akn:num>
-                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_9">als Kapitän entgegen <akn:ref GUID="0e8672ae-a498-4545-94f2-1ab578804f50" eId="hauptteil-6_para-2_überschrift-1_point_9_ref-1" href="">Artikel 8 Absatz 3 Satz 1</akn:ref> oder <akn:ref GUID="4205046a-cdda-402e-91df-e1c857491b79" eId="hauptteil-6_para-2_überschrift-1_point_9_ref-2" href="">Artikel 9 Absatz 3</akn:ref> Fischabfälle über Bord wirft,</akn:p>
+                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_9">
+                                                                als Kapitän entgegen <akn:ref GUID="eccb03cd-99ce-4c38-a01f-bd4d15f1b9e3" eId="hauptteil-6_para-2_überschrift-1_point_9_ref-1" href="">Artikel 8 Absatz 3 Satz 1</akn:ref> oder
+                                                                <akn:ref GUID="0cfa4947-fc14-4cf8-90a5-d55d3de275e8" eId="hauptteil-6_para-2_überschrift-1_point_9_ref-2" href="">Artikel 9 Absatz 3</akn:ref> Fischabfälle über Bord wirft,
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>10.</akn:num>
-                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_10">entgegen <akn:ref GUID="fb7237e8-067a-481e-be34-06422eec7223" eId="hauptteil-6_para-2_überschrift-1_point_10_ref-1" href="">Artikel 9 Absatz 1</akn:ref> ein Netzsteuerkabel verwendet,</akn:p>
+                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_10">
+                                                                entgegen <akn:ref GUID="b9af822a-5274-4b20-83de-a1a4c88582a2" eId="hauptteil-6_para-2_überschrift-1_point_10_ref-1" href="">Artikel 9 Absatz 1</akn:ref> ein Netzsteuerkabel
+                                                                verwendet,
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>11.</akn:num>
-                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_11">als Kapitän entgegen <akn:ref GUID="dce40b3c-1e38-4b69-8c91-1b040daaf9c5" eId="hauptteil-6_para-2_überschrift-1_point_11_ref-1" href="">Artikel 10 Absatz 1 oder 2</akn:ref> ein Fischereifahrzeug nicht, nicht richtig oder nicht unverzüglich nach Erreichen des Beifangvolumens an einen anderen Fangplatz begibt,</akn:p>
+                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_11">
+                                                                als Kapitän entgegen <akn:ref GUID="8c580a27-ba73-4b77-8275-439645932798" eId="hauptteil-6_para-2_überschrift-1_point_11_ref-1" href="">Artikel 10 Absatz 1 oder 2</akn:ref> ein
+                                                                Fischereifahrzeug nicht, nicht richtig oder nicht
+                                                                unverzüglich nach Erreichen des Beifangvolumens an einen
+                                                                anderen Fangplatz begibt,
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>12.</akn:num>
-                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_12">als Kapitän entgegen <akn:ref GUID="10b31cdd-8443-4cea-a88b-6cfbe7b8d8e4" eId="hauptteil-6_para-2_überschrift-1_point_12_ref-1" href="">Artikel 11 Absatz 3 Satz 2</akn:ref> erster Halbsatz den Fischfang nicht einstellt,</akn:p>
+                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_12">
+                                                                als Kapitän entgegen <akn:ref GUID="cb75b0bd-df95-4518-b9dd-9ca197414b6b" eId="hauptteil-6_para-2_überschrift-1_point_12_ref-1" href="">Artikel 11 Absatz 3 Satz 2</akn:ref> erster
+                                                                Halbsatz den Fischfang nicht einstellt,
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>13.</akn:num>
-                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_13">entgegen <akn:ref GUID="b181d5d8-84ed-4456-8edf-a71bb6f868bc" eId="hauptteil-6_para-2_überschrift-1_point_13_ref-1" href="">Artikel 12 Absatz 1</akn:ref> Fischerei ausübt,</akn:p>
+                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_13">
+                                                                entgegen <akn:ref GUID="8c60e2f8-68d8-4959-b617-ae13bf408133" eId="hauptteil-6_para-2_überschrift-1_point_13_ref-1" href="">Artikel 12 Absatz 1</akn:ref> Fischerei ausübt,
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>14.</akn:num>
-                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_14">als Kapitän entgegen <akn:ref GUID="d85f84cf-67b8-48b0-b472-51aaa3b4f6f0" eId="hauptteil-6_para-2_überschrift-1_point_14_ref-1" href="">Artikel 12 Absatz 2 Satz 1</akn:ref> ein Fischereifahrzeug nicht, nicht richtig oder nicht unverzüglich nach Erreichen der dort genannten Fangmenge an einen dort genannten Fangplatz begibt,</akn:p>
+                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_14">
+                                                                als Kapitän entgegen <akn:ref GUID="f6806c5c-e1ff-4fcc-87d4-d86d51aadc20" eId="hauptteil-6_para-2_überschrift-1_point_14_ref-1" href="">Artikel 12 Absatz 2 Satz 1</akn:ref> ein
+                                                                Fischereifahrzeug nicht, nicht richtig oder nicht
+                                                                unverzüglich nach Erreichen der dort genannten Fangmenge
+                                                                an einen dort genannten Fangplatz begibt,
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>15.</akn:num>
-                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_15">als Kapitän entgegen <akn:ref GUID="669a1ffb-c7c8-4d34-86d7-9073aa93bd1f" eId="hauptteil-6_para-2_überschrift-1_point_15_ref-1" href="">Artikel 12 Absatz 3</akn:ref> die Fangtätigkeit nicht, nicht richtig, nicht vollständig oder nicht rechtzeitig einstellt,</akn:p>
+                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_15">
+                                                                als Kapitän entgegen <akn:ref GUID="a15e9091-ffba-4477-a775-87bab0f5aad0" eId="hauptteil-6_para-2_überschrift-1_point_15_ref-1" href="">Artikel 12 Absatz 3</akn:ref> die
+                                                                Fangtätigkeit nicht, nicht richtig, nicht vollständig
+                                                                oder nicht rechtzeitig einstellt,
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>16.</akn:num>
-                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_16">als Kapitän entgegen <akn:ref GUID="9ad9a2a5-b21b-429d-96c0-72ec312c8a0a" eId="hauptteil-6_para-2_überschrift-1_point_16_ref-1" href="">Artikel 12 Absatz 4</akn:ref> Hols zu Forschungszwecken nicht, nicht richtig, nicht vollständig, nicht in der vorgeschriebenen Weise oder nicht rechtzeitig ausführt oder</akn:p>
+                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_16">
+                                                                als Kapitän entgegen <akn:ref GUID="340ad89e-fd70-4dbf-8239-bf0de68d776f" eId="hauptteil-6_para-2_überschrift-1_point_16_ref-1" href="">Artikel 12 Absatz 4</akn:ref> Hols zu
+                                                                Forschungszwecken nicht, nicht richtig, nicht
+                                                                vollständig, nicht in der vorgeschriebenen Weise oder
+                                                                nicht rechtzeitig ausführt oder
+                                                            </akn:p>
                                                         </akn:point>
                                                         <akn:point>
                                                             <akn:num>17.</akn:num>
-                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_17">entgegen <akn:ref GUID="fe77edd3-993a-41ae-ba4e-9a2a5d80aa7a" eId="hauptteil-6_para-2_überschrift-1_point_17_ref-1" href="">Artikel 14 Absatz 1</akn:ref>, 2 oder 3 eine dort genannte Person nicht an Bord nimmt.</akn:p>
+                                                            <akn:p eId="hauptteil-6_para-2_überschrift-1_point_17">
+                                                                entgegen <akn:ref GUID="835f8231-4e30-43b5-8ddc-5c758ab1b202" eId="hauptteil-6_para-2_überschrift-1_point_17_ref-1" href="">Artikel 14 Absatz 1</akn:ref>, 2 oder 3 eine dort
+                                                                genannte Person nicht an Bord nimmt.
+                                                            </akn:p>
                                                         </akn:point>
                                                     </akn:p>
                                                 </akn:content>
@@ -311,61 +485,138 @@
                                             <akn:paragraph GUID="c0a4c9d2-dc0d-4b59-be88-7663f1e32bae" eId="hauptteil-7_para-2_abs-1">
                                                 <akn:content GUID="0f24a464-a987-4eab-be22-2badb8cc3321" eId="hauptteil-7_para-2_abs-1_inhalt-1">
 
-                                                    <akn:heading GUID="e696f540-586c-4725-ae49-654bb28918ab" eId="hauptteil-7_para-2_überschrift-1"><akn:ref GUID="e93714ca-6e66-41e2-823d-7783e450c5e0" eId="hauptteil-7_para-2_überschrift-1_ref-1" href="">§ 11</akn:ref> Durchsetzung bestimmter Vorschriften der <akn:ref GUID="c2ee2c1c-96de-4bee-9d5b-0c21212e231c" eId="hauptteil-7_para-2_überschrift-1_ref-2" href="">Verordnung (EG) Nr. 601/2004</akn:ref></akn:heading>
+                                                    <akn:heading GUID="e696f540-586c-4725-ae49-654bb28918ab" eId="hauptteil-7_para-2_überschrift-1">
+                                                        <akn:ref GUID="4aa17686-c115-4db5-9286-914e33b0fdb6" eId="hauptteil-7_para-2_überschrift-1_ref-1" href="">§ 11</akn:ref> Durchsetzung bestimmter Vorschriften der <akn:ref GUID="3d5d186f-1203-4465-95f1-2c283be9b5b1" eId="hauptteil-7_para-2_überschrift-1_ref-2" href="">Verordnung (EG)
+                                                        Nr. 601/2004</akn:ref>
+                                                    </akn:heading>
                                                     <akn:list eId="hauptteil-7_para-2_text-1">
                                                         <akn:p>
                                                             <akn:num>(1)</akn:num>
-                                                            <akn:p eId="hauptteil-7_para-2_überschrift-1_abs-1">Ordnungswidrig im Sinne des <akn:ref GUID="acdde459-f4c2-46d5-8171-430d314ba6a1" eId="hauptteil-7_para-2_überschrift-1_abs-1_ref-1" href="">§ 18 Absatz 2 Nummer 11 Buchstabe a des Seefischereigesetzes</akn:ref> handelt, wer gegen die <akn:ref GUID="ddc67699-068c-4a11-854e-e3e0a6d7026e" eId="hauptteil-7_para-2_überschrift-1_abs-1_ref-2" href="">Verordnung (EG) Nr. 601/2004 des Rates vom 22. März 2004 zur Festlegung von Kontrollmaßnahmen für die Fischerei im Regelungsbereich des Übereinkommens über die Erhaltung der lebenden Meeresschätze der Antarktis und zur Aufhebung der Verordnungen (EWG) Nr. 3943/90, (EG) Nr. 66/98 und (EG) Nr. 1721/1999 (ABl. L 97 vom 1.4.2004, S. 16)</akn:ref>, die zuletzt durch die <akn:ref GUID="3ba751e7-63d7-49e7-a15d-61129e59e6bb" eId="hauptteil-7_para-2_überschrift-1_abs-1_ref-3" href="">Verordnung (EG) Nr. 1005/2008 (ABl. L 286 vom 29.10.2008, S. 1)</akn:ref> geändert worden ist, verstößt, indem er vorsätzlich oder fahrlässig<akn:point>
-                                                                <akn:num>1.</akn:num>
-                                                                <akn:p eId="hauptteil-7_para-2_überschrift-1_point_1">als Kapitän entgegen <akn:ref GUID="2a7bc785-1264-456c-8fbf-4e1ac82ccf56" eId="hauptteil-7_para-2_überschrift-1_point_1_ref-1" href="">Artikel 3 Absatz 1</akn:ref> fischt oder einen Fang an Bord behält, umlädt oder anlandet,</akn:p>
-                                                            </akn:point>
+                                                            <akn:p eId="hauptteil-7_para-2_überschrift-1_abs-1">
+                                                                Ordnungswidrig im Sinne des <akn:ref GUID="b2071049-0fda-4e80-ac0e-c1c5570c4c01" eId="hauptteil-7_para-2_überschrift-1_abs-1_ref-1" href="">§ 18 Absatz 2 Nummer 11
+                                                                Buchstabe a des Seefischereigesetzes</akn:ref> handelt, wer gegen
+                                                                die <akn:ref GUID="7363b9e2-1891-4771-b37a-67fca83c065d" eId="hauptteil-7_para-2_überschrift-1_abs-1_ref-2" href="">Verordnung (EG) Nr. 601/2004 des Rates vom 22. März
+                                                                2004 zur Festlegung von Kontrollmaßnahmen für die
+                                                                Fischerei im Regelungsbereich des Übereinkommens über
+                                                                die Erhaltung der lebenden Meeresschätze der Antarktis
+                                                                und zur Aufhebung der Verordnungen (EWG) Nr. 3943/90,
+                                                                (EG) Nr. 66/98 und (EG) Nr. 1721/1999 (ABl. L 97 vom
+                                                                1.4.2004, S. 16)</akn:ref>, die zuletzt durch die <akn:ref GUID="c28fa421-d9a9-4955-889d-f5292f96df9f" eId="hauptteil-7_para-2_überschrift-1_abs-1_ref-3" href="">Verordnung (EG)
+                                                                Nr. 1005/2008 (ABl. L 286 vom 29.10.2008, S. 1)</akn:ref> geändert
+                                                                worden ist, verstößt, indem er vorsätzlich oder
+                                                                fahrlässig
+                                                                <akn:point>
+                                                                    <akn:num>1.</akn:num>
+                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_1">
+                                                                        als Kapitän entgegen <akn:ref GUID="8bebb9c8-9bcc-44d7-98d2-2b81c6085633" eId="hauptteil-7_para-2_überschrift-1_point_1_ref-1" href="">Artikel 3 Absatz 1</akn:ref> fischt
+                                                                        oder einen Fang an Bord behält, umlädt oder
+                                                                        anlandet,
+                                                                    </akn:p>
+                                                                </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>2.</akn:num>
-                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_2">entgegen <akn:ref GUID="e28287b4-b5a1-4b21-9a5c-8fefba367f1a" eId="hauptteil-7_para-2_überschrift-1_point_2_ref-1" href="">Artikel 6 Absatz 1</akn:ref> oder <akn:ref GUID="ef566b7f-1247-4c87-a59a-04a9d062693f" eId="hauptteil-7_para-2_überschrift-1_point_2_ref-2" href="">Artikel 7 Absatz 1</akn:ref> eine Fischerei oder eine Versuchsfischerei ausübt,</akn:p>
+                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_2">
+                                                                        entgegen <akn:ref GUID="457442ec-92dc-426b-82f4-f76494abac23" eId="hauptteil-7_para-2_überschrift-1_point_2_ref-1" href="">Artikel 6 Absatz 1</akn:ref> oder <akn:ref GUID="e6198943-428c-41b1-a591-3d8ea2c6b13e" eId="hauptteil-7_para-2_überschrift-1_point_2_ref-2" href="">Artikel 7
+                                                                        Absatz 1</akn:ref> eine Fischerei oder eine
+                                                                        Versuchsfischerei ausübt,
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>3.</akn:num>
-                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_3">als Kapitän entgegen <akn:ref GUID="38711a9e-4192-4bb9-b924-468e94cd931d" eId="hauptteil-7_para-2_überschrift-1_point_3_ref-1" href="">Artikel 7a Buchstabe a</akn:ref> einen dort genannten Stoff ins Meer einbringt,</akn:p>
+                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_3">
+                                                                        als Kapitän entgegen <akn:ref GUID="a1bf8153-9ecf-478d-a57e-1dddc96b20d0" eId="hauptteil-7_para-2_überschrift-1_point_3_ref-1" href="">Artikel 7a Buchstabe a</akn:ref>
+                                                                        einen dort genannten Stoff ins Meer einbringt,
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>4.</akn:num>
-                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_4">entgegen <akn:ref GUID="21a76679-7e18-4ae0-867c-4a05d8f1de71" eId="hauptteil-7_para-2_überschrift-1_point_4_ref-1" href="">Artikel 7a Buchstabe b</akn:ref> lebendes Geflügel oder einen lebenden Vogel verbringt oder dort genanntes Geflügel nicht, nicht richtig oder nicht vollständig entfernt,</akn:p>
+                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_4">
+                                                                        entgegen <akn:ref GUID="63ccf3f2-cf18-4cdf-9cf1-346053f4e2e9" eId="hauptteil-7_para-2_überschrift-1_point_4_ref-1" href="">Artikel 7a Buchstabe b</akn:ref> lebendes
+                                                                        Geflügel oder einen lebenden Vogel verbringt
+                                                                        oder dort genanntes Geflügel nicht, nicht
+                                                                        richtig oder nicht vollständig entfernt,
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>5.</akn:num>
-                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_5">entgegen <akn:ref GUID="42baab02-1bb1-4102-ba84-7f71f780d3f3" eId="hauptteil-7_para-2_überschrift-1_point_5_ref-1" href="">Artikel 7a Buchstabe c</akn:ref> Dissostichus spp. fischt,</akn:p>
+                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_5">
+                                                                        entgegen <akn:ref GUID="dff787ed-0533-456d-9b8a-e53220a7ac67" eId="hauptteil-7_para-2_überschrift-1_point_5_ref-1" href="">Artikel 7a Buchstabe c</akn:ref> Dissostichus
+                                                                        spp. fischt,
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>6.</akn:num>
-                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_6">als Kapitän entgegen <akn:ref GUID="e35503be-7971-4b8d-bbd2-74ebaa62c7eb" eId="hauptteil-7_para-2_überschrift-1_point_6_ref-1" href="">Artikel 7b Absatz 1 Buchstabe a Satz 1</akn:ref> ein dort genanntes Exemplar nicht markiert oder nicht wieder freilässt oder</akn:p>
+                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_6">
+                                                                        als Kapitän entgegen <akn:ref GUID="6bbdbd8d-a758-4fcb-bf62-d0f81a5aa921" eId="hauptteil-7_para-2_überschrift-1_point_6_ref-1" href="">Artikel 7b Absatz 1
+                                                                        Buchstabe a Satz 1</akn:ref> ein dort genanntes Exemplar
+                                                                        nicht markiert oder nicht wieder freilässt oder
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>7.</akn:num>
-                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_7">als Kapitän entgegen <akn:ref GUID="16050eff-d48a-4077-bd14-e60852708390" eId="hauptteil-7_para-2_überschrift-1_point_7_ref-1" href="">Artikel 7b Absatz 1 Buchstabe d</akn:ref> einen Fisch freilässt.(2) Ordnungswidrig im Sinne des <akn:ref GUID="6728f2f3-08d6-4719-bfce-515b3a7cb131" eId="hauptteil-7_para-2_überschrift-1_point_7_ref-2" href="">§ 18 Absatz 2 Nummer 11 Buchstabe b des Seefischereigesetzes</akn:ref> handelt, wer gegen die <akn:ref GUID="5525a999-6f9f-4e7b-b711-efeee91bf485" eId="hauptteil-7_para-2_überschrift-1_point_7_ref-3" href="">Verordnung (EG) Nr. 601/2004</akn:ref> verstößt, indem er vorsätzlich oder fahrlässig</akn:p>
+                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_7">
+                                                                        als Kapitän entgegen <akn:ref GUID="59c9053c-0c33-470e-89a4-903d22566ddb" eId="hauptteil-7_para-2_überschrift-1_point_7_ref-1" href="">Artikel 7b Absatz 1
+                                                                        Buchstabe d</akn:ref> einen Fisch freilässt.(2)
+                                                                        Ordnungswidrig im Sinne des <akn:ref GUID="0c2820ac-184e-4069-867c-931b04b27129" eId="hauptteil-7_para-2_überschrift-1_point_7_ref-2" href="">§ 18 Absatz 2 Nummer
+                                                                        11 Buchstabe b des Seefischereigesetzes</akn:ref> handelt,
+                                                                        wer gegen die <akn:ref GUID="28cf76ca-f543-41c4-817f-960122edc0e1" eId="hauptteil-7_para-2_überschrift-1_point_7_ref-3" href="">Verordnung (EG) Nr. 601/2004</akn:ref>
+                                                                        verstößt, indem er vorsätzlich oder fahrlässig
+                                                                    </akn:p>
                                                                 </akn:point>
                                                             </akn:p>
                                                         </akn:p>
                                                         <akn:p>
                                                             <akn:num>(2)</akn:num>
-                                                            <akn:p eId="hauptteil-7_para-2_überschrift-1_abs-2">Ordnungswidrig im Sinne des <akn:ref GUID="174a1137-916d-4933-8694-647ffba630e1" eId="hauptteil-7_para-2_überschrift-1_abs-2_ref-1" href="">§ 18 Absatz 2 Nummer 11 Buchstabe b des Seefischereigesetzes</akn:ref> handelt, wer gegen die <akn:ref GUID="ff3f833e-f38b-43e3-b81d-69d87eed42f2" eId="hauptteil-7_para-2_überschrift-1_abs-2_ref-2" href="">Verordnung (EG) Nr. 601/2004</akn:ref> verstößt, indem er vorsätzlich oder fahrlässig<akn:point>
-                                                                <akn:num>1.</akn:num>
-                                                                <akn:p eId="hauptteil-7_para-2_überschrift-1_point_8">als Kapitän entgegen <akn:ref GUID="e8969fa0-1c48-4a2f-b067-a71e169bc081" eId="hauptteil-7_para-2_überschrift-1_point_8_ref-1" href="">Artikel 4 Absatz 1</akn:ref> eine Fangerlaubnis und eine beglaubigte Kopie nicht mitführt oder nicht, nicht richtig oder nicht rechtzeitig vorlegt,</akn:p>
-                                                            </akn:point>
+                                                            <akn:p eId="hauptteil-7_para-2_überschrift-1_abs-2">
+                                                                Ordnungswidrig im Sinne des <akn:ref GUID="b201b51f-658b-4d14-b926-ab6c64b38531" eId="hauptteil-7_para-2_überschrift-1_abs-2_ref-1" href="">§ 18 Absatz 2 Nummer 11
+                                                                Buchstabe b des Seefischereigesetzes</akn:ref> handelt, wer gegen
+                                                                die <akn:ref GUID="31ca3795-f849-40b5-af0c-e00d4bb99025" eId="hauptteil-7_para-2_überschrift-1_abs-2_ref-2" href="">Verordnung (EG) Nr. 601/2004</akn:ref> verstößt, indem er
+                                                                vorsätzlich oder fahrlässig
+                                                                <akn:point>
+                                                                    <akn:num>1.</akn:num>
+                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_8">
+                                                                        als Kapitän entgegen <akn:ref GUID="80c4913c-5830-42b1-bcf4-11f9661f2612" eId="hauptteil-7_para-2_überschrift-1_point_8_ref-1" href="">Artikel 4 Absatz 1</akn:ref> eine
+                                                                        Fangerlaubnis und eine beglaubigte Kopie nicht
+                                                                        mitführt oder nicht, nicht richtig oder nicht
+                                                                        rechtzeitig vorlegt,
+                                                                    </akn:p>
+                                                                </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>2.</akn:num>
-                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_9">als Kapitän entgegen <akn:ref GUID="4f220bea-19e7-4a9c-a0fe-54b81bfa14a0" eId="hauptteil-7_para-2_überschrift-1_point_9_ref-1" href="">Artikel 9 Absatz 1</akn:ref> eine Angabe nicht, nicht richtig, nicht vollständig oder nicht rechtzeitig macht,</akn:p>
+                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_9">
+                                                                        als Kapitän entgegen <akn:ref GUID="45635062-fec0-4e0d-ac87-48f9f5fe3287" eId="hauptteil-7_para-2_überschrift-1_point_9_ref-1" href="">Artikel 9 Absatz 1</akn:ref> eine
+                                                                        Angabe nicht, nicht richtig, nicht vollständig
+                                                                        oder nicht rechtzeitig macht,
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>3.</akn:num>
-                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_10">als Kapitän entgegen <akn:ref GUID="47e66767-341c-400a-bf7f-12deb8b95d04" eId="hauptteil-7_para-2_überschrift-1_point_10_ref-1" href="">Artikel 13 Absatz 1</akn:ref> erster Halbsatz, <akn:ref GUID="f2ea3791-ee5b-46d7-8bb3-6e2d01c420ce" eId="hauptteil-7_para-2_überschrift-1_point_10_ref-2" href="">Artikel 14 Absatz 1</akn:ref>, <akn:ref GUID="2f876345-7ed5-45b9-b6db-0c00111d8a77" eId="hauptteil-7_para-2_überschrift-1_point_10_ref-3" href="">Artikel 17 Absatz 1</akn:ref>, <akn:ref GUID="d28de7bd-cbcb-49f7-8194-da93589dc893" eId="hauptteil-7_para-2_überschrift-1_point_10_ref-4" href="">Artikel 18 Absatz 1</akn:ref> oder <akn:ref GUID="cbf1d0e5-d175-4f23-808a-b588423a482d" eId="hauptteil-7_para-2_überschrift-1_point_10_ref-5" href="">Artikel 19 Absatz 1 Satz 1</akn:ref> die dort genannten Daten oder eine dort genannte Angabe nicht, nicht richtig, nicht vollständig, nicht in der vorgeschriebenen Weise oder nicht rechtzeitig übermittelt,</akn:p>
+                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_10">
+                                                                        als Kapitän entgegen <akn:ref GUID="340a2420-9520-4f9d-a312-e56aa0ba811f" eId="hauptteil-7_para-2_überschrift-1_point_10_ref-1" href="">Artikel 13 Absatz 1</akn:ref> erster
+                                                                        Halbsatz, <akn:ref GUID="3ee56202-934e-42f6-b9f0-9835537633c3" eId="hauptteil-7_para-2_überschrift-1_point_10_ref-2" href="">Artikel 14 Absatz 1</akn:ref>, <akn:ref GUID="38a01d73-1aef-4ffb-8c09-d9a49df98d46" eId="hauptteil-7_para-2_überschrift-1_point_10_ref-3" href="">Artikel 17 Absatz
+                                                                        1</akn:ref>, <akn:ref GUID="3611b55b-ac35-4fb4-8c47-4b888f539c1d" eId="hauptteil-7_para-2_überschrift-1_point_10_ref-4" href="">Artikel 18 Absatz 1</akn:ref> oder <akn:ref GUID="37abaa31-6034-4f86-8920-5c7ff9626176" eId="hauptteil-7_para-2_überschrift-1_point_10_ref-5" href="">Artikel 19 Absatz 1
+                                                                        Satz 1</akn:ref> die dort genannten Daten oder eine dort
+                                                                        genannte Angabe nicht, nicht richtig, nicht
+                                                                        vollständig, nicht in der vorgeschriebenen Weise
+                                                                        oder nicht rechtzeitig übermittelt,
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>4.</akn:num>
-                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_11">als Kapitän entgegen <akn:ref GUID="021eadf9-8dd3-4d83-aa24-13b48493ac6d" eId="hauptteil-7_para-2_überschrift-1_point_11_ref-1" href="">Artikel 24 Absatz 2 Satz 1</akn:ref> einer dort genannten Person das Übersetzen nicht oder nicht richtig gestattet oder</akn:p>
+                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_11">
+                                                                        als Kapitän entgegen <akn:ref GUID="7418e015-8f18-4c3c-933d-982aed9a0495" eId="hauptteil-7_para-2_überschrift-1_point_11_ref-1" href="">Artikel 24 Absatz 2 Satz 1</akn:ref>
+                                                                        einer dort genannten Person das Übersetzen nicht
+                                                                        oder nicht richtig gestattet oder
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>5.</akn:num>
-                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_12">als Kapitän entgegen <akn:ref GUID="e624e773-5aa6-43da-afe1-e734ddf7f9d9" eId="hauptteil-7_para-2_überschrift-1_point_12_ref-1" href="">Artikel 27 Absatz 2 Satz 1</akn:ref> eine Anmeldung nicht oder nicht rechtzeitig macht oder eine Erklärung nicht, nicht richtig, nicht vollständig oder nicht rechtzeitig abgibt.</akn:p>
+                                                                    <akn:p eId="hauptteil-7_para-2_überschrift-1_point_12">
+                                                                        als Kapitän entgegen <akn:ref GUID="a7c2129d-ee2d-48c0-86ed-7af5e4280794" eId="hauptteil-7_para-2_überschrift-1_point_12_ref-1" href="">Artikel 27 Absatz 2 Satz 1</akn:ref>
+                                                                        eine Anmeldung nicht oder nicht rechtzeitig
+                                                                        macht oder eine Erklärung nicht, nicht richtig,
+                                                                        nicht vollständig oder nicht rechtzeitig abgibt.
+                                                                    </akn:p>
                                                                 </akn:point>
                                                             </akn:p>
                                                         </akn:p>
@@ -375,32 +626,65 @@
                                             <akn:paragraph GUID="c0a4c9d2-dc0d-4b59-be88-7663f1e32bae" eId="hauptteil-8_para-2_abs-1">
                                                 <akn:content GUID="0f24a464-a987-4eab-be22-2badb8cc3321" eId="hauptteil-8_para-2_abs-1_inhalt-1">
 
-                                                    <akn:heading GUID="e696f540-586c-4725-ae49-654bb28918ab" eId="hauptteil-8_para-2_überschrift-1"><akn:ref GUID="a85583dc-359c-45f1-873a-b959dcf16400" eId="hauptteil-8_para-2_überschrift-1_ref-1" href="">§ 12</akn:ref> Durchsetzung bestimmter Vorschriften der <akn:ref GUID="74479169-e3c6-4be3-a77a-3c8427bd5508" eId="hauptteil-8_para-2_überschrift-1_ref-2" href="">Verordnung (EG) Nr. 734/2008</akn:ref></akn:heading>
+                                                    <akn:heading GUID="e696f540-586c-4725-ae49-654bb28918ab" eId="hauptteil-8_para-2_überschrift-1">
+                                                        <akn:ref GUID="e8a8b7d0-dffb-40b8-889c-d200f234703a" eId="hauptteil-8_para-2_überschrift-1_ref-1" href="">§ 12</akn:ref> Durchsetzung bestimmter Vorschriften der <akn:ref GUID="eb1bc52f-985e-4bbf-86a9-d0e11b9ea3eb" eId="hauptteil-8_para-2_überschrift-1_ref-2" href="">Verordnung (EG)
+                                                        Nr. 734/2008</akn:ref>
+                                                    </akn:heading>
                                                     <akn:list eId="hauptteil-8_para-2_text-1">
                                                         <akn:p>
                                                             <akn:num>(1)</akn:num>
-                                                            <akn:p eId="hauptteil-8_para-2_überschrift-1_abs-1">Ordnungswidrig im Sinne des <akn:ref GUID="524e9489-d660-4f73-a417-e53a1c3251a7" eId="hauptteil-8_para-2_überschrift-1_abs-1_ref-1" href="">§ 18 Absatz 2 Nummer 11 Buchstabe a des Seefischereigesetzes</akn:ref> handelt, wer gegen die <akn:ref GUID="daff154a-815a-4c64-aa96-1a135e249892" eId="hauptteil-8_para-2_überschrift-1_abs-1_ref-2" href="">Verordnung (EG) Nr. 734/2008 des Rates vom 15. Juli 2008 zum Schutz empfindlicher Tiefseeökosysteme vor den schädlichen Auswirkungen von Grundfanggeräten (ABl. L 201 vom 30.7.2008, S. 8)</akn:ref> verstößt, indem er vorsätzlich oder fahrlässig<akn:point>
-                                                                <akn:num>1.</akn:num>
-                                                                <akn:p eId="hauptteil-8_para-2_überschrift-1_point_1">ohne Fangerlaubnis nach <akn:ref GUID="f6cc7d7e-ef1b-43ca-9e1b-2f30e8e3f3ae" eId="hauptteil-8_para-2_überschrift-1_point_1_ref-1" href="">Artikel 3 Absatz 1</akn:ref> eine Fischereitätigkeit ausführt,</akn:p>
-                                                            </akn:point>
+                                                            <akn:p eId="hauptteil-8_para-2_überschrift-1_abs-1">
+                                                                Ordnungswidrig im Sinne des <akn:ref GUID="bd872fb5-8e6d-43e7-a37a-39df9ed2dc4a" eId="hauptteil-8_para-2_überschrift-1_abs-1_ref-1" href="">§ 18 Absatz 2 Nummer 11
+                                                                Buchstabe a des Seefischereigesetzes</akn:ref> handelt, wer gegen
+                                                                die <akn:ref GUID="e0c2052f-0c42-47cb-8805-a1f52b1eff0e" eId="hauptteil-8_para-2_überschrift-1_abs-1_ref-2" href="">Verordnung (EG) Nr. 734/2008 des Rates vom 15. Juli
+                                                                2008 zum Schutz empfindlicher Tiefseeökosysteme vor den
+                                                                schädlichen Auswirkungen von Grundfanggeräten (ABl. L
+                                                                201 vom 30.7.2008, S. 8)</akn:ref> verstößt, indem er vorsätzlich
+                                                                oder fahrlässig
+                                                                <akn:point>
+                                                                    <akn:num>1.</akn:num>
+                                                                    <akn:p eId="hauptteil-8_para-2_überschrift-1_point_1">
+                                                                        ohne Fangerlaubnis nach <akn:ref GUID="95427c56-7815-463e-823d-4e9442b3f43a" eId="hauptteil-8_para-2_überschrift-1_point_1_ref-1" href="">Artikel 3 Absatz 1</akn:ref> eine
+                                                                        Fischereitätigkeit ausführt,
+                                                                    </akn:p>
+                                                                </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>2.</akn:num>
-                                                                    <akn:p eId="hauptteil-8_para-2_überschrift-1_point_2">als Kapitän entgegen <akn:ref GUID="f7e4335e-6297-4072-9cad-75df694b9841" eId="hauptteil-8_para-2_überschrift-1_point_2_ref-1" href="">Artikel 7 Absatz 1 Satz 1</akn:ref> eine Fischereitätigkeit nicht, nicht richtig, nicht vollständig oder nicht rechtzeitig einstellt,</akn:p>
+                                                                    <akn:p eId="hauptteil-8_para-2_überschrift-1_point_2">
+                                                                        als Kapitän entgegen <akn:ref GUID="547ecc7b-f44a-482b-8f18-56612a22f327" eId="hauptteil-8_para-2_überschrift-1_point_2_ref-1" href="">Artikel 7 Absatz 1 Satz 1</akn:ref>
+                                                                        eine Fischereitätigkeit nicht, nicht richtig,
+                                                                        nicht vollständig oder nicht rechtzeitig
+                                                                        einstellt,
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>3.</akn:num>
-                                                                    <akn:p eId="hauptteil-8_para-2_überschrift-1_point_3">entgegen <akn:ref GUID="77a2467b-ccfe-45a0-b689-b1594d042882" eId="hauptteil-8_para-2_überschrift-1_point_3_ref-1" href="">Artikel 7 Absatz 1 Satz 2</akn:ref> eine Fischereitätigkeit wieder aufnimmt oder</akn:p>
+                                                                    <akn:p eId="hauptteil-8_para-2_überschrift-1_point_3">
+                                                                        entgegen <akn:ref GUID="494a0f23-2c5a-48c6-9d61-aa1cf872deb3" eId="hauptteil-8_para-2_überschrift-1_point_3_ref-1" href="">Artikel 7 Absatz 1 Satz 2</akn:ref> eine
+                                                                        Fischereitätigkeit wieder aufnimmt oder
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>4.</akn:num>
-                                                                    <akn:p eId="hauptteil-8_para-2_überschrift-1_point_4">als Kapitän entgegen <akn:ref GUID="17309d94-91a2-4f7f-948e-2132425b69e2" eId="hauptteil-8_para-2_überschrift-1_point_4_ref-1" href="">Artikel 9 Absatz 2</akn:ref> den Hafen wieder verlässt.</akn:p>
+                                                                    <akn:p eId="hauptteil-8_para-2_überschrift-1_point_4">
+                                                                        als Kapitän entgegen <akn:ref GUID="42ae5ed6-36dc-4da2-ba89-1ba095497e79" eId="hauptteil-8_para-2_überschrift-1_point_4_ref-1" href="">Artikel 9 Absatz 2</akn:ref> den
+                                                                        Hafen wieder verlässt.
+                                                                    </akn:p>
                                                                 </akn:point>
 
                                                             </akn:p>
                                                         </akn:p>
                                                         <akn:p>
                                                             <akn:num>(2)</akn:num>
-                                                            <akn:p eId="hauptteil-8_para-2_überschrift-1_abs-2">Ordnungswidrig im Sinne des <akn:ref GUID="99b0836b-abad-4ad0-9694-b3ae472770ca" eId="hauptteil-8_para-2_überschrift-1_abs-2_ref-1" href="">§ 18 Absatz 2 Nummer 11 Buchstabe b des Seefischereigesetzes</akn:ref> handelt, wer vorsätzlich oder fahrlässig als Kapitän entgegen <akn:ref GUID="ee08f1cd-222f-47ac-acc9-a845e43a7ae7" eId="hauptteil-8_para-2_überschrift-1_abs-2_ref-2" href="">Artikel 5 Absatz 2 Satz 1</akn:ref>, <akn:ref GUID="01186ac1-90da-418e-8e8c-00f39d12eb20" eId="hauptteil-8_para-2_überschrift-1_abs-2_ref-3" href="">Artikel 7 Absatz 3</akn:ref> oder <akn:ref GUID="d579f2e9-b446-4218-985a-ab661cec07c8" eId="hauptteil-8_para-2_überschrift-1_abs-2_ref-4" href="">Artikel 9 Absatz 1</akn:ref> der <akn:ref GUID="a8e633ae-c852-47c9-9550-c14c58670478" eId="hauptteil-8_para-2_überschrift-1_abs-2_ref-5" href="">Verordnung (EG) Nr. 734/2008</akn:ref> eine Mitteilung nicht, nicht richtig, nicht vollständig oder nicht rechtzeitig macht.</akn:p>
+                                                            <akn:p eId="hauptteil-8_para-2_überschrift-1_abs-2">
+                                                                Ordnungswidrig im Sinne des <akn:ref GUID="54d8710d-71e2-4a31-b566-634d900a62e0" eId="hauptteil-8_para-2_überschrift-1_abs-2_ref-1" href="">§ 18 Absatz 2 Nummer 11
+                                                                Buchstabe b des Seefischereigesetzes</akn:ref> handelt, wer
+                                                                vorsätzlich oder fahrlässig als Kapitän entgegen <akn:ref GUID="435e3cb8-7600-4600-bfba-03a1de6b5ff8" eId="hauptteil-8_para-2_überschrift-1_abs-2_ref-2" href="">Artikel
+                                                                5 Absatz 2 Satz 1</akn:ref>, <akn:ref GUID="c4df6daa-67e2-4bba-8eb7-414ab7fb5e28" eId="hauptteil-8_para-2_überschrift-1_abs-2_ref-3" href="">Artikel 7 Absatz 3</akn:ref> oder <akn:ref GUID="b7a69f62-9e1a-4a3e-bb8b-f888873a2f66" eId="hauptteil-8_para-2_überschrift-1_abs-2_ref-4" href="">Artikel 9
+                                                                Absatz 1</akn:ref> der <akn:ref GUID="93a2f24f-7947-4b9f-8acd-344a990cdfba" eId="hauptteil-8_para-2_überschrift-1_abs-2_ref-5" href="">Verordnung (EG) Nr. 734/2008</akn:ref> eine
+                                                                Mitteilung nicht, nicht richtig, nicht vollständig oder
+                                                                nicht rechtzeitig macht.
+                                                            </akn:p>
                                                         </akn:p>
                                                     </akn:list>
                                                 </akn:content>
@@ -409,73 +693,147 @@
                                             <akn:paragraph GUID="c0a4c9d2-dc0d-4b59-be88-7663f1e32bae" eId="hauptteil-9_para-2_abs-1">
                                                 <akn:content GUID="0f24a464-a987-4eab-be22-2badb8cc3321" eId="hauptteil-9_para-2_abs-1_inhalt-1">
 
-                                                    <akn:heading GUID="e696f540-586c-4725-ae49-654bb28918ab" eId="hauptteil-9_para-2_überschrift-1"><akn:ref GUID="3e7d0986-a2e9-4eb1-a5c3-707ba867a321" eId="hauptteil-9_para-2_überschrift-1_ref-1" href="">§ 13</akn:ref> Durchsetzung bestimmter Vorschriften der <akn:ref GUID="7b67a5d8-42c1-445f-8ff1-8bde6de09113" eId="hauptteil-9_para-2_überschrift-1_ref-2" href="">Verordnung (EG) Nr. 1005/2008</akn:ref></akn:heading>
+                                                    <akn:heading GUID="e696f540-586c-4725-ae49-654bb28918ab" eId="hauptteil-9_para-2_überschrift-1">
+                                                        <akn:ref GUID="f1402eef-5b81-4c53-a82b-2390cb54ebb2" eId="hauptteil-9_para-2_überschrift-1_ref-1" href="">§ 13</akn:ref> Durchsetzung bestimmter Vorschriften der <akn:ref GUID="4612f820-967a-4edb-8142-eab660673e32" eId="hauptteil-9_para-2_überschrift-1_ref-2" href="">Verordnung (EG)
+                                                        Nr. 1005/2008</akn:ref>
+                                                    </akn:heading>
                                                     <akn:list eId="hauptteil-9_para-2_text-1">
                                                         <akn:p>
                                                             <akn:num>(1)</akn:num>
-                                                            <akn:p eId="hauptteil-9_para-2_überschrift-1_abs-1">Ordnungswidrig im Sinne des <akn:ref GUID="99cd46e0-0bb5-40cb-a54c-0327e816f68d" eId="hauptteil-9_para-2_überschrift-1_abs-1_ref-1" href="">§ 18 Absatz 2 Nummer 11 Buchstabe a des Seefischereigesetzes</akn:ref> handelt, wer gegen die <akn:ref GUID="ab1d12e4-c701-4114-b837-56d1eb3d6190" eId="hauptteil-9_para-2_überschrift-1_abs-1_ref-2" href="">Verordnung (EG) Nr. 1005/2008</akn:ref> des Rates vom 29. September 2008 über ein Gemeinschaftssystem zur Verhinderung, Bekämpfung und Unterbindung der illegalen, nicht gemeldeten und unregulierten Fischerei, zur Änderung der <akn:ref GUID="baa50793-d43c-4f78-a2c2-663b69c109b8" eId="hauptteil-9_para-2_überschrift-1_abs-1_ref-3" href="">Verordnungen (EWG) Nr. 2847/93</akn:ref><akn:ref GUID="6d5fe202-0596-4aa7-b01e-a306cc6c43fd" eId="hauptteil-9_para-2_überschrift-1_abs-1_ref-4" href="">, (EG) Nr. 1936/2001</akn:ref><akn:ref GUID="bc8ea20b-9559-4d46-9178-bf2847ada17c" eId="hauptteil-9_para-2_überschrift-1_abs-1_ref-5" href="">und (EG) Nr. 601/2004</akn:ref> und zur Aufhebung der <akn:ref GUID="cb3b6799-a9a4-40f4-ae8f-2acc32feea25" eId="hauptteil-9_para-2_überschrift-1_abs-1_ref-6" href="">Verordnungen (EG) Nr. 1093/94</akn:ref><akn:ref GUID="c0df6c64-14a5-4be7-9771-2f39dd1dfbff" eId="hauptteil-9_para-2_überschrift-1_abs-1_ref-7" href="">und (EG) Nr. 1447/1999</akn:ref> (ABl. L 286 vom 29.10.2008, S. 1; L 22 vom 26.1.2011, S. 8), die zuletzt durch die <akn:ref GUID="48245149-0052-4797-a6e4-e334a3d958a0" eId="hauptteil-9_para-2_überschrift-1_abs-1_ref-8" href="">Verordnung (EU) 2023/2842</akn:ref> (ABl. L, 2023/2842, 20.12.2023) geändert worden ist, verstößt, indem er vorsätzlich oder fahrlässig<akn:point>
-                                                                <akn:num>1.</akn:num>
-                                                                <akn:p eId="hauptteil-9_para-2_überschrift-1_point_1">entgegen <akn:ref GUID="60f6bbe2-c42e-4ad5-952e-2988ef886893" eId="hauptteil-9_para-2_überschrift-1_point_1_ref-1" href="">Artikel 4 Absatz 3</akn:ref> in Gemeinschaftsgewässern umlädt,</akn:p>
-                                                            </akn:point>
+                                                            <akn:p eId="hauptteil-9_para-2_überschrift-1_abs-1">
+                                                                Ordnungswidrig im Sinne des <akn:ref GUID="d6037eaa-4525-4377-b614-b735870aa740" eId="hauptteil-9_para-2_überschrift-1_abs-1_ref-1" href="">§ 18 Absatz 2 Nummer 11
+                                                                Buchstabe a des Seefischereigesetzes</akn:ref> handelt, wer gegen
+                                                                die <akn:ref GUID="bbdca155-2579-45fb-bb25-871482b5660b" eId="hauptteil-9_para-2_überschrift-1_abs-1_ref-2" href="">Verordnung (EG) Nr. 1005/2008</akn:ref> des Rates vom 29.
+                                                                September 2008 über ein Gemeinschaftssystem zur
+                                                                Verhinderung, Bekämpfung und Unterbindung der illegalen,
+                                                                nicht gemeldeten und unregulierten Fischerei, zur
+                                                                Änderung der <akn:ref GUID="0ad41091-8d64-415b-a2cd-1b46f47f3c99" eId="hauptteil-9_para-2_überschrift-1_abs-1_ref-3" href="">Verordnungen (EWG) Nr. 2847/93</akn:ref><akn:ref GUID="48e45f0b-5687-4d41-9b02-43545c17124d" eId="hauptteil-9_para-2_überschrift-1_abs-1_ref-4" href="">, (EG) Nr.
+                                                                1936/2001</akn:ref> <akn:ref GUID="25c1d5a6-706f-4bd3-a088-6f02e8fe9513" eId="hauptteil-9_para-2_überschrift-1_abs-1_ref-5" href="">und (EG) Nr. 601/2004</akn:ref> und zur Aufhebung der
+                                                                <akn:ref GUID="87a00ed1-0312-45c6-ac79-a467d1fca315" eId="hauptteil-9_para-2_überschrift-1_abs-1_ref-6" href="">Verordnungen (EG) Nr. 1093/94</akn:ref> <akn:ref GUID="982ccedc-bdae-4330-87a1-f6cd10c51f90" eId="hauptteil-9_para-2_überschrift-1_abs-1_ref-7" href="">und (EG) Nr. 1447/1999</akn:ref>
+                                                                (ABl. L 286 vom 29.10.2008, S. 1; L 22 vom 26.1.2011, S.
+                                                                8), die zuletzt durch die <akn:ref GUID="cc4e28df-2201-4603-b1dc-8cb2e0f9e3f1" eId="hauptteil-9_para-2_überschrift-1_abs-1_ref-8" href="">Verordnung (EU) 2023/2842</akn:ref>
+                                                                (ABl. L, 2023/2842, 20.12.2023) geändert worden ist,
+                                                                verstößt, indem er vorsätzlich oder fahrlässig
+                                                                <akn:point>
+                                                                    <akn:num>1.</akn:num>
+                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_1">
+                                                                        entgegen <akn:ref GUID="e059d19c-ff99-4f19-9444-71c828a83751" eId="hauptteil-9_para-2_überschrift-1_point_1_ref-1" href="">Artikel 4 Absatz 3</akn:ref> in
+                                                                        Gemeinschaftsgewässern umlädt,
+                                                                    </akn:p>
+                                                                </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>2.</akn:num>
-                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_2">als Kapitän entgegen <akn:ref GUID="b50a86b2-781c-4470-ba21-a64c6d2b5f73" eId="hauptteil-9_para-2_überschrift-1_point_2_ref-1" href="">Artikel 4 Absatz 4</akn:ref> einen Fang umlädt,</akn:p>
+                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_2">
+                                                                        als Kapitän entgegen <akn:ref GUID="d37944a9-1d1a-4740-b539-bc462e8e73f0" eId="hauptteil-9_para-2_überschrift-1_point_2_ref-1" href="">Artikel 4 Absatz 4</akn:ref> einen
+                                                                        Fang umlädt,
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>3.</akn:num>
-                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_3">entgegen <akn:ref GUID="3746558d-cd7c-4a39-9075-a5ed6f83b89b" eId="hauptteil-9_para-2_überschrift-1_point_3_ref-1" href="">Artikel 12 Absatz 1 oder 2</akn:ref> ein Fischereierzeugnis einführt,</akn:p>
+                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_3">
+                                                                        entgegen <akn:ref GUID="1b1071db-bd5c-4ca6-9d76-3d9f37ffacf8" eId="hauptteil-9_para-2_überschrift-1_point_3_ref-1" href="">Artikel 12 Absatz 1 oder 2</akn:ref> ein
+                                                                        Fischereierzeugnis einführt,
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>4.</akn:num>
-                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_4">entgegen <akn:ref GUID="1dd7fe2a-fd9a-41c1-bbb7-a278997d2c0a" eId="hauptteil-9_para-2_überschrift-1_point_4_ref-1" href="">Artikel 37 Nummer 3</akn:ref> ein dort genanntes Fischereifahrzeug chartert,</akn:p>
+                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_4">
+                                                                        entgegen <akn:ref GUID="7943af4d-6d18-46bd-8f09-18facd50996a" eId="hauptteil-9_para-2_überschrift-1_point_4_ref-1" href="">Artikel 37 Nummer 3</akn:ref> ein dort genanntes
+                                                                        Fischereifahrzeug chartert,
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>5.</akn:num>
-                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_5">als Kapitän entgegen <akn:ref GUID="bf0f001b-bb6c-4e96-8697-c2b8dc98beb4" eId="hauptteil-9_para-2_überschrift-1_point_5_ref-1" href="">Artikel 37 Nummer 4</akn:ref> eine Fischverarbeitungstätigkeit übernimmt oder sich an einer Umladung oder einem Fangeinsatz beteiligt,</akn:p>
+                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_5">
+                                                                        als Kapitän entgegen <akn:ref GUID="1926adfb-3c6b-48fe-8ec0-9421da4b5da6" eId="hauptteil-9_para-2_überschrift-1_point_5_ref-1" href="">Artikel 37 Nummer 4</akn:ref> eine
+                                                                        Fischverarbeitungstätigkeit übernimmt oder sich
+                                                                        an einer Umladung oder einem Fangeinsatz
+                                                                        beteiligt,
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>6.</akn:num>
-                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_6">entgegen <akn:ref GUID="e01f966d-9538-462b-b006-aa24fa5d9378" eId="hauptteil-9_para-2_überschrift-1_point_6_ref-1" href="">Artikel 37 Nummer 5 Satz 2</akn:ref> in einen Hafen einläuft,</akn:p>
+                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_6">
+                                                                        entgegen <akn:ref GUID="c12090a1-c677-45cb-aa88-e87865f849cb" eId="hauptteil-9_para-2_überschrift-1_point_6_ref-1" href="">Artikel 37 Nummer 5 Satz 2</akn:ref> in einen
+                                                                        Hafen einläuft,
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>7.</akn:num>
-                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_7">entgegen <akn:ref GUID="fad3a1a9-1e1a-455a-be37-27740aa610e0" eId="hauptteil-9_para-2_überschrift-1_point_7_ref-1" href="">Artikel 38 Nummer 2</akn:ref> ein dort genanntes Fischereierfahrzeug erwirbt,</akn:p>
+                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_7">
+                                                                        entgegen <akn:ref GUID="7a742605-6946-4fc4-9e3e-0d6b81747553" eId="hauptteil-9_para-2_überschrift-1_point_7_ref-1" href="">Artikel 38 Nummer 2</akn:ref> ein dort genanntes
+                                                                        Fischereierfahrzeug erwirbt,
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>8.</akn:num>
-                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_8">entgegen <akn:ref GUID="6ade0482-f0ad-47f5-a9a3-e686cb3b7f85" eId="hauptteil-9_para-2_überschrift-1_point_8_ref-1" href="">Artikel 38 Nummer 3</akn:ref> ein dort genanntes Fischereifahrzeug umflaggt,</akn:p>
+                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_8">
+                                                                        entgegen <akn:ref GUID="8a451942-6c35-423d-aeab-b0e9e0b20588" eId="hauptteil-9_para-2_überschrift-1_point_8_ref-1" href="">Artikel 38 Nummer 3</akn:ref> ein dort genanntes
+                                                                        Fischereifahrzeug umflaggt,
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>9.</akn:num>
-                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_9">entgegen <akn:ref GUID="d7208448-6335-41be-acf3-c7d0a47eb6d2" eId="hauptteil-9_para-2_überschrift-1_point_9_ref-1" href="">Artikel 38 Nummer 5</akn:ref> ein dort genanntes Fischereifahrzeug ausführt,</akn:p>
+                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_9">
+                                                                        entgegen <akn:ref GUID="63d56be2-20f4-4b5a-b75b-a1fd08f12354" eId="hauptteil-9_para-2_überschrift-1_point_9_ref-1" href="">Artikel 38 Nummer 5</akn:ref> ein dort genanntes
+                                                                        Fischereifahrzeug ausführt,
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>10.</akn:num>
-                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_10">entgegen <akn:ref GUID="0b21e508-ed45-48ec-80e3-80413c1b9ae6" eId="hauptteil-9_para-2_überschrift-1_point_10_ref-1" href="">Artikel 38 Nummer 10</akn:ref> ein Fischereifahrzeug betreibt, besitzt oder managt,</akn:p>
+                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_10">
+                                                                        entgegen <akn:ref GUID="1147f3e8-5596-468d-8cc9-18794b7f3cbd" eId="hauptteil-9_para-2_überschrift-1_point_10_ref-1" href="">Artikel 38 Nummer 10</akn:ref> ein
+                                                                        Fischereifahrzeug betreibt, besitzt oder managt,
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>11.</akn:num>
-                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_11">entgegen <akn:ref GUID="504021e9-c9fc-42a7-9eec-9ea5ddf32f0a" eId="hauptteil-9_para-2_überschrift-1_point_11_ref-1" href="">Artikel 38 Nummer 11</akn:ref> anlandet oder umlädt oder</akn:p>
+                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_11">
+                                                                        entgegen <akn:ref GUID="b85d6abd-48ef-44bc-92c8-9d72ff215f68" eId="hauptteil-9_para-2_überschrift-1_point_11_ref-1" href="">Artikel 38 Nummer 11</akn:ref> anlandet oder
+                                                                        umlädt oder
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>12.</akn:num>
-                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_12">entgegen <akn:ref GUID="5ce64cff-3a0a-4ffe-ad7b-37fd0091cca2" eId="hauptteil-9_para-2_überschrift-1_point_12_ref-1" href="">Artikel 40 Absatz 2</akn:ref> ein Fischereifahrzeug verkauft oder exportiert.</akn:p>
+                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_12">
+                                                                        entgegen <akn:ref GUID="2db700c4-831c-4fa5-8496-0e2e0228bac7" eId="hauptteil-9_para-2_überschrift-1_point_12_ref-1" href="">Artikel 40 Absatz 2</akn:ref> ein
+                                                                        Fischereifahrzeug verkauft oder exportiert.
+                                                                    </akn:p>
                                                                 </akn:point>
                                                             </akn:p>
                                                         </akn:p>
                                                         <akn:p>
                                                             <akn:num>(2)</akn:num>
-                                                            <akn:p eId="hauptteil-9_para-2_überschrift-1_abs-2">Ordnungswidrig im Sinne des <akn:ref GUID="0d8827bf-43c8-41a7-b20d-a58803339dc9" eId="hauptteil-9_para-2_überschrift-1_abs-2_ref-1" href="">§ 18 Absatz 2 Nummer 11 Buchstabe b des Seefischereigesetzes</akn:ref> handelt, wer gegen die <akn:ref GUID="ba937ef7-0e20-4cfd-9cd3-c7642e5f6973" eId="hauptteil-9_para-2_überschrift-1_abs-2_ref-2" href="">Verordnung (EG) Nr. 1005/2008</akn:ref> verstößt, indem er vorsätzlich oder fahrlässig<akn:point>
-                                                                <akn:num>1.</akn:num>
-                                                                <akn:p eId="hauptteil-9_para-2_überschrift-1_point_28">entgegen <akn:ref GUID="f0487d27-d2d3-496b-bf63-9c79ecad8e09" eId="hauptteil-9_para-2_überschrift-1_point_28_ref-1" href="">Artikel 14 Absatz 1 Unterabsatz 1</akn:ref> Satz 1 Buchstabe a oder b eine dort genannte Unterlage nicht, nicht richtig, nicht vollständig, nicht in der vorgeschriebenen Weise oder nicht rechtzeitig vorlegt,</akn:p>
-                                                            </akn:point>
+                                                            <akn:p eId="hauptteil-9_para-2_überschrift-1_abs-2">
+                                                                Ordnungswidrig im Sinne des <akn:ref GUID="2e9fdfb4-099c-4564-816f-013517cc5b09" eId="hauptteil-9_para-2_überschrift-1_abs-2_ref-1" href="">§ 18 Absatz 2 Nummer 11
+                                                                Buchstabe b des Seefischereigesetzes</akn:ref> handelt, wer gegen
+                                                                die <akn:ref GUID="5da85793-2a22-4b19-bbff-2c8f188ef38c" eId="hauptteil-9_para-2_überschrift-1_abs-2_ref-2" href="">Verordnung (EG) Nr. 1005/2008</akn:ref> verstößt, indem er
+                                                                vorsätzlich oder fahrlässig
+                                                                <akn:point>
+                                                                    <akn:num>1.</akn:num>
+                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_28">
+                                                                        entgegen <akn:ref GUID="7525ab3c-ce20-4aea-8cd9-d4b97b7e997d" eId="hauptteil-9_para-2_überschrift-1_point_28_ref-1" href="">Artikel 14 Absatz 1 Unterabsatz 1</akn:ref> Satz
+                                                                        1 Buchstabe a oder b eine dort genannte
+                                                                        Unterlage nicht, nicht richtig, nicht
+                                                                        vollständig, nicht in der vorgeschriebenen Weise
+                                                                        oder nicht rechtzeitig vorlegt,
+                                                                    </akn:p>
+                                                                </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>2.</akn:num>
-                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_29">entgegen <akn:ref GUID="7aa0a062-9d74-4042-a490-b8ba382ec22b" eId="hauptteil-9_para-2_überschrift-1_point_29_ref-1" href="">Artikel 14 Absatz 2 Satz 1</akn:ref> eine dort genannte Erklärung nicht, nicht richtig, nicht vollständig oder nicht rechtzeitig vorlegt oder</akn:p>
+                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_29">
+                                                                        entgegen <akn:ref GUID="c16e0843-7ac4-454b-aea6-fc60110db78e" eId="hauptteil-9_para-2_überschrift-1_point_29_ref-1" href="">Artikel 14 Absatz 2 Satz 1</akn:ref> eine dort
+                                                                        genannte Erklärung nicht, nicht richtig, nicht
+                                                                        vollständig oder nicht rechtzeitig vorlegt oder
+                                                                    </akn:p>
                                                                 </akn:point>
                                                                 <akn:point>
                                                                     <akn:num>3.</akn:num>
-                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_30">entgegen <akn:ref GUID="5bb3e0bf-9619-4b26-a920-918c962bcf5d" eId="hauptteil-9_para-2_überschrift-1_point_30_ref-1" href="">Artikel 16 Absatz 1 Satz 1</akn:ref> eine validierte Fangbescheinigung nicht, nicht richtig oder nicht rechtzeitig vorlegt.</akn:p>
+                                                                    <akn:p eId="hauptteil-9_para-2_überschrift-1_point_30">
+                                                                        entgegen <akn:ref GUID="5e23bfec-a580-403d-9420-fd91168d2ffc" eId="hauptteil-9_para-2_überschrift-1_point_30_ref-1" href="">Artikel 16 Absatz 1 Satz 1</akn:ref> eine
+                                                                        validierte Fangbescheinigung nicht, nicht
+                                                                        richtig oder nicht rechtzeitig vorlegt.
+                                                                    </akn:p>
                                                                 </akn:point>
                                                             </akn:p>
                                                         </akn:p>
@@ -492,7 +850,7 @@
                                 <akn:marker GUID="5d7d54f0-8a4e-4d8f-b5d0-93d0ca393e82" eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_bezeichnung-1_zaehlbez-1" name="2"/>2.</akn:num>
                             <akn:content GUID="6cb14ab5-3a7f-45f4-9e85-00ac2fb0fe5e" eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1">
                                 <akn:p GUID="db3fbe0f-b758-4cc4-b528-a723cacad94a" eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1">
-                                    <akn:mod GUID="148c2f06-6e33-4af8-9f4a-3da67c888510" eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1" refersTo="aenderungsbefehl-ersetzen">In <akn:ref GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206" eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/0-0.xml">§ 20 Absatz 1 Satz 2</akn:ref> wird die Angabe <akn:quotedText GUID="694459c4-ef66-4f87-bb78-a332054a2216" eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-1" endQuote="“" startQuote="„">§ 9 Abs. 1 Satz 2, Abs. 2</akn:quotedText> durch die Wörter <akn:quotedText GUID="dd25bdb6-4ef4-4ef5-808c-27579b6ae196" eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2" endQuote="“" startQuote="„"><akn:ref GUID="6e4cdf50-bdcb-4746-b0d9-efb2d04ea0b7" eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2_ref-1" href="">§ 9 Absatz 1 Satz 2</akn:ref></akn:quotedText> ersetzt.</akn:mod>
+                                    <akn:mod GUID="148c2f06-6e33-4af8-9f4a-3da67c888510" eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1" refersTo="aenderungsbefehl-ersetzen">In <akn:ref GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206" eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/0-0.xml">§ 20 Absatz 1 Satz 2</akn:ref> wird die Angabe <akn:quotedText GUID="694459c4-ef66-4f87-bb78-a332054a2216" eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-1" endQuote="“" startQuote="„">§ 9 Abs. 1 Satz 2, Abs. 2</akn:quotedText> durch die Wörter <akn:quotedText GUID="dd25bdb6-4ef4-4ef5-808c-27579b6ae196" eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2" endQuote="“" startQuote="„"><akn:ref GUID="f177018d-5462-4da5-bb1b-3fe32b0d6e7b" eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2_ref-1" href="">§ 9 Absatz 1 Satz 2</akn:ref></akn:quotedText> ersetzt.</akn:mod>
                                 </akn:p>
                             </akn:content>
                         </akn:point>


### PR DESCRIPTION
In order for the regex to work (as provided as it is from the prototyping sessions) we need to clean the text content of a node. In the first iteration of the reference detection we:
1. Cleaned the text of a node to run the regex pattern
2. Created `akn:ref` nodes out of the matches
3. Inserted the created `akn:ref` nodes into the node that contained the text with the references. In this process we worked on the cleaned text content of the node, since the matches had the start and end indexes in relation to the cleaned text.

This PR introduces changes to this algorithm by respecting the whitespaces, as they were, in the XML nodes. For that:

1. We still need to clean the text content to run the regex pattern.
2. But now a mapping is done between every matched reference and the start and end indexes relative to the original text (including whitespaces).
4. Then the original text content is used to replace the matches with the `akn:ref` nodes, but using the adapted start and end indexes relative to the original text (counting also whitespaces)