### PR TITLE
Switch java formatter to Prettier + format

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -166,7 +166,19 @@ tasks {
 spotless {
     java {
         removeUnusedImports()
-        googleJavaFormat()
+
+        prettier(
+            mapOf(
+                "prettier" to "3.0.3",
+                "prettier-plugin-java" to "2.3.0",
+            ),
+        ).config(
+            mapOf(
+                "parser" to "java",
+                "printWidth" to 100,
+                "plugins" to listOf("prettier-plugin-java"),
+            ),
+        )
     }
 
     kotlinGradle {

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/Generated.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/Generated.java
@@ -17,5 +17,6 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RUNTIME)
-@Target({TYPE, METHOD})
-public @interface Generated {}
+@Target({ TYPE, METHOD })
+public @interface Generated {
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/constraints/UniqueTimeBoundariesDatesConstraintValidator.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/constraints/UniqueTimeBoundariesDatesConstraintValidator.java
@@ -7,11 +7,16 @@ import java.util.List;
 
 /** Validates if TimeBoundary dates are unique */
 public class UniqueTimeBoundariesDatesConstraintValidator
-    implements ConstraintValidator<UniqueTimeBoundariesDatesConstraint, List<TimeBoundarySchema>> {
+  implements ConstraintValidator<UniqueTimeBoundariesDatesConstraint, List<TimeBoundarySchema>> {
+
   @Override
   public boolean isValid(
-      List<TimeBoundarySchema> timeBoundaries, ConstraintValidatorContext context) {
-    return timeBoundaries.stream().map(TimeBoundarySchema::getDate).distinct().count()
-        == timeBoundaries.size();
+    List<TimeBoundarySchema> timeBoundaries,
+    ConstraintValidatorContext context
+  ) {
+    return (
+      timeBoundaries.stream().map(TimeBoundarySchema::getDate).distinct().count() ==
+      timeBoundaries.size()
+    );
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/AnnouncementController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/AnnouncementController.java
@@ -27,19 +27,19 @@ public class AnnouncementController {
 
   private final LoadAllAnnouncementsUseCase loadAllAnnouncementsUseCase;
   private final LoadAnnouncementByNormEliUseCase loadAnnouncementByNormEliUseCase;
-  private final LoadTargetNormsAffectedByAnnouncementUseCase
-      loadTargetNormsAffectedByAnnouncementUseCase;
+  private final LoadTargetNormsAffectedByAnnouncementUseCase loadTargetNormsAffectedByAnnouncementUseCase;
   private final ReleaseAnnouncementUseCase releaseAnnouncementUseCase;
 
   public AnnouncementController(
-      LoadAllAnnouncementsUseCase loadAllAnnouncementsUseCase,
-      LoadAnnouncementByNormEliUseCase loadAnnouncementByNormEliUseCase,
-      LoadTargetNormsAffectedByAnnouncementUseCase loadTargetNormsAffectedByAnnouncementUseCase,
-      ReleaseAnnouncementUseCase releaseAnnouncementUseCase) {
+    LoadAllAnnouncementsUseCase loadAllAnnouncementsUseCase,
+    LoadAnnouncementByNormEliUseCase loadAnnouncementByNormEliUseCase,
+    LoadTargetNormsAffectedByAnnouncementUseCase loadTargetNormsAffectedByAnnouncementUseCase,
+    ReleaseAnnouncementUseCase releaseAnnouncementUseCase
+  ) {
     this.loadAllAnnouncementsUseCase = loadAllAnnouncementsUseCase;
     this.loadAnnouncementByNormEliUseCase = loadAnnouncementByNormEliUseCase;
     this.loadTargetNormsAffectedByAnnouncementUseCase =
-        loadTargetNormsAffectedByAnnouncementUseCase;
+    loadTargetNormsAffectedByAnnouncementUseCase;
     this.releaseAnnouncementUseCase = releaseAnnouncementUseCase;
   }
 
@@ -53,11 +53,12 @@ public class AnnouncementController {
    */
   @GetMapping(produces = APPLICATION_JSON_VALUE)
   public ResponseEntity<List<NormResponseSchema>> getAllAnnouncements() {
-    var responseSchemas =
-        loadAllAnnouncementsUseCase.loadAllAnnouncements().stream()
-            .map(Announcement::getNorm)
-            .map(NormResponseMapper::fromUseCaseData)
-            .toList();
+    var responseSchemas = loadAllAnnouncementsUseCase
+      .loadAllAnnouncements()
+      .stream()
+      .map(Announcement::getNorm)
+      .map(NormResponseMapper::fromUseCaseData)
+      .toList();
     return ResponseEntity.ok(responseSchemas);
   }
 
@@ -74,16 +75,17 @@ public class AnnouncementController {
    *     <p>Returns HTTP 404 (Not Found) if no release is found.
    */
   @GetMapping(
-      path =
-          "/eli/bund/{agent}/{year}/{naturalIdentifier}/{pointInTime}/{version}/{language}/{subtype}/release",
-      produces = {APPLICATION_JSON_VALUE})
+    path = "/eli/bund/{agent}/{year}/{naturalIdentifier}/{pointInTime}/{version}/{language}/{subtype}/release",
+    produces = { APPLICATION_JSON_VALUE }
+  )
   public ResponseEntity<ReleaseResponseSchema> getRelease(final Eli eli) {
-    var announcement =
-        loadAnnouncementByNormEliUseCase.loadAnnouncementByNormEli(
-            new LoadAnnouncementByNormEliUseCase.Query(eli.getValue()));
+    var announcement = loadAnnouncementByNormEliUseCase.loadAnnouncementByNormEli(
+      new LoadAnnouncementByNormEliUseCase.Query(eli.getValue())
+    );
     var affectedNorms =
-        loadTargetNormsAffectedByAnnouncementUseCase.loadTargetNormsAffectedByAnnouncement(
-            new LoadTargetNormsAffectedByAnnouncementUseCase.Query(eli.getValue()));
+      loadTargetNormsAffectedByAnnouncementUseCase.loadTargetNormsAffectedByAnnouncement(
+        new LoadTargetNormsAffectedByAnnouncementUseCase.Query(eli.getValue())
+      );
 
     return ResponseEntity.ok(ReleaseResponseMapper.fromAnnouncement(announcement, affectedNorms));
   }
@@ -101,17 +103,18 @@ public class AnnouncementController {
    *     <p>Returns HTTP 404 (Not Found) if no {@link Announcement} is found.
    */
   @PutMapping(
-      path =
-          "/eli/bund/{agent}/{year}/{naturalIdentifier}/{pointInTime}/{version}/{language}/{subtype}/release",
-      produces = {APPLICATION_JSON_VALUE})
+    path = "/eli/bund/{agent}/{year}/{naturalIdentifier}/{pointInTime}/{version}/{language}/{subtype}/release",
+    produces = { APPLICATION_JSON_VALUE }
+  )
   public ResponseEntity<ReleaseResponseSchema> putRelease(final Eli eli) {
-    var announcement =
-        releaseAnnouncementUseCase.releaseAnnouncement(
-            new ReleaseAnnouncementUseCase.Query(eli.getValue()));
+    var announcement = releaseAnnouncementUseCase.releaseAnnouncement(
+      new ReleaseAnnouncementUseCase.Query(eli.getValue())
+    );
 
     var affectedNorms =
-        loadTargetNormsAffectedByAnnouncementUseCase.loadTargetNormsAffectedByAnnouncement(
-            new LoadTargetNormsAffectedByAnnouncementUseCase.Query(eli.getValue()));
+      loadTargetNormsAffectedByAnnouncementUseCase.loadTargetNormsAffectedByAnnouncement(
+        new LoadTargetNormsAffectedByAnnouncementUseCase.Query(eli.getValue())
+      );
 
     return ResponseEntity.ok(ReleaseResponseMapper.fromAnnouncement(announcement, affectedNorms));
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ElementController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ElementController.java
@@ -15,18 +15,21 @@ import org.springframework.web.bind.annotation.*;
 /** Controller for retrieving a norm's elements. */
 @RestController
 @RequestMapping(
-    "/api/v1/norms/eli/bund/{agent}/{year}/{naturalIdentifier}/{pointInTime}/{version}/{language}/{subtype}/elements")
+  "/api/v1/norms/eli/bund/{agent}/{year}/{naturalIdentifier}/{pointInTime}/{version}/{language}/{subtype}/elements"
+)
 public class ElementController {
+
   private final LoadElementFromNormUseCase loadElementFromNormUseCase;
   private final LoadElementHtmlFromNormUseCase loadElementHtmlFromNormUseCase;
   private final LoadElementHtmlAtDateFromNormUseCase loadElementHtmlAtDateFromNormUseCase;
   private final LoadElementsByTypeFromNormUseCase loadElementsByTypeFromNormUseCase;
 
   public ElementController(
-      LoadElementFromNormUseCase loadElementFromNormUseCase,
-      LoadElementHtmlFromNormUseCase loadElementHtmlFromNormUseCase,
-      LoadElementHtmlAtDateFromNormUseCase loadElementHtmlAtDateFromNormUseCase,
-      LoadElementsByTypeFromNormUseCase loadElementsByTypeFromNormUseCase) {
+    LoadElementFromNormUseCase loadElementFromNormUseCase,
+    LoadElementHtmlFromNormUseCase loadElementHtmlFromNormUseCase,
+    LoadElementHtmlAtDateFromNormUseCase loadElementHtmlAtDateFromNormUseCase,
+    LoadElementsByTypeFromNormUseCase loadElementsByTypeFromNormUseCase
+  ) {
     this.loadElementFromNormUseCase = loadElementFromNormUseCase;
     this.loadElementHtmlFromNormUseCase = loadElementHtmlFromNormUseCase;
     this.loadElementHtmlAtDateFromNormUseCase = loadElementHtmlAtDateFromNormUseCase;
@@ -46,23 +49,25 @@ public class ElementController {
    * @return A {@link ResponseEntity} containing the HTML.
    *     <p>Returns HTTP 400 (Bad Request) if ELI or EID can not be found
    */
-  @GetMapping(
-      path = "/{eid}",
-      produces = {TEXT_HTML_VALUE})
+  @GetMapping(path = "/{eid}", produces = { TEXT_HTML_VALUE })
   public ResponseEntity<String> getElementHtmlPreview(
-      final Eli eli, @PathVariable final String eid, @RequestParam Optional<Instant> atIsoDate) {
-
+    final Eli eli,
+    @PathVariable final String eid,
+    @RequestParam Optional<Instant> atIsoDate
+  ) {
     return atIsoDate
-        .map(
-            date ->
-                loadElementHtmlAtDateFromNormUseCase.loadElementHtmlAtDateFromNorm(
-                    new LoadElementHtmlAtDateFromNormUseCase.Query(eli.getValue(), eid, date)))
-        .orElseGet(
-            () ->
-                loadElementHtmlFromNormUseCase.loadElementHtmlFromNorm(
-                    new LoadElementHtmlFromNormUseCase.Query(eli.getValue(), eid)))
-        .map(ResponseEntity::ok)
-        .orElse(ResponseEntity.notFound().build());
+      .map(date ->
+        loadElementHtmlAtDateFromNormUseCase.loadElementHtmlAtDateFromNorm(
+          new LoadElementHtmlAtDateFromNormUseCase.Query(eli.getValue(), eid, date)
+        )
+      )
+      .orElseGet(() ->
+        loadElementHtmlFromNormUseCase.loadElementHtmlFromNorm(
+          new LoadElementHtmlFromNormUseCase.Query(eli.getValue(), eid)
+        )
+      )
+      .map(ResponseEntity::ok)
+      .orElse(ResponseEntity.notFound().build());
   }
 
   /**
@@ -76,17 +81,16 @@ public class ElementController {
    * @return A {@link ResponseEntity} containing the element's information.
    *     <p>Returns HTTP 400 (Bad Request) if ELI or EID can not be found
    */
-  @GetMapping(
-      path = "/{eid}",
-      produces = {APPLICATION_JSON_VALUE})
+  @GetMapping(path = "/{eid}", produces = { APPLICATION_JSON_VALUE })
   public ResponseEntity<ElementResponseSchema> getElementInfo(
-      final Eli eli, @PathVariable final String eid) {
-
+    final Eli eli,
+    @PathVariable final String eid
+  ) {
     return loadElementFromNormUseCase
-        .loadElementFromNorm(new LoadElementFromNormUseCase.Query(eli.getValue(), eid))
-        .map(ElementResponseMapper::fromElementNode)
-        .map(ResponseEntity::ok)
-        .orElse(ResponseEntity.notFound().build());
+      .loadElementFromNorm(new LoadElementFromNormUseCase.Query(eli.getValue(), eid))
+      .map(ElementResponseMapper::fromElementNode)
+      .map(ResponseEntity::ok)
+      .orElse(ResponseEntity.notFound().build());
   }
 
   /**
@@ -105,21 +109,24 @@ public class ElementController {
    *     <p>Returns HTTP 404 (Not Found) if the norm is not found.
    *     <p>Returns HTTP 500 (Server error) if an unsupported type is provided.
    */
-  @GetMapping(produces = {APPLICATION_JSON_VALUE})
+  @GetMapping(produces = { APPLICATION_JSON_VALUE })
   public ResponseEntity<List<ElementResponseSchema>> getElementList(
-      final Eli eli,
-      @RequestParam final String[] type,
-      @RequestParam final Optional<String> amendedBy) {
-
+    final Eli eli,
+    @RequestParam final String[] type,
+    @RequestParam final Optional<String> amendedBy
+  ) {
     try {
-      List<ElementResponseSchema> elements =
-          loadElementsByTypeFromNormUseCase
-              .loadElementsByTypeFromNorm(
-                  new LoadElementsByTypeFromNormUseCase.Query(
-                      eli.getValue(), Arrays.asList(type), amendedBy.orElse(null)))
-              .stream()
-              .map(ElementResponseMapper::fromElementNode)
-              .toList();
+      List<ElementResponseSchema> elements = loadElementsByTypeFromNormUseCase
+        .loadElementsByTypeFromNorm(
+          new LoadElementsByTypeFromNormUseCase.Query(
+            eli.getValue(),
+            Arrays.asList(type),
+            amendedBy.orElse(null)
+          )
+        )
+        .stream()
+        .map(ElementResponseMapper::fromElementNode)
+        .toList();
 
       return ResponseEntity.ok(elements);
     } catch (LoadElementsByTypeFromNormUseCase.UnsupportedElementTypeException e) {

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/NormController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/NormController.java
@@ -31,7 +31,8 @@ import org.springframework.web.bind.annotation.*;
  */
 @RestController
 @RequestMapping(
-    "/api/v1/norms/eli/bund/{agent}/{year}/{naturalIdentifier}/{pointInTime}/{version}/{language}/{subtype}")
+  "/api/v1/norms/eli/bund/{agent}/{year}/{naturalIdentifier}/{pointInTime}/{version}/{language}/{subtype}"
+)
 public class NormController {
 
   private final LoadNormUseCase loadNormUseCase;
@@ -43,13 +44,14 @@ public class NormController {
   private final UpdateModsUseCase updateModsUseCase;
 
   public NormController(
-      LoadNormUseCase loadNormUseCase,
-      LoadNormXmlUseCase loadNormXmlUseCase,
-      UpdateNormXmlUseCase updateNormXmlUseCase,
-      TransformLegalDocMlToHtmlUseCase transformLegalDocMlToHtmlUseCase,
-      ApplyPassiveModificationsUseCase applyPassiveModificationsUseCase,
-      UpdateModUseCase updateModUseCase,
-      UpdateModsUseCase updateModsUseCase) {
+    LoadNormUseCase loadNormUseCase,
+    LoadNormXmlUseCase loadNormXmlUseCase,
+    UpdateNormXmlUseCase updateNormXmlUseCase,
+    TransformLegalDocMlToHtmlUseCase transformLegalDocMlToHtmlUseCase,
+    ApplyPassiveModificationsUseCase applyPassiveModificationsUseCase,
+    UpdateModUseCase updateModUseCase,
+    UpdateModsUseCase updateModsUseCase
+  ) {
     this.loadNormUseCase = loadNormUseCase;
     this.loadNormXmlUseCase = loadNormXmlUseCase;
     this.updateNormXmlUseCase = updateNormXmlUseCase;
@@ -71,7 +73,7 @@ public class NormController {
    *     <p>Returns HTTP 200 (OK) and the norm if found.
    *     <p>Returns HTTP 404 (Not Found) if the norm is not found.
    */
-  @GetMapping(produces = {APPLICATION_JSON_VALUE})
+  @GetMapping(produces = { APPLICATION_JSON_VALUE })
   public ResponseEntity<NormResponseSchema> getNorm(final Eli eli) {
     var norm = loadNormUseCase.loadNorm(new LoadNormUseCase.Query(eli.getValue()));
     return ResponseEntity.ok(NormResponseMapper.fromUseCaseData(norm));
@@ -89,12 +91,12 @@ public class NormController {
    *     <p>Returns HTTP 200 (OK) and the norm's xml if found.
    *     <p>Returns HTTP 404 (Not Found) if the norm is not found.
    */
-  @GetMapping(produces = {APPLICATION_XML_VALUE})
+  @GetMapping(produces = { APPLICATION_XML_VALUE })
   public ResponseEntity<String> getNormXml(final Eli eli) {
     return loadNormXmlUseCase
-        .loadNormXml(new LoadNormXmlUseCase.Query(eli.getValue()))
-        .map(ResponseEntity::ok)
-        .orElseGet(() -> ResponseEntity.notFound().build());
+      .loadNormXml(new LoadNormXmlUseCase.Query(eli.getValue()))
+      .map(ResponseEntity::ok)
+      .orElseGet(() -> ResponseEntity.notFound().build());
   }
 
   /**
@@ -112,11 +114,12 @@ public class NormController {
    *     <p>Returns HTTP 200 (OK) and the norm as rendered html.
    *     <p>Returns HTTP 404 (Not Found) if the norm is not found.
    */
-  @GetMapping(produces = {TEXT_HTML_VALUE})
+  @GetMapping(produces = { TEXT_HTML_VALUE })
   public ResponseEntity<String> getNormRender(
-      final Eli eli,
-      @RequestParam(defaultValue = "false") boolean showMetadata,
-      @RequestParam Optional<String> atIsoDate) {
+    final Eli eli,
+    @RequestParam(defaultValue = "false") boolean showMetadata,
+    @RequestParam Optional<String> atIsoDate
+  ) {
     if (atIsoDate.isPresent()) {
       try {
         DateTimeFormatter.ISO_DATE_TIME.parse(atIsoDate.get());
@@ -126,23 +129,31 @@ public class NormController {
 
       var norm = loadNormUseCase.loadNorm(new LoadNormUseCase.Query(eli.getValue()));
       norm =
-          applyPassiveModificationsUseCase.applyPassiveModifications(
-              new ApplyPassiveModificationsUseCase.Query(norm, Instant.parse(atIsoDate.get())));
+      applyPassiveModificationsUseCase.applyPassiveModifications(
+        new ApplyPassiveModificationsUseCase.Query(norm, Instant.parse(atIsoDate.get()))
+      );
 
       return ResponseEntity.ok(
-          this.transformLegalDocMlToHtmlUseCase.transformLegalDocMlToHtml(
-              new TransformLegalDocMlToHtmlUseCase.Query(
-                  XmlMapper.toString(norm.getDocument()), showMetadata, false)));
+        this.transformLegalDocMlToHtmlUseCase.transformLegalDocMlToHtml(
+            new TransformLegalDocMlToHtmlUseCase.Query(
+              XmlMapper.toString(norm.getDocument()),
+              showMetadata,
+              false
+            )
+          )
+      );
     }
 
     return loadNormXmlUseCase
-        .loadNormXml(new LoadNormXmlUseCase.Query(eli.getValue()))
-        .map(
-            xml ->
-                ResponseEntity.ok(
-                    this.transformLegalDocMlToHtmlUseCase.transformLegalDocMlToHtml(
-                        new TransformLegalDocMlToHtmlUseCase.Query(xml, showMetadata, false))))
-        .orElseGet(() -> ResponseEntity.notFound().build());
+      .loadNormXml(new LoadNormXmlUseCase.Query(eli.getValue()))
+      .map(xml ->
+        ResponseEntity.ok(
+          this.transformLegalDocMlToHtmlUseCase.transformLegalDocMlToHtml(
+              new TransformLegalDocMlToHtmlUseCase.Query(xml, showMetadata, false)
+            )
+        )
+      )
+      .orElseGet(() -> ResponseEntity.notFound().build());
   }
 
   /**
@@ -158,15 +169,13 @@ public class NormController {
    *     <p>Returns HTTP 200 (OK) with the saved XML as response payload.
    *     <p>Returns HTTP 404 (Not Found) if the amending law is not found.
    */
-  @PutMapping(
-      consumes = {APPLICATION_XML_VALUE},
-      produces = {APPLICATION_XML_VALUE})
+  @PutMapping(consumes = { APPLICATION_XML_VALUE }, produces = { APPLICATION_XML_VALUE })
   public ResponseEntity<String> updateAmendingLaw(final Eli eli, @RequestBody String xml) {
     try {
       return updateNormXmlUseCase
-          .updateNormXml(new UpdateNormXmlUseCase.Query(eli.getValue(), xml))
-          .map(ResponseEntity::ok)
-          .orElseGet(() -> ResponseEntity.notFound().build());
+        .updateNormXml(new UpdateNormXmlUseCase.Query(eli.getValue(), xml))
+        .map(ResponseEntity::ok)
+        .orElseGet(() -> ResponseEntity.notFound().build());
     } catch (UpdateNormXmlUseCase.InvalidUpdateException e) {
       return ResponseEntity.badRequest().body(e.getMessage());
     }
@@ -186,29 +195,32 @@ public class NormController {
    *     found.
    */
   @PutMapping(
-      path = "/mods/{eid}",
-      consumes = {APPLICATION_JSON_VALUE},
-      produces = {APPLICATION_JSON_VALUE})
+    path = "/mods/{eid}",
+    consumes = { APPLICATION_JSON_VALUE },
+    produces = { APPLICATION_JSON_VALUE }
+  )
   public ResponseEntity<UpdateModResponseSchema> updateMod(
-      final Eli eli,
-      @PathVariable final String eid,
-      @RequestBody @Valid final UpdateModRequestSchema updateModRequestSchema,
-      @RequestParam(defaultValue = "false") final Boolean dryRun) {
-
+    final Eli eli,
+    @PathVariable final String eid,
+    @RequestBody @Valid final UpdateModRequestSchema updateModRequestSchema,
+    @RequestParam(defaultValue = "false") final Boolean dryRun
+  ) {
     return updateModUseCase
-        .updateMod(
-            new UpdateModUseCase.Query(
-                eli.getValue(),
-                eid,
-                updateModRequestSchema.getRefersTo(),
-                updateModRequestSchema.getTimeBoundaryEid(),
-                updateModRequestSchema.getDestinationHref(),
-                updateModRequestSchema.getDestinationUpTo(),
-                updateModRequestSchema.getNewContent(),
-                dryRun))
-        .map(UpdateModResponseMapper::fromResult)
-        .map(ResponseEntity::ok)
-        .orElseGet(() -> ResponseEntity.notFound().build());
+      .updateMod(
+        new UpdateModUseCase.Query(
+          eli.getValue(),
+          eid,
+          updateModRequestSchema.getRefersTo(),
+          updateModRequestSchema.getTimeBoundaryEid(),
+          updateModRequestSchema.getDestinationHref(),
+          updateModRequestSchema.getDestinationUpTo(),
+          updateModRequestSchema.getNewContent(),
+          dryRun
+        )
+      )
+      .map(UpdateModResponseMapper::fromResult)
+      .map(ResponseEntity::ok)
+      .orElseGet(() -> ResponseEntity.notFound().build());
   }
 
   /**
@@ -224,28 +236,34 @@ public class NormController {
    *     found.
    */
   @PatchMapping(
-      path = "/mods",
-      consumes = {APPLICATION_JSON_VALUE},
-      produces = {APPLICATION_JSON_VALUE})
+    path = "/mods",
+    consumes = { APPLICATION_JSON_VALUE },
+    produces = { APPLICATION_JSON_VALUE }
+  )
   public ResponseEntity<UpdateModsResponseSchema> updateMods(
-      final Eli eli,
-      @RequestBody @Valid
-          final Map<String, UpdateModsRequestSchema.ModUpdate> updateModsRequestSchema,
-      @RequestParam(defaultValue = "false") final Boolean dryRun) {
-
+    final Eli eli,
+    @RequestBody @Valid final Map<
+      String,
+      UpdateModsRequestSchema.ModUpdate
+    > updateModsRequestSchema,
+    @RequestParam(defaultValue = "false") final Boolean dryRun
+  ) {
     return updateModsUseCase
-        .updateMods(
-            new UpdateModsUseCase.Query(
-                eli.getValue(),
-                updateModsRequestSchema.entrySet().stream()
-                    .map(
-                        entry ->
-                            new UpdateModsUseCase.NewModData(
-                                entry.getKey(), entry.getValue().timeBoundaryEid()))
-                    .toList(),
-                dryRun))
-        .map(UpdateModsResponseMapper::fromResult)
-        .map(ResponseEntity::ok)
-        .orElseGet(() -> ResponseEntity.unprocessableEntity().build());
+      .updateMods(
+        new UpdateModsUseCase.Query(
+          eli.getValue(),
+          updateModsRequestSchema
+            .entrySet()
+            .stream()
+            .map(entry ->
+              new UpdateModsUseCase.NewModData(entry.getKey(), entry.getValue().timeBoundaryEid())
+            )
+            .toList(),
+          dryRun
+        )
+      )
+      .map(UpdateModsResponseMapper::fromResult)
+      .map(ResponseEntity::ok)
+      .orElseGet(() -> ResponseEntity.unprocessableEntity().build());
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ProprietaryController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ProprietaryController.java
@@ -23,22 +23,23 @@ import org.springframework.web.bind.annotation.RestController;
 /** Retrieve proprietary data of a {@link Norm}. */
 @RestController
 @RequestMapping(
-    "/api/v1/norms/eli/bund/{agent}/{year}/{naturalIdentifier}/{pointInTime}/{version}/{language}/{subtype}/proprietary")
+  "/api/v1/norms/eli/bund/{agent}/{year}/{naturalIdentifier}/{pointInTime}/{version}/{language}/{subtype}/proprietary"
+)
 public class ProprietaryController {
 
   private final LoadProprietaryFromNormUseCase loadProprietaryFromNormUseCase;
   private final UpdateProprietaryFrameFromNormUseCase updateProprietaryFrameFromNormUseCase;
-  private final UpdateProprietarySingleElementFromNormUseCase
-      updateProprietarySingleElementFromNormUseCase;
+  private final UpdateProprietarySingleElementFromNormUseCase updateProprietarySingleElementFromNormUseCase;
 
   public ProprietaryController(
-      LoadProprietaryFromNormUseCase loadProprietaryFromNormUseCase,
-      UpdateProprietaryFrameFromNormUseCase updateProprietaryFrameFromNormUseCase,
-      UpdateProprietarySingleElementFromNormUseCase updateProprietarySingleElementFromNormUseCase) {
+    LoadProprietaryFromNormUseCase loadProprietaryFromNormUseCase,
+    UpdateProprietaryFrameFromNormUseCase updateProprietaryFrameFromNormUseCase,
+    UpdateProprietarySingleElementFromNormUseCase updateProprietarySingleElementFromNormUseCase
+  ) {
     this.loadProprietaryFromNormUseCase = loadProprietaryFromNormUseCase;
     this.updateProprietaryFrameFromNormUseCase = updateProprietaryFrameFromNormUseCase;
     this.updateProprietarySingleElementFromNormUseCase =
-        updateProprietarySingleElementFromNormUseCase;
+    updateProprietarySingleElementFromNormUseCase;
   }
 
   /**
@@ -49,15 +50,14 @@ public class ProprietaryController {
    * @param atDate the time boundary at which to return the metadata
    * @return the specific metadata returned in the form of {@link ProprietaryFrameSchema}
    */
-  @GetMapping(
-      path = "/{atDate}",
-      produces = {APPLICATION_JSON_VALUE})
+  @GetMapping(path = "/{atDate}", produces = { APPLICATION_JSON_VALUE })
   public ResponseEntity<ProprietaryFrameSchema> getProprietaryAtDate(
-      final Eli eli, @PathVariable final LocalDate atDate) {
-
-    var proprietary =
-        loadProprietaryFromNormUseCase.loadProprietaryFromNorm(
-            new LoadProprietaryFromNormUseCase.Query(eli.getValue()));
+    final Eli eli,
+    @PathVariable final LocalDate atDate
+  ) {
+    var proprietary = loadProprietaryFromNormUseCase.loadProprietaryFromNorm(
+      new LoadProprietaryFromNormUseCase.Query(eli.getValue())
+    );
 
     return ResponseEntity.ok(ProprietaryResponseMapper.fromProprietary(proprietary, atDate));
   }
@@ -73,31 +73,34 @@ public class ProprietaryController {
    * @return the specific metadata updated in the form of {@link ProprietaryFrameSchema}
    */
   @PutMapping(
-      path = "/{atDate}",
-      consumes = {APPLICATION_JSON_VALUE},
-      produces = {APPLICATION_JSON_VALUE})
+    path = "/{atDate}",
+    consumes = { APPLICATION_JSON_VALUE },
+    produces = { APPLICATION_JSON_VALUE }
+  )
   public ResponseEntity<ProprietaryFrameSchema> updateProprietaryAtDate(
-      final Eli eli,
-      @PathVariable final LocalDate atDate,
-      @RequestBody ProprietaryFrameSchema proprietaryFrameSchema) {
-
-    var proprietary =
-        updateProprietaryFrameFromNormUseCase.updateProprietaryFrameFromNorm(
-            new UpdateProprietaryFrameFromNormUseCase.Query(
-                eli.getValue(),
-                atDate,
-                new UpdateProprietaryFrameFromNormUseCase.Metadata(
-                    proprietaryFrameSchema.getFna(),
-                    proprietaryFrameSchema.getArt(),
-                    proprietaryFrameSchema.getTyp(),
-                    proprietaryFrameSchema.getSubtyp(),
-                    proprietaryFrameSchema.getBezeichnungInVorlage(),
-                    proprietaryFrameSchema.getArtDerNorm(),
-                    proprietaryFrameSchema.getStaat(),
-                    proprietaryFrameSchema.getBeschliessendesOrgan(),
-                    proprietaryFrameSchema.getQualifizierteMehrheit(),
-                    proprietaryFrameSchema.getRessort(),
-                    proprietaryFrameSchema.getOrganisationsEinheit())));
+    final Eli eli,
+    @PathVariable final LocalDate atDate,
+    @RequestBody ProprietaryFrameSchema proprietaryFrameSchema
+  ) {
+    var proprietary = updateProprietaryFrameFromNormUseCase.updateProprietaryFrameFromNorm(
+      new UpdateProprietaryFrameFromNormUseCase.Query(
+        eli.getValue(),
+        atDate,
+        new UpdateProprietaryFrameFromNormUseCase.Metadata(
+          proprietaryFrameSchema.getFna(),
+          proprietaryFrameSchema.getArt(),
+          proprietaryFrameSchema.getTyp(),
+          proprietaryFrameSchema.getSubtyp(),
+          proprietaryFrameSchema.getBezeichnungInVorlage(),
+          proprietaryFrameSchema.getArtDerNorm(),
+          proprietaryFrameSchema.getStaat(),
+          proprietaryFrameSchema.getBeschliessendesOrgan(),
+          proprietaryFrameSchema.getQualifizierteMehrheit(),
+          proprietaryFrameSchema.getRessort(),
+          proprietaryFrameSchema.getOrganisationsEinheit()
+        )
+      )
+    );
 
     return ResponseEntity.ok(ProprietaryResponseMapper.fromProprietary(proprietary, atDate));
   }
@@ -111,18 +114,19 @@ public class ProprietaryController {
    * @param atDate the time boundary at which to return the metadata
    * @return the specific metadata returned in the form of {@link ProprietarySingleElementSchema}
    */
-  @GetMapping(
-      path = "/{eid}/{atDate}",
-      produces = {APPLICATION_JSON_VALUE})
+  @GetMapping(path = "/{eid}/{atDate}", produces = { APPLICATION_JSON_VALUE })
   public ResponseEntity<ProprietarySingleElementSchema> getProprietaryAtDate(
-      final Eli eli, @PathVariable final String eid, @PathVariable final LocalDate atDate) {
-
-    var proprietary =
-        loadProprietaryFromNormUseCase.loadProprietaryFromNorm(
-            new LoadProprietaryFromNormUseCase.Query(eli.getValue()));
+    final Eli eli,
+    @PathVariable final String eid,
+    @PathVariable final LocalDate atDate
+  ) {
+    var proprietary = loadProprietaryFromNormUseCase.loadProprietaryFromNorm(
+      new LoadProprietaryFromNormUseCase.Query(eli.getValue())
+    );
 
     return ResponseEntity.ok(
-        ProprietaryResponseMapper.fromProprietarySingleElement(proprietary, eid, atDate));
+      ProprietaryResponseMapper.fromProprietarySingleElement(proprietary, eid, atDate)
+    );
   }
 
   /**
@@ -137,25 +141,30 @@ public class ProprietaryController {
    * @return the specific metadata returned in the form of {@link ProprietarySingleElementSchema}
    */
   @PutMapping(
-      path = "/{eid}/{atDate}",
-      consumes = {APPLICATION_JSON_VALUE},
-      produces = {APPLICATION_JSON_VALUE})
+    path = "/{eid}/{atDate}",
+    consumes = { APPLICATION_JSON_VALUE },
+    produces = { APPLICATION_JSON_VALUE }
+  )
   public ResponseEntity<ProprietarySingleElementSchema> updateProprietaryAtDate(
-      final Eli eli,
-      @PathVariable final String eid,
-      @PathVariable final LocalDate atDate,
-      @RequestBody ProprietarySingleElementSchema proprietarySchema) {
-
+    final Eli eli,
+    @PathVariable final String eid,
+    @PathVariable final LocalDate atDate,
+    @RequestBody ProprietarySingleElementSchema proprietarySchema
+  ) {
     var proprietary =
-        updateProprietarySingleElementFromNormUseCase.updateProprietarySingleElementFromNorm(
-            new UpdateProprietarySingleElementFromNormUseCase.Query(
-                eli.getValue(),
-                eid,
-                atDate,
-                new UpdateProprietarySingleElementFromNormUseCase.Metadata(
-                    proprietarySchema.getArtDerNorm())));
+      updateProprietarySingleElementFromNormUseCase.updateProprietarySingleElementFromNorm(
+        new UpdateProprietarySingleElementFromNormUseCase.Query(
+          eli.getValue(),
+          eid,
+          atDate,
+          new UpdateProprietarySingleElementFromNormUseCase.Metadata(
+            proprietarySchema.getArtDerNorm()
+          )
+        )
+      );
 
     return ResponseEntity.ok(
-        ProprietaryResponseMapper.fromProprietarySingleElement(proprietary, eid, atDate));
+      ProprietaryResponseMapper.fromProprietarySingleElement(proprietary, eid, atDate)
+    );
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ReferenceController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ReferenceController.java
@@ -12,7 +12,8 @@ import org.springframework.web.bind.annotation.RestController;
 /** Controller for references actions. */
 @RestController
 @RequestMapping(
-    "/api/v1/references/eli/bund/{agent}/{year}/{naturalIdentifier}/{pointInTime}/{version}/{language}/{subtype}")
+  "/api/v1/references/eli/bund/{agent}/{year}/{naturalIdentifier}/{pointInTime}/{version}/{language}/{subtype}"
+)
 public class ReferenceController {
 
   private final ReferenceRecognitionUseCase referenceRecognitionUseCase;
@@ -29,10 +30,12 @@ public class ReferenceController {
    *     <p>Returns HTTP 200 (OK) and the updated norm's xml if found.
    *     <p>Returns HTTP 404 (Not Found) if the norm is not found.
    */
-  @PostMapping(produces = {APPLICATION_XML_VALUE})
+  @PostMapping(produces = { APPLICATION_XML_VALUE })
   public ResponseEntity<String> findReferencesInNorm(final Eli eli) {
     return ResponseEntity.ok(
-        referenceRecognitionUseCase.findAndCreateReferences(
-            new ReferenceRecognitionUseCase.Query(eli.getValue())));
+      referenceRecognitionUseCase.findAndCreateReferences(
+        new ReferenceRecognitionUseCase.Query(eli.getValue())
+      )
+    );
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/RenderingController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/RenderingController.java
@@ -26,8 +26,9 @@ public class RenderingController {
   private final ApplyPassiveModificationsUseCase applyPassiveModificationsUseCase;
 
   public RenderingController(
-      TransformLegalDocMlToHtmlUseCase transformLegalDocMlToHtmlUseCase,
-      ApplyPassiveModificationsUseCase applyPassiveModificationsUseCase) {
+    TransformLegalDocMlToHtmlUseCase transformLegalDocMlToHtmlUseCase,
+    ApplyPassiveModificationsUseCase applyPassiveModificationsUseCase
+  ) {
     this.transformLegalDocMlToHtmlUseCase = transformLegalDocMlToHtmlUseCase;
     this.applyPassiveModificationsUseCase = applyPassiveModificationsUseCase;
   }
@@ -44,20 +45,22 @@ public class RenderingController {
    *     HTML gets rendered and returned. If no date is provided the current date is used.
    * @return A {@link ResponseEntity} containing the HTML rendering of the law document.
    */
-  @PostMapping(
-      consumes = {APPLICATION_JSON_VALUE},
-      produces = {TEXT_HTML_VALUE})
+  @PostMapping(consumes = { APPLICATION_JSON_VALUE }, produces = { TEXT_HTML_VALUE })
   public ResponseEntity<String> getHtmlPreview(
-      @RequestBody final PreviewRequestSchema previewRequestSchema,
-      @RequestParam(defaultValue = "false") boolean showMetadata,
-      @RequestParam(defaultValue = "false") boolean snippet,
-      @RequestParam Optional<Instant> atIsoDate) {
+    @RequestBody final PreviewRequestSchema previewRequestSchema,
+    @RequestParam(defaultValue = "false") boolean showMetadata,
+    @RequestParam(defaultValue = "false") boolean snippet,
+    @RequestParam Optional<Instant> atIsoDate
+  ) {
     return ResponseEntity.ok(
-        this.transformLegalDocMlToHtmlUseCase.transformLegalDocMlToHtml(
-            new TransformLegalDocMlToHtmlUseCase.Query(
-                snippet ? previewRequestSchema.getNorm() : render(previewRequestSchema, atIsoDate),
-                showMetadata,
-                snippet)));
+      this.transformLegalDocMlToHtmlUseCase.transformLegalDocMlToHtml(
+          new TransformLegalDocMlToHtmlUseCase.Query(
+            snippet ? previewRequestSchema.getNorm() : render(previewRequestSchema, atIsoDate),
+            showMetadata,
+            snippet
+          )
+        )
+    );
   }
 
   /**
@@ -70,27 +73,28 @@ public class RenderingController {
    *     HTML gets rendered and returned. If no date is provided the current date is used.
    * @return A {@link ResponseEntity} containing the HTML rendering of the law document.
    */
-  @PostMapping(
-      consumes = {APPLICATION_JSON_VALUE},
-      produces = {APPLICATION_XML_VALUE})
+  @PostMapping(consumes = { APPLICATION_JSON_VALUE }, produces = { APPLICATION_XML_VALUE })
   public ResponseEntity<String> getXMLPreview(
-      @RequestBody final PreviewRequestSchema previewRequestSchema,
-      @RequestParam Optional<Instant> atIsoDate) {
+    @RequestBody final PreviewRequestSchema previewRequestSchema,
+    @RequestParam Optional<Instant> atIsoDate
+  ) {
     return ResponseEntity.ok(render(previewRequestSchema, atIsoDate));
   }
 
   private String render(PreviewRequestSchema previewRequestSchema, Optional<Instant> atIsoDate) {
-    final var norm =
-        Norm.builder().document(XmlMapper.toDocument(previewRequestSchema.getNorm())).build();
-    final Set<Norm> customNorms =
-        previewRequestSchema.getCustomNorms().stream()
-            .map(xml -> new Norm(XmlMapper.toDocument(xml)))
-            .collect(Collectors.toSet());
+    final var norm = Norm
+      .builder()
+      .document(XmlMapper.toDocument(previewRequestSchema.getNorm()))
+      .build();
+    final Set<Norm> customNorms = previewRequestSchema
+      .getCustomNorms()
+      .stream()
+      .map(xml -> new Norm(XmlMapper.toDocument(xml)))
+      .collect(Collectors.toSet());
 
-    Norm normWithAppliedModifications =
-        applyPassiveModificationsUseCase.applyPassiveModifications(
-            new ApplyPassiveModificationsUseCase.Query(
-                norm, atIsoDate.orElse(Instant.now()), customNorms));
+    Norm normWithAppliedModifications = applyPassiveModificationsUseCase.applyPassiveModifications(
+      new ApplyPassiveModificationsUseCase.Query(norm, atIsoDate.orElse(Instant.now()), customNorms)
+    );
 
     return XmlMapper.toString(normWithAppliedModifications.getDocument());
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/TimeBoundaryController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/TimeBoundaryController.java
@@ -18,7 +18,8 @@ import org.springframework.web.bind.annotation.*;
 /** Controller for norm-related actions. */
 @RestController
 @RequestMapping(
-    "/api/v1/norms/eli/bund/{agent}/{year}/{naturalIdentifier}/{pointInTime}/{version}/{language}/{subtype}/timeBoundaries")
+  "/api/v1/norms/eli/bund/{agent}/{year}/{naturalIdentifier}/{pointInTime}/{version}/{language}/{subtype}/timeBoundaries"
+)
 public class TimeBoundaryController {
 
   private final LoadTimeBoundariesUseCase loadTimeBoundariesUseCase;
@@ -26,10 +27,10 @@ public class TimeBoundaryController {
   private final UpdateTimeBoundariesUseCase updateTimeBoundariesUseCase;
 
   public TimeBoundaryController(
-      LoadTimeBoundariesUseCase loadTimeBoundariesUseCase,
-      LoadTimeBoundariesAmendedByUseCase loadTimeBoundariesAmendedByUseCase,
-      UpdateTimeBoundariesUseCase updateTimeBoundariesUseCase) {
-
+    LoadTimeBoundariesUseCase loadTimeBoundariesUseCase,
+    LoadTimeBoundariesAmendedByUseCase loadTimeBoundariesAmendedByUseCase,
+    UpdateTimeBoundariesUseCase updateTimeBoundariesUseCase
+  ) {
     this.loadTimeBoundariesUseCase = loadTimeBoundariesUseCase;
     this.loadTimeBoundariesAmendedByUseCase = loadTimeBoundariesAmendedByUseCase;
     this.updateTimeBoundariesUseCase = updateTimeBoundariesUseCase;
@@ -48,22 +49,27 @@ public class TimeBoundaryController {
    * @return a {@link ResponseEntity} containing a list of {@link TimeBoundarySchema} or HTTP 404
    *     Not Found if no boundaries are available.
    */
-  @GetMapping(produces = {APPLICATION_JSON_VALUE})
+  @GetMapping(produces = { APPLICATION_JSON_VALUE })
   public ResponseEntity<List<TimeBoundarySchema>> getTimeBoundaries(
-      final Eli eli, @RequestParam final Optional<String> amendedBy) {
+    final Eli eli,
+    @RequestParam final Optional<String> amendedBy
+  ) {
     return ResponseEntity.ok(
-        amendedBy
-            .map(
-                amendingBy ->
-                    loadTimeBoundariesAmendedByUseCase.loadTimeBoundariesAmendedBy(
-                        new LoadTimeBoundariesAmendedByUseCase.Query(eli.getValue(), amendingBy)))
-            .orElseGet(
-                () ->
-                    loadTimeBoundariesUseCase.loadTimeBoundariesOfNorm(
-                        new LoadTimeBoundariesUseCase.Query(eli.getValue())))
-            .stream()
-            .map(TimeBoundaryMapper::fromUseCaseData)
-            .toList());
+      amendedBy
+        .map(amendingBy ->
+          loadTimeBoundariesAmendedByUseCase.loadTimeBoundariesAmendedBy(
+            new LoadTimeBoundariesAmendedByUseCase.Query(eli.getValue(), amendingBy)
+          )
+        )
+        .orElseGet(() ->
+          loadTimeBoundariesUseCase.loadTimeBoundariesOfNorm(
+            new LoadTimeBoundariesUseCase.Query(eli.getValue())
+          )
+        )
+        .stream()
+        .map(TimeBoundaryMapper::fromUseCaseData)
+        .toList()
+    );
   }
 
   /**
@@ -78,26 +84,25 @@ public class TimeBoundaryController {
    * @return a {@link ResponseEntity} containing a list of {@link TimeBoundarySchema} or HTTP 404
    *     Not Found if no boundaries are available or a 400 if the update failed.
    */
-  @PutMapping(
-      consumes = {APPLICATION_JSON_VALUE},
-      produces = {APPLICATION_JSON_VALUE})
+  @PutMapping(consumes = { APPLICATION_JSON_VALUE }, produces = { APPLICATION_JSON_VALUE })
   public ResponseEntity<List<TimeBoundarySchema>> updateTimeBoundaries(
-      final Eli eli,
-      @RequestBody
-          @Valid
-          @UniqueTimeBoundariesDatesConstraint
-          @NotEmpty(message = "Change list must not be empty")
-          @Size(max = 100, message = "A maximum of 100 time boundaries is supported")
-          final List<TimeBoundarySchema> timeBoundaries) {
-
-    List<TimeBoundarySchema> result =
-        updateTimeBoundariesUseCase
-            .updateTimeBoundariesOfNorm(
-                new UpdateTimeBoundariesUseCase.Query(
-                    eli.getValue(), TimeBoundaryMapper.fromResponseSchema(timeBoundaries)))
-            .stream()
-            .map(TimeBoundaryMapper::fromUseCaseData)
-            .toList();
+    final Eli eli,
+    @RequestBody @Valid @UniqueTimeBoundariesDatesConstraint @NotEmpty(
+      message = "Change list must not be empty"
+    ) @Size(max = 100, message = "A maximum of 100 time boundaries is supported") final List<
+      TimeBoundarySchema
+    > timeBoundaries
+  ) {
+    List<TimeBoundarySchema> result = updateTimeBoundariesUseCase
+      .updateTimeBoundariesOfNorm(
+        new UpdateTimeBoundariesUseCase.Query(
+          eli.getValue(),
+          TimeBoundaryMapper.fromResponseSchema(timeBoundaries)
+        )
+      )
+      .stream()
+      .map(TimeBoundaryMapper::fromUseCaseData)
+      .toList();
 
     // Assumptions: According to spec there must always be a temporalData with one temporalGroup
     // having 1 temporalInterval in a ReglungstextVerkuendungsfassung

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/exceptions/FrameWorkExceptionHandler.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/exceptions/FrameWorkExceptionHandler.java
@@ -32,12 +32,13 @@ public class FrameWorkExceptionHandler {
   @ExceptionHandler(HttpMessageNotReadableException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public ResponseEntity<String> handleHttpMessageNotReadableException(
-      final HttpMessageNotReadableException e) {
-
+    final HttpMessageNotReadableException e
+  ) {
     log.error("HttpMessageNotReadableException: {}", e.getMessage(), e);
 
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-        .body(CONTENT_FORMAT_TEMPLATE.formatted(e.getMessage()));
+    return ResponseEntity
+      .status(HttpStatus.BAD_REQUEST)
+      .body(CONTENT_FORMAT_TEMPLATE.formatted(e.getMessage()));
   }
 
   /**
@@ -50,24 +51,25 @@ public class FrameWorkExceptionHandler {
   @ExceptionHandler(HandlerMethodValidationException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public ResponseEntity<String> handleHandlerMethodValidationException(
-      final HandlerMethodValidationException e) {
-
-    e.getAllValidationResults()
-        .forEach(
-            validationResults ->
-                validationResults
-                    .getResolvableErrors()
-                    .forEach(
-                        resolvableErrors ->
-                            log.error(
-                                "Validation Error: {}", resolvableErrors.getDefaultMessage())));
+    final HandlerMethodValidationException e
+  ) {
+    e
+      .getAllValidationResults()
+      .forEach(validationResults ->
+        validationResults
+          .getResolvableErrors()
+          .forEach(resolvableErrors ->
+            log.error("Validation Error: {}", resolvableErrors.getDefaultMessage())
+          )
+      );
 
     log.error("HandlerMethodValidationException: {}", e.getMessage(), e);
 
     final String safeMessage = e.getMessage().replace("\"", "'");
 
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-        .body(CONTENT_FORMAT_TEMPLATE.formatted(safeMessage));
+    return ResponseEntity
+      .status(HttpStatus.BAD_REQUEST)
+      .body(CONTENT_FORMAT_TEMPLATE.formatted(safeMessage));
   }
 
   /**
@@ -79,11 +81,11 @@ public class FrameWorkExceptionHandler {
   @ExceptionHandler(Exception.class)
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
   public ResponseEntity<String> handleException(final Exception e) {
-
     log.error("Internal server error: {}", e.getMessage(), e);
 
-    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-        .body(CONTENT_FORMAT_TEMPLATE.formatted(e.getMessage()));
+    return ResponseEntity
+      .status(HttpStatus.INTERNAL_SERVER_ERROR)
+      .body(CONTENT_FORMAT_TEMPLATE.formatted(e.getMessage()));
   }
 
   /**
@@ -103,7 +105,8 @@ public class FrameWorkExceptionHandler {
    */
   @ExceptionHandler(AsyncRequestNotUsableException.class)
   public ResponseEntity<Object> handleAsyncRequestNotUsableException(
-      AsyncRequestNotUsableException e) {
+    AsyncRequestNotUsableException e
+  ) {
     log.debug("Async request was not usable: ", e);
     return null;
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/exceptions/NormExceptionHandler.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/exceptions/NormExceptionHandler.java
@@ -37,8 +37,9 @@ public class NormExceptionHandler {
   public ResponseEntity<String> handleException(final AnnouncementNotFoundException e) {
     log.error("AnnouncementNotFoundException: {}", e.getMessage(), e);
 
-    return ResponseEntity.status(HttpStatus.NOT_FOUND)
-        .body(CONTENT_FORMAT_TEMPLATE.formatted(e.getMessage()));
+    return ResponseEntity
+      .status(HttpStatus.NOT_FOUND)
+      .body(CONTENT_FORMAT_TEMPLATE.formatted(e.getMessage()));
   }
 
   /**
@@ -50,11 +51,11 @@ public class NormExceptionHandler {
   @ExceptionHandler(ValidationException.class)
   @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
   public ResponseEntity<String> handleException(final ValidationException e) {
-
     log.error("ValidationException: {}", e.getMessage(), e);
 
-    return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
-        .body(CONTENT_FORMAT_TEMPLATE.formatted(e.getMessage()));
+    return ResponseEntity
+      .status(HttpStatus.UNPROCESSABLE_ENTITY)
+      .body(CONTENT_FORMAT_TEMPLATE.formatted(e.getMessage()));
   }
 
   /**
@@ -66,11 +67,11 @@ public class NormExceptionHandler {
   @ExceptionHandler(TransformationException.class)
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
   public ResponseEntity<String> handleException(final TransformationException e) {
-
     log.error("TransformationException: {}", e.getMessage(), e);
 
-    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-        .body(CONTENT_FORMAT_TEMPLATE.formatted(e.getMessage()));
+    return ResponseEntity
+      .status(HttpStatus.INTERNAL_SERVER_ERROR)
+      .body(CONTENT_FORMAT_TEMPLATE.formatted(e.getMessage()));
   }
 
   /**
@@ -82,11 +83,11 @@ public class NormExceptionHandler {
   @ExceptionHandler(NormNotFoundException.class)
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public ResponseEntity<String> handleException(final NormNotFoundException e) {
-
     log.error("NormNotFoundException: {}", e.getMessage(), e);
 
-    return ResponseEntity.status(HttpStatus.NOT_FOUND)
-        .body(CONTENT_FORMAT_TEMPLATE.formatted(e.getMessage()));
+    return ResponseEntity
+      .status(HttpStatus.NOT_FOUND)
+      .body(CONTENT_FORMAT_TEMPLATE.formatted(e.getMessage()));
   }
 
   /**
@@ -100,8 +101,9 @@ public class NormExceptionHandler {
   public ResponseEntity<String> handleException(final ArticleNotFoundException e) {
     log.error("ArticleNotFoundException: {}", e.getMessage(), e);
 
-    return ResponseEntity.status(HttpStatus.NOT_FOUND)
-        .body(CONTENT_FORMAT_TEMPLATE.formatted(e.getMessage()));
+    return ResponseEntity
+      .status(HttpStatus.NOT_FOUND)
+      .body(CONTENT_FORMAT_TEMPLATE.formatted(e.getMessage()));
   }
 
   /**
@@ -114,10 +116,12 @@ public class NormExceptionHandler {
   @ExceptionHandler(LoadSpecificArticlesXmlFromNormUseCase.ArticleOfTypeNotFoundException.class)
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public ResponseEntity<String> handleException(
-      final LoadSpecificArticlesXmlFromNormUseCase.ArticleOfTypeNotFoundException e) {
+    final LoadSpecificArticlesXmlFromNormUseCase.ArticleOfTypeNotFoundException e
+  ) {
     log.error("ArticleOfTypeNotFoundException: {}", e.getMessage(), e);
 
-    return ResponseEntity.status(HttpStatus.NOT_FOUND)
-        .body(CONTENT_FORMAT_TEMPLATE.formatted(e.getMessage()));
+    return ResponseEntity
+      .status(HttpStatus.NOT_FOUND)
+      .body(CONTENT_FORMAT_TEMPLATE.formatted(e.getMessage()));
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ArticleResponseMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ArticleResponseMapper.java
@@ -21,12 +21,15 @@ public class ArticleResponseMapper {
    * @return A new {@link ArticleResponseSchema} instance mapped from the input {@link Article}.
    */
   public static ArticleResponseSchema fromNormArticle(
-      final Article article, final @Nullable Norm targetLawZf0) {
+    final Article article,
+    final @Nullable Norm targetLawZf0
+  ) {
     return new ArticleResponseSchema(
-        article.getEnumeration().orElse(null),
-        article.getEid().orElse(null),
-        article.getHeading().orElse(null),
-        article.getAffectedDocumentEli().orElse(null),
-        Optional.ofNullable(targetLawZf0).map(Norm::getEli).orElse(null));
+      article.getEnumeration().orElse(null),
+      article.getEid().orElse(null),
+      article.getHeading().orElse(null),
+      article.getAffectedDocumentEli().orElse(null),
+      Optional.ofNullable(targetLawZf0).map(Norm::getEli).orElse(null)
+    );
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ElementResponseMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ElementResponseMapper.java
@@ -10,14 +10,15 @@ import org.w3c.dom.Node;
 
 /** Mapper class for converting between {@link Node} and {@link ElementResponseSchema}. */
 public class ElementResponseMapper {
+
   // Private constructor to hide the implicit public one and prevent instantiation
   private ElementResponseMapper() {}
 
-  private static final Map<String, String> staticNodeTitles =
-      Map.ofEntries(
-          Map.entry(ElementService.ElementType.PREFACE.name(), "Dokumentenkopf"),
-          Map.entry(ElementService.ElementType.PREAMBLE.name(), "Eingangsformel"),
-          Map.entry(ElementService.ElementType.CONCLUSIONS.name(), "Schlussteil"));
+  private static final Map<String, String> staticNodeTitles = Map.ofEntries(
+    Map.entry(ElementService.ElementType.PREFACE.name(), "Dokumentenkopf"),
+    Map.entry(ElementService.ElementType.PREAMBLE.name(), "Eingangsformel"),
+    Map.entry(ElementService.ElementType.CONCLUSIONS.name(), "Schlussteil")
+  );
 
   private static String getNodeType(Node node) {
     return node.getNodeName().replace("akn:", "");
@@ -30,9 +31,11 @@ public class ElementResponseMapper {
 
     if (staticNodeTitles.containsKey(nodeTypeName)) {
       title = staticNodeTitles.get(nodeTypeName);
-    } else if (Set.of(
-            "ARTICLE", "BOOK", "PART", "CHAPTER", "SECTION", "SUBSECTION", "TITLE", "SUBTITLE")
-        .contains(nodeTypeName)) {
+    } else if (
+      Set
+        .of("ARTICLE", "BOOK", "PART", "CHAPTER", "SECTION", "SUBSECTION", "TITLE", "SUBTITLE")
+        .contains(nodeTypeName)
+    ) {
       var num = NodeParser.getValueFromExpression("./num", node).orElse("").strip();
       var heading = NodeParser.getValueFromExpression("./heading", node).orElse("").strip();
       title = (num + " " + heading).strip();
@@ -50,10 +53,11 @@ public class ElementResponseMapper {
    * @return A new {@link ElementResponseSchema} instance mapped from the input.
    */
   public static ElementResponseSchema fromElementNode(final Node node) {
-    return ElementResponseSchema.builder()
-        .title(getNodeTitle(node))
-        .eid(EId.fromNode(node).map(EId::value).orElseThrow())
-        .type(getNodeType(node))
-        .build();
+    return ElementResponseSchema
+      .builder()
+      .title(getNodeTitle(node))
+      .eid(EId.fromNode(node).map(EId::value).orElseThrow())
+      .type(getNodeType(node))
+      .build();
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/NormResponseMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/NormResponseMapper.java
@@ -16,14 +16,15 @@ public class NormResponseMapper {
    * @return A new {@link NormResponseSchema} instance mapped from the input {@link Norm}.
    */
   public static NormResponseSchema fromUseCaseData(final Norm norm) {
-    return NormResponseSchema.builder()
-        .eli(norm.getEli())
-        .title(norm.getTitle().orElse(null))
-        .frbrName(norm.getMeta().getFRBRWork().getFRBRname().orElse(null))
-        .frbrNumber(norm.getMeta().getFRBRWork().getFRBRnumber().orElse(null))
-        .frbrDateVerkuendung(norm.getMeta().getFRBRWork().getFBRDate())
-        .shortTitle(norm.getShortTitle().orElse(null))
-        .fna(norm.getMeta().getOrCreateProprietary().getFna().orElse(null))
-        .build();
+    return NormResponseSchema
+      .builder()
+      .eli(norm.getEli())
+      .title(norm.getTitle().orElse(null))
+      .frbrName(norm.getMeta().getFRBRWork().getFRBRname().orElse(null))
+      .frbrNumber(norm.getMeta().getFRBRWork().getFRBRnumber().orElse(null))
+      .frbrDateVerkuendung(norm.getMeta().getFRBRWork().getFBRDate())
+      .shortTitle(norm.getShortTitle().orElse(null))
+      .fna(norm.getMeta().getOrCreateProprietary().getFna().orElse(null))
+      .build();
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ProprietaryResponseMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ProprietaryResponseMapper.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
  * ProprietaryFrameSchema}.
  */
 public class ProprietaryResponseMapper {
+
   // Private constructor to hide the implicit public one and prevent instantiation
   private ProprietaryResponseMapper() {}
 
@@ -22,20 +23,23 @@ public class ProprietaryResponseMapper {
    * @return Converted data
    */
   public static ProprietaryFrameSchema fromProprietary(
-      Proprietary proprietary, final LocalDate date) {
-    return ProprietaryFrameSchema.builder()
-        .fna(proprietary.getFna(date).orElse(null))
-        .art(proprietary.getArt(date).orElse(null))
-        .typ(proprietary.getTyp(date).orElse(null))
-        .subtyp(proprietary.getSubtyp(date).orElse(null))
-        .bezeichnungInVorlage(proprietary.getBezeichnungInVorlage(date).orElse(null))
-        .artDerNorm(proprietary.getArtDerNorm(date).orElse(null))
-        .staat(proprietary.getStaat(date).orElse(null))
-        .beschliessendesOrgan(proprietary.getBeschliessendesOrgan(date).orElse(null))
-        .qualifizierteMehrheit(proprietary.getQualifizierteMehrheit(date).orElse(null))
-        .ressort(proprietary.getRessort(date).orElse(null))
-        .organisationsEinheit(proprietary.getOrganisationsEinheit(date).orElse(null))
-        .build();
+    Proprietary proprietary,
+    final LocalDate date
+  ) {
+    return ProprietaryFrameSchema
+      .builder()
+      .fna(proprietary.getFna(date).orElse(null))
+      .art(proprietary.getArt(date).orElse(null))
+      .typ(proprietary.getTyp(date).orElse(null))
+      .subtyp(proprietary.getSubtyp(date).orElse(null))
+      .bezeichnungInVorlage(proprietary.getBezeichnungInVorlage(date).orElse(null))
+      .artDerNorm(proprietary.getArtDerNorm(date).orElse(null))
+      .staat(proprietary.getStaat(date).orElse(null))
+      .beschliessendesOrgan(proprietary.getBeschliessendesOrgan(date).orElse(null))
+      .qualifizierteMehrheit(proprietary.getQualifizierteMehrheit(date).orElse(null))
+      .ressort(proprietary.getRessort(date).orElse(null))
+      .organisationsEinheit(proprietary.getOrganisationsEinheit(date).orElse(null))
+      .build();
   }
 
   /**
@@ -48,9 +52,13 @@ public class ProprietaryResponseMapper {
    * @return Converted data
    */
   public static ProprietarySingleElementSchema fromProprietarySingleElement(
-      Proprietary proprietary, final String eid, final LocalDate date) {
-    return ProprietarySingleElementSchema.builder()
-        .artDerNorm(proprietary.getArtDerNorm(date, eid).orElse(null))
-        .build();
+    Proprietary proprietary,
+    final String eid,
+    final LocalDate date
+  ) {
+    return ProprietarySingleElementSchema
+      .builder()
+      .artDerNorm(proprietary.getArtDerNorm(date, eid).orElse(null))
+      .build();
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ReleaseResponseMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ReleaseResponseMapper.java
@@ -23,11 +23,14 @@ public class ReleaseResponseMapper {
    *     Announcement}.
    */
   public static ReleaseResponseSchema fromAnnouncement(
-      final Announcement announcement, final List<Norm> affectedNorms) {
-    return ReleaseResponseSchema.builder()
-        .amendingLawEli(announcement.getNorm().getEli())
-        .releaseAt(announcement.getReleasedByDocumentalistAt())
-        .zf0Elis(affectedNorms.stream().map(Norm::getEli).toList())
-        .build();
+    final Announcement announcement,
+    final List<Norm> affectedNorms
+  ) {
+    return ReleaseResponseSchema
+      .builder()
+      .amendingLawEli(announcement.getNorm().getEli())
+      .releaseAt(announcement.getReleasedByDocumentalistAt())
+      .zf0Elis(affectedNorms.stream().map(Norm::getEli).toList())
+      .build();
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/TimeBoundaryMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/TimeBoundaryMapper.java
@@ -17,11 +17,12 @@ public class TimeBoundaryMapper {
    * @return A new {@link TimeBoundarySchema} instance mapped from the input {@link TimeBoundary}.
    */
   public static TimeBoundarySchema fromUseCaseData(final TimeBoundary timeBoundary) {
-    return TimeBoundarySchema.builder()
-        .date(timeBoundary.getEventRef().getDate().orElse(null))
-        .eventRefEid(timeBoundary.getEventRefEid().orElse(null))
-        .temporalGroupEid(timeBoundary.getTemporalGroupEid().orElse(null))
-        .build();
+    return TimeBoundarySchema
+      .builder()
+      .date(timeBoundary.getEventRef().getDate().orElse(null))
+      .eventRefEid(timeBoundary.getEventRefEid().orElse(null))
+      .temporalGroupEid(timeBoundary.getTemporalGroupEid().orElse(null))
+      .build();
   }
 
   /**
@@ -31,14 +32,17 @@ public class TimeBoundaryMapper {
    * @return A new {@link TimeBoundarySchema} instance mapped from the input {@link TimeBoundary}.
    */
   public static List<TimeBoundaryChangeData> fromResponseSchema(
-      final List<TimeBoundarySchema> timeBoundaries) {
-    return timeBoundaries.stream()
-        .map(
-            timeBoundary ->
-                TimeBoundaryChangeData.builder()
-                    .date(timeBoundary.getDate())
-                    .eid(timeBoundary.getEventRefEid())
-                    .build())
-        .toList();
+    final List<TimeBoundarySchema> timeBoundaries
+  ) {
+    return timeBoundaries
+      .stream()
+      .map(timeBoundary ->
+        TimeBoundaryChangeData
+          .builder()
+          .date(timeBoundary.getDate())
+          .eid(timeBoundary.getEventRefEid())
+          .build()
+      )
+      .toList();
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/UpdateModResponseMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/UpdateModResponseMapper.java
@@ -17,9 +17,10 @@ public class UpdateModResponseMapper {
    * @return A new {@link UpdateModResponseSchema} instance.
    */
   public static UpdateModResponseSchema fromResult(final UpdateModUseCase.Result result) {
-    return UpdateModResponseSchema.builder()
-        .amendingNormXml(result.amendingNormXml())
-        .targetNormZf0Xml(result.targetNormZf0Xml())
-        .build();
+    return UpdateModResponseSchema
+      .builder()
+      .amendingNormXml(result.amendingNormXml())
+      .targetNormZf0Xml(result.targetNormZf0Xml())
+      .build();
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/UpdateModsResponseMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/UpdateModsResponseMapper.java
@@ -17,9 +17,10 @@ public class UpdateModsResponseMapper {
    * @return A new {@link UpdateModsResponseSchema} instance.
    */
   public static UpdateModsResponseSchema fromResult(final UpdateModsUseCase.Result result) {
-    return UpdateModsResponseSchema.builder()
-        .amendingNormXml(result.amendingNormXml())
-        .targetNormZf0Xml(result.targetNormZf0Xml())
-        .build();
+    return UpdateModsResponseSchema
+      .builder()
+      .amendingNormXml(result.amendingNormXml())
+      .targetNormZf0Xml(result.targetNormZf0Xml())
+      .build();
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/ArticleResponseSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/ArticleResponseSchema.java
@@ -12,6 +12,7 @@ import lombok.experimental.SuperBuilder;
 @Data
 @SuperBuilder(toBuilder = true)
 public class ArticleResponseSchema {
+
   private String enumeration;
 
   private String eid;

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/ElementResponseSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/ElementResponseSchema.java
@@ -12,6 +12,7 @@ import lombok.experimental.SuperBuilder;
 @Data
 @SuperBuilder(toBuilder = true)
 public class ElementResponseSchema {
+
   private String title;
   private String eid;
   private String type;

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/PreviewRequestSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/PreviewRequestSchema.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 /** Schema for the request for rendering the preview of a norm xml. */
 @Getter
 public class PreviewRequestSchema {
+
   /** The xml of the norm. */
   private String norm;
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/ProprietaryFrameSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/ProprietaryFrameSchema.java
@@ -9,6 +9,7 @@ import lombok.experimental.SuperBuilder;
 @Data
 @SuperBuilder(toBuilder = true)
 public class ProprietaryFrameSchema {
+
   private String fna;
   private String art;
   private String typ;

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/ProprietarySingleElementSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/ProprietarySingleElementSchema.java
@@ -9,5 +9,6 @@ import lombok.experimental.SuperBuilder;
 @Data
 @SuperBuilder(toBuilder = true)
 public class ProprietarySingleElementSchema {
+
   private String artDerNorm;
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/ReleaseResponseSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/ReleaseResponseSchema.java
@@ -15,6 +15,7 @@ import lombok.experimental.SuperBuilder;
 @Data
 @SuperBuilder(toBuilder = true)
 public class ReleaseResponseSchema {
+
   private Instant releaseAt;
   private String amendingLawEli;
   private List<String> zf0Elis;

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/TimeBoundarySchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/TimeBoundarySchema.java
@@ -14,6 +14,7 @@ import lombok.experimental.SuperBuilder;
 @Data
 @SuperBuilder(toBuilder = true)
 public class TimeBoundarySchema {
+
   @NotNull(message = "Date must not be null")
   private LocalDate date;
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/UpdateModRequestSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/UpdateModRequestSchema.java
@@ -12,9 +12,18 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder(toBuilder = true)
 public class UpdateModRequestSchema {
 
-  @NotNull private String refersTo;
-  @Nullable private String timeBoundaryEid;
-  @NotNull private String destinationHref;
-  @Nullable private String destinationUpTo;
-  @NotNull private String newContent;
+  @NotNull
+  private String refersTo;
+
+  @Nullable
+  private String timeBoundaryEid;
+
+  @NotNull
+  private String destinationHref;
+
+  @Nullable
+  private String destinationUpTo;
+
+  @NotNull
+  private String newContent;
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/UpdateModResponseSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/UpdateModResponseSchema.java
@@ -9,6 +9,7 @@ import lombok.experimental.SuperBuilder;
 @Data
 @SuperBuilder(toBuilder = true)
 public class UpdateModResponseSchema {
+
   /** The xml of the amending norm. */
   private String amendingNormXml;
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/UpdateModsResponseSchema.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/schema/UpdateModsResponseSchema.java
@@ -9,6 +9,7 @@ import lombok.experimental.SuperBuilder;
 @Data
 @SuperBuilder(toBuilder = true)
 public class UpdateModsResponseSchema {
+
   /** The xml of the amending norm. */
   private String amendingNormXml;
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/AnnouncementDto.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/AnnouncementDto.java
@@ -30,7 +30,9 @@ import lombok.Setter;
 @Table(name = "announcements")
 public class AnnouncementDto {
 
-  @Id @GeneratedValue private UUID id;
+  @Id
+  @GeneratedValue
+  private UUID id;
 
   @Column(name = "released_by_documentalist_at")
   private Instant releasedByDocumentalistAt;

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/NormDto.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/NormDto.java
@@ -24,9 +24,16 @@ import lombok.Setter;
 @Entity
 @Table(name = "norms")
 public class NormDto {
-  @Id @NotNull private UUID guid;
 
-  @NotNull @Column private String eli;
+  @Id
+  @NotNull
+  private UUID guid;
 
-  @NotNull @Column private String xml;
+  @NotNull
+  @Column
+  private String eli;
+
+  @NotNull
+  @Column
+  private String xml;
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/AnnouncementMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/AnnouncementMapper.java
@@ -16,10 +16,11 @@ public class AnnouncementMapper {
    * @return A new {@link Announcement} mapped from the input {@link AnnouncementDto}.
    */
   public static Announcement mapToDomain(final AnnouncementDto announcementDto) {
-    return Announcement.builder()
-        .releasedByDocumentalistAt(announcementDto.getReleasedByDocumentalistAt())
-        .norm(NormMapper.mapToDomain(announcementDto.getNormDto()))
-        .build();
+    return Announcement
+      .builder()
+      .releasedByDocumentalistAt(announcementDto.getReleasedByDocumentalistAt())
+      .norm(NormMapper.mapToDomain(announcementDto.getNormDto()))
+      .build();
   }
 
   /**
@@ -29,9 +30,10 @@ public class AnnouncementMapper {
    * @return A new {@link AnnouncementDto} mapped from the input {@link Announcement}.
    */
   public static AnnouncementDto mapToDto(final Announcement announcement) {
-    return AnnouncementDto.builder()
-        .releasedByDocumentalistAt(announcement.getReleasedByDocumentalistAt())
-        .normDto(NormMapper.mapToDto(announcement.getNorm()))
-        .build();
+    return AnnouncementDto
+      .builder()
+      .releasedByDocumentalistAt(announcement.getReleasedByDocumentalistAt())
+      .normDto(NormMapper.mapToDto(announcement.getNorm()))
+      .build();
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/NormMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/NormMapper.java
@@ -27,10 +27,11 @@ public class NormMapper {
    * @return A new {@link NormDto} mapped from the input {@link Norm}.
    */
   public static NormDto mapToDto(final Norm norm) {
-    return NormDto.builder()
-        .xml(XmlMapper.toString(norm.getDocument()))
-        .eli(norm.getEli())
-        .guid(norm.getGuid())
-        .build();
+    return NormDto
+      .builder()
+      .xml(XmlMapper.toString(norm.getDocument()))
+      .eli(norm.getEli())
+      .guid(norm.getGuid())
+      .build();
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/repository/AnnouncementRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/repository/AnnouncementRepository.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface AnnouncementRepository extends JpaRepository<AnnouncementDto, UUID> {
-
   /**
    * Finds a {@link AnnouncementDto} by its norms ELI (European Legislation Identifier).
    *

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/service/DBService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/service/DBService.java
@@ -20,13 +20,14 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class DBService
-    implements LoadNormPort,
-        LoadNormByGuidPort,
-        LoadAnnouncementByNormEliPort,
-        LoadAllAnnouncementsPort,
-        UpdateNormPort,
-        UpdateAnnouncementPort,
-        UpdateOrSaveNormPort {
+  implements
+    LoadNormPort,
+    LoadNormByGuidPort,
+    LoadAnnouncementByNormEliPort,
+    LoadAllAnnouncementsPort,
+    UpdateNormPort,
+    UpdateAnnouncementPort,
+    UpdateOrSaveNormPort {
 
   private final AnnouncementRepository announcementRepository;
   private final NormRepository normRepository;
@@ -48,35 +49,39 @@ public class DBService
 
   @Override
   public Optional<Announcement> loadAnnouncementByNormEli(
-      LoadAnnouncementByNormEliPort.Command command) {
+    LoadAnnouncementByNormEliPort.Command command
+  ) {
     return announcementRepository
-        .findByNormDtoEli(command.eli())
-        .map(AnnouncementMapper::mapToDomain);
+      .findByNormDtoEli(command.eli())
+      .map(AnnouncementMapper::mapToDomain);
   }
 
   @Override
   public List<Announcement> loadAllAnnouncements() {
-    return announcementRepository.findAll().stream()
-        .map(AnnouncementMapper::mapToDomain)
-        .sorted(
-            Comparator.comparing(
-                    (Announcement announcement) ->
-                        announcement.getNorm().getMeta().getFRBRWork().getFBRDate())
-                .reversed())
-        .toList();
+    return announcementRepository
+      .findAll()
+      .stream()
+      .map(AnnouncementMapper::mapToDomain)
+      .sorted(
+        Comparator
+          .comparing((Announcement announcement) ->
+            announcement.getNorm().getMeta().getFRBRWork().getFBRDate()
+          )
+          .reversed()
+      )
+      .toList();
   }
 
   @Override
   public Optional<Norm> updateNorm(UpdateNormPort.Command command) {
     var normXml = XmlMapper.toString(command.norm().getDocument());
     return normRepository
-        .findByEli(command.norm().getEli())
-        .map(
-            normDto -> {
-              normDto.setXml(normXml);
-              // we do not update the GUID or ELI as they may not change
-              return NormMapper.mapToDomain(normRepository.save(normDto));
-            });
+      .findByEli(command.norm().getEli())
+      .map(normDto -> {
+        normDto.setXml(normXml);
+        // we do not update the GUID or ELI as they may not change
+        return NormMapper.mapToDomain(normRepository.save(normDto));
+      });
   }
 
   @Override
@@ -94,14 +99,12 @@ public class DBService
   public Optional<Announcement> updateAnnouncement(UpdateAnnouncementPort.Command command) {
     var announcement = command.announcement();
     return announcementRepository
-        .findByNormDtoEli(command.announcement().getNorm().getEli())
-        .map(
-            announcementDto -> {
-              announcementDto.setReleasedByDocumentalistAt(
-                  announcement.getReleasedByDocumentalistAt());
-              // It is not possible to change the norm associated with an announcement.
-              // Therefore, we don't update that relationship.
-              return AnnouncementMapper.mapToDomain(announcementRepository.save(announcementDto));
-            });
+      .findByNormDtoEli(command.announcement().getNorm().getEli())
+      .map(announcementDto -> {
+        announcementDto.setReleasedByDocumentalistAt(announcement.getReleasedByDocumentalistAt());
+        // It is not possible to change the norm associated with an announcement.
+        // Therefore, we don't update that relationship.
+        return AnnouncementMapper.mapToDomain(announcementRepository.save(announcementDto));
+      });
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/exception/ArticleNotFoundException.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/exception/ArticleNotFoundException.java
@@ -2,6 +2,7 @@ package de.bund.digitalservice.ris.norms.application.exception;
 
 /** Indicates that an article was not found based on the provided parameters. */
 public class ArticleNotFoundException extends RuntimeException {
+
   public ArticleNotFoundException(final String eli, final String eid) {
     super("Article with eid %s does not exist in norm with eli %s".formatted(eli, eid));
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/exception/TransformationException.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/exception/TransformationException.java
@@ -2,6 +2,7 @@ package de.bund.digitalservice.ris.norms.application.exception;
 
 /** This exception indicates that something went wrong while transforming the xml into html */
 public class TransformationException extends RuntimeException {
+
   public TransformationException(final String message, final Exception e) {
     super(message, e);
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/ApplyPassiveModificationsUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/ApplyPassiveModificationsUseCase.java
@@ -9,7 +9,6 @@ import java.util.Set;
  * given date.
  */
 public interface ApplyPassiveModificationsUseCase {
-
   /**
    * Applies the passive modifications of the norm. Only applies "aenderungsbefehl-ersetzen".
    *

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/LoadAllAnnouncementsUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/LoadAllAnnouncementsUseCase.java
@@ -9,7 +9,6 @@ import java.util.List;
  * system.
  */
 public interface LoadAllAnnouncementsUseCase {
-
   /**
    * Loads all {@link Announcement}s available in the system.
    *

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/LoadAnnouncementByNormEliUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/LoadAnnouncementByNormEliUseCase.java
@@ -8,7 +8,6 @@ import java.util.Optional;
  * interface should provide functionality to load an {@link Announcement} based on a given query.
  */
 public interface LoadAnnouncementByNormEliUseCase {
-
   /**
    * Retrieves an {@link Announcement} based on the provided query.
    *

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/LoadElementHtmlAtDateFromNormUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/LoadElementHtmlAtDateFromNormUseCase.java
@@ -16,7 +16,7 @@ public interface LoadElementHtmlAtDateFromNormUseCase {
    *     the element don't exist.
    */
   Optional<String> loadElementHtmlAtDateFromNorm(LoadElementHtmlAtDateFromNormUseCase.Query query)
-      throws IllegalArgumentException;
+    throws IllegalArgumentException;
 
   /**
    * Contains the parameters needed for loading an element from a norm at a specific date.

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/LoadElementsByTypeFromNormUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/LoadElementsByTypeFromNormUseCase.java
@@ -35,6 +35,7 @@ public interface LoadElementsByTypeFromNormUseCase {
 
   /** Indicates that at least one of the requested types is not supported. */
   class UnsupportedElementTypeException extends IllegalArgumentException {
+
     public UnsupportedElementTypeException(String message) {
       super(message);
     }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/LoadNormXmlUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/LoadNormXmlUseCase.java
@@ -9,7 +9,6 @@ import java.util.Optional;
  * a norm based on a given query.
  */
 public interface LoadNormXmlUseCase {
-
   /**
    * Retrieves the xml representation of a norm based on the provided query.
    *

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/LoadSpecificArticlesXmlFromNormUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/LoadSpecificArticlesXmlFromNormUseCase.java
@@ -9,7 +9,6 @@ import java.util.List;
  * query.
  */
 public interface LoadSpecificArticlesXmlFromNormUseCase {
-
   /**
    * Retrieves articles of a specific type based on the provided query.
    *
@@ -30,6 +29,7 @@ public interface LoadSpecificArticlesXmlFromNormUseCase {
 
   /** Indicates that the Norm was found but does not include articles of that type. */
   class ArticleOfTypeNotFoundException extends RuntimeException {
+
     public ArticleOfTypeNotFoundException(final String eli, final String type) {
       super("Norm with eli %s does not contain articles of type %s".formatted(eli, type));
     }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/LoadTargetNormsAffectedByAnnouncementUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/LoadTargetNormsAffectedByAnnouncementUseCase.java
@@ -10,7 +10,6 @@ import java.util.List;
  * functionality to load these {@link Norm}s based on a given query.
  */
 public interface LoadTargetNormsAffectedByAnnouncementUseCase {
-
   /**
    * Retrieves all target {@link Norm}s that are released when an {@link Announcement} is released
    * based on the provided query. (These are the zf0 versions of the target laws)

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/LoadTimeBoundariesAmendedByUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/LoadTimeBoundariesAmendedByUseCase.java
@@ -9,7 +9,6 @@ import java.util.List;
  * given amending law.
  */
 public interface LoadTimeBoundariesAmendedByUseCase {
-
   /**
    * Retrieves a list of time boundaries related to the specified norm filtered by the amending law
    * eli.

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/LoadTimeBoundariesUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/LoadTimeBoundariesUseCase.java
@@ -9,7 +9,6 @@ import java.util.List;
  * based on a given query.
  */
 public interface LoadTimeBoundariesUseCase {
-
   /**
    * Retrieves a list of time boundaries related to the specified norm based on the provided query.
    *

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/ReferenceRecognitionUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/ReferenceRecognitionUseCase.java
@@ -7,7 +7,6 @@ import de.bund.digitalservice.ris.norms.domain.entity.Norm;
  * the xml representation of a {@link Norm}.
  */
 public interface ReferenceRecognitionUseCase {
-
   /**
    * Runs the regex pattern recognition for references in the norm by the given ELI and updates the
    * XML of it in the DB.

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/ReleaseAnnouncementUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/ReleaseAnnouncementUseCase.java
@@ -8,7 +8,6 @@ import de.bund.digitalservice.ris.norms.domain.entity.Norm;
  * {@link Norm}s.
  */
 public interface ReleaseAnnouncementUseCase {
-
   /**
    * Releases an {@link Announcement} and the corresponding {@link Norm}s based on the provided
    * query.

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/TransformLegalDocMlToHtmlUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/TransformLegalDocMlToHtmlUseCase.java
@@ -2,7 +2,6 @@ package de.bund.digitalservice.ris.norms.application.port.input;
 
 /** Interface representing the use case for transforming a LegalDocML.de XML to HTML. */
 public interface TransformLegalDocMlToHtmlUseCase {
-
   /**
    * Provides a html representation of a LegalDocML.de law.
    *

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/UpdateActiveModificationsUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/UpdateActiveModificationsUseCase.java
@@ -6,7 +6,6 @@ import de.bund.digitalservice.ris.norms.domain.entity.Norm;
  * Interface representing the use case for updating the akn:activeModifications of a {@link Norm}.
  */
 public interface UpdateActiveModificationsUseCase {
-
   /**
    * Update the active modifications of the amendingNorm.
    *
@@ -27,10 +26,11 @@ public interface UpdateActiveModificationsUseCase {
    * @param newContent - the new text to replace the old one
    */
   record Query(
-      Norm amendingNorm,
-      String eId,
-      String destinationHref,
-      String destinationUpTo,
-      String timeBoundaryEid,
-      String newContent) {}
+    Norm amendingNorm,
+    String eId,
+    String destinationHref,
+    String destinationUpTo,
+    String timeBoundaryEid,
+    String newContent
+  ) {}
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/UpdateModUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/UpdateModUseCase.java
@@ -11,7 +11,6 @@ import java.util.Optional;
  * the corresponding ZF0 versions of the target law.
  */
 public interface UpdateModUseCase {
-
   /**
    * Updates an amending command of an amending law and also updates the corresponding ZF0 version
    * of the affected target laws.
@@ -36,24 +35,34 @@ public interface UpdateModUseCase {
    *     Default: false
    */
   record Query(
+    String eli,
+    String eid,
+    String refersTo,
+    String timeBoundaryEid,
+    String destinationHref,
+    String destinationUpTo,
+    String newContent,
+    boolean dryRun
+  ) {
+    public Query(
       String eli,
       String eid,
       String refersTo,
       String timeBoundaryEid,
       String destinationHref,
       String destinationUpTo,
-      String newContent,
-      boolean dryRun) {
-    public Query(
-        String eli,
-        String eid,
-        String refersTo,
-        String timeBoundaryEid,
-        String destinationHref,
-        String destinationUpTo,
-        String newContent) {
+      String newContent
+    ) {
       this(
-          eli, eid, refersTo, timeBoundaryEid, destinationHref, destinationUpTo, newContent, false);
+        eli,
+        eid,
+        refersTo,
+        timeBoundaryEid,
+        destinationHref,
+        destinationUpTo,
+        newContent,
+        false
+      );
     }
   }
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/UpdateModsUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/UpdateModsUseCase.java
@@ -12,7 +12,6 @@ import java.util.Optional;
  * target the same norm.
  */
 public interface UpdateModsUseCase {
-
   /**
    * Updates amending commands of an amending law and also updates the corresponding ZF0 version of
    * the affected target law.

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/UpdateNormXmlUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/UpdateNormXmlUseCase.java
@@ -9,7 +9,6 @@ import java.util.Optional;
  * query.
  */
 public interface UpdateNormXmlUseCase {
-
   /**
    * Updates a xml representation of {@link Norm} based on the provided query.
    *
@@ -30,6 +29,7 @@ public interface UpdateNormXmlUseCase {
 
   /** This exception indicates that a proposed change to a norm is not allowed */
   class InvalidUpdateException extends Exception {
+
     public InvalidUpdateException(String message) {
       super(message);
     }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/UpdatePassiveModificationsUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/UpdatePassiveModificationsUseCase.java
@@ -7,7 +7,6 @@ import de.bund.digitalservice.ris.norms.domain.entity.Norm;
  * by another {@link Norm}'s akn:activeModifications.
  */
 public interface UpdatePassiveModificationsUseCase {
-
   /**
    * Update the passive modifications of the zf0Norm.
    *

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/UpdateProprietaryFrameFromNormUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/UpdateProprietaryFrameFromNormUseCase.java
@@ -42,15 +42,16 @@ public interface UpdateProprietaryFrameFromNormUseCase {
    * @param organisationsEinheit - "Organisationseinheit"
    */
   record Metadata(
-      String fna,
-      String art,
-      String typ,
-      String subtyp,
-      String bezeichnungInVorlage,
-      String artDerNorm,
-      String staat,
-      String beschliessendesOrgan,
-      Boolean qualifizierterMehrheit,
-      String ressort,
-      String organisationsEinheit) {}
+    String fna,
+    String art,
+    String typ,
+    String subtyp,
+    String bezeichnungInVorlage,
+    String artDerNorm,
+    String staat,
+    String beschliessendesOrgan,
+    Boolean qualifizierterMehrheit,
+    String ressort,
+    String organisationsEinheit
+  ) {}
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/UpdateTimeBoundariesUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/UpdateTimeBoundariesUseCase.java
@@ -10,7 +10,6 @@ import java.util.List;
  * based on a given query.
  */
 public interface UpdateTimeBoundariesUseCase {
-
   /**
    * Updates a list of time boundaries related to the specified norm based on the provided query.
    *

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/LoadAllAnnouncementsPort.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/LoadAllAnnouncementsPort.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 /** Port interface for loading all {@link Announcement}s from the storage. */
 public interface LoadAllAnnouncementsPort {
-
   /**
    * Loads all {@link Announcement}s available in the system.
    *

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/LoadAnnouncementByNormEliPort.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/LoadAnnouncementByNormEliPort.java
@@ -10,7 +10,6 @@ import java.util.Optional;
  * specified command.
  */
 public interface LoadAnnouncementByNormEliPort {
-
   /**
    * Loads a {@link Announcement} based on the provided ELI specified in the command.
    *

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/LoadNormByGuidPort.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/LoadNormByGuidPort.java
@@ -9,7 +9,6 @@ import java.util.UUID;
  * this interface should provide functionality to load a norm using the specified command.
  */
 public interface LoadNormByGuidPort {
-
   /**
    * Loads a {@link Norm} based on the provided GUID specified in the command.
    *

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/LoadNormPort.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/LoadNormPort.java
@@ -9,7 +9,6 @@ import java.util.Optional;
  * the specified command.
  */
 public interface LoadNormPort {
-
   /**
    * Loads a {@link Norm} based on the provided ELI specified in the command.
    *

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/UpdateAnnouncementPort.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/UpdateAnnouncementPort.java
@@ -8,7 +8,6 @@ import java.util.Optional;
  * interface should provide functionality to update an announcement using the specified command.
  */
 public interface UpdateAnnouncementPort {
-
   /**
    * Updates a {@link Announcement} based on the provided data in the command.
    *

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/UpdateNormPort.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/UpdateNormPort.java
@@ -8,7 +8,6 @@ import java.util.Optional;
  * should provide functionality to update a norm using the specified command.
  */
 public interface UpdateNormPort {
-
   /**
    * Updates a {@link Norm} based on the provided data in the command.
    *

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/UpdateOrSaveNormPort.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/UpdateOrSaveNormPort.java
@@ -7,7 +7,6 @@ import de.bund.digitalservice.ris.norms.domain.entity.Norm;
  * interface should provide functionality to update a norm using the specified command.
  */
 public interface UpdateOrSaveNormPort {
-
   /**
    * Updates or saves a {@link Norm} based on the provided data in the command.
    *

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/ProprietaryService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/ProprietaryService.java
@@ -12,9 +12,10 @@ import org.springframework.stereotype.Service;
 /** Implements operations related to the "proprietary" of a {@link Norm} */
 @Service
 public class ProprietaryService
-    implements LoadProprietaryFromNormUseCase,
-        UpdateProprietaryFrameFromNormUseCase,
-        UpdateProprietarySingleElementFromNormUseCase {
+  implements
+    LoadProprietaryFromNormUseCase,
+    UpdateProprietaryFrameFromNormUseCase,
+    UpdateProprietarySingleElementFromNormUseCase {
 
   final LoadNormPort loadNormPort;
   final UpdateNormPort updateNormPort;
@@ -27,54 +28,79 @@ public class ProprietaryService
   @Override
   public Proprietary loadProprietaryFromNorm(LoadProprietaryFromNormUseCase.Query query) {
     return loadNormPort
-        .loadNorm(new LoadNormPort.Command(query.eli()))
-        .map(m -> m.getMeta().getOrCreateProprietary())
-        .orElseThrow(() -> new NormNotFoundException((query.eli())));
+      .loadNorm(new LoadNormPort.Command(query.eli()))
+      .map(m -> m.getMeta().getOrCreateProprietary())
+      .orElseThrow(() -> new NormNotFoundException((query.eli())));
   }
 
   @Override
   public Proprietary updateProprietaryFrameFromNorm(
-      UpdateProprietaryFrameFromNormUseCase.Query query) {
-    final Norm norm =
-        loadNormPort
-            .loadNorm(new LoadNormPort.Command(query.eli()))
-            .orElseThrow(() -> new NormNotFoundException((query.eli())));
+    UpdateProprietaryFrameFromNormUseCase.Query query
+  ) {
+    final Norm norm = loadNormPort
+      .loadNorm(new LoadNormPort.Command(query.eli()))
+      .orElseThrow(() -> new NormNotFoundException((query.eli())));
     final Proprietary proprietary = norm.getMeta().getOrCreateProprietary();
     final MetadatenDs metadatenDs = proprietary.getOrCreateMetadatenDs();
     final MetadatenDe metadatenDe = proprietary.getOrCreateMetadatenDe();
 
     metadatenDs.updateSimpleMetadatum(
-        MetadatenDs.Metadata.FNA, query.atDate(), query.metadata().fna());
+      MetadatenDs.Metadata.FNA,
+      query.atDate(),
+      query.metadata().fna()
+    );
     metadatenDs.updateSimpleMetadatum(
-        MetadatenDs.Metadata.ART, query.atDate(), query.metadata().art());
+      MetadatenDs.Metadata.ART,
+      query.atDate(),
+      query.metadata().art()
+    );
     metadatenDs.updateSimpleMetadatum(
-        MetadatenDs.Metadata.TYP, query.atDate(), query.metadata().typ());
+      MetadatenDs.Metadata.TYP,
+      query.atDate(),
+      query.metadata().typ()
+    );
     metadatenDs.updateSimpleMetadatum(
-        MetadatenDs.Metadata.SUBTYP, query.atDate(), query.metadata().subtyp());
+      MetadatenDs.Metadata.SUBTYP,
+      query.atDate(),
+      query.metadata().subtyp()
+    );
     metadatenDs.updateSimpleMetadatum(
-        MetadatenDs.Metadata.BEZEICHNUNG_IN_VORLAGE,
-        query.atDate(),
-        query.metadata().bezeichnungInVorlage());
+      MetadatenDs.Metadata.BEZEICHNUNG_IN_VORLAGE,
+      query.atDate(),
+      query.metadata().bezeichnungInVorlage()
+    );
     metadatenDs.updateSimpleMetadatum(
-        MetadatenDs.Metadata.ART_DER_NORM, query.atDate(), query.metadata().artDerNorm());
+      MetadatenDs.Metadata.ART_DER_NORM,
+      query.atDate(),
+      query.metadata().artDerNorm()
+    );
     metadatenDs.updateSimpleMetadatum(
-        MetadatenDs.Metadata.STAAT, query.atDate(), query.metadata().staat());
+      MetadatenDs.Metadata.STAAT,
+      query.atDate(),
+      query.metadata().staat()
+    );
     metadatenDs.updateSimpleMetadatum(
-        MetadatenDs.Metadata.BESCHLIESSENDES_ORGAN,
-        query.atDate(),
-        query.metadata().beschliessendesOrgan());
+      MetadatenDs.Metadata.BESCHLIESSENDES_ORGAN,
+      query.atDate(),
+      query.metadata().beschliessendesOrgan()
+    );
     metadatenDs.setAttributeOfSimpleMetadatum(
-        MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
-        query.atDate(),
-        String.valueOf(query.metadata().qualifizierterMehrheit()).equals("null")
-            ? "false"
-            : String.valueOf(query.metadata().qualifizierterMehrheit()));
+      MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+      query.atDate(),
+      String.valueOf(query.metadata().qualifizierterMehrheit()).equals("null")
+        ? "false"
+        : String.valueOf(query.metadata().qualifizierterMehrheit())
+    );
     metadatenDe.updateSimpleMetadatum(
-        MetadatenDe.Metadata.RESSORT, query.atDate(), query.metadata().ressort());
+      MetadatenDe.Metadata.RESSORT,
+      query.atDate(),
+      query.metadata().ressort()
+    );
     metadatenDs.updateSimpleMetadatum(
-        MetadatenDs.Metadata.ORGANISATIONS_EINHEIT,
-        query.atDate(),
-        query.metadata().organisationsEinheit());
+      MetadatenDs.Metadata.ORGANISATIONS_EINHEIT,
+      query.atDate(),
+      query.metadata().organisationsEinheit()
+    );
 
     updateNormPort.updateNorm(new UpdateNormPort.Command(norm));
 
@@ -83,19 +109,20 @@ public class ProprietaryService
 
   @Override
   public Proprietary updateProprietarySingleElementFromNorm(
-      UpdateProprietarySingleElementFromNormUseCase.Query query) {
-    final Norm norm =
-        loadNormPort
-            .loadNorm(new LoadNormPort.Command(query.eli()))
-            .orElseThrow(() -> new NormNotFoundException((query.eli())));
+    UpdateProprietarySingleElementFromNormUseCase.Query query
+  ) {
+    final Norm norm = loadNormPort
+      .loadNorm(new LoadNormPort.Command(query.eli()))
+      .orElseThrow(() -> new NormNotFoundException((query.eli())));
     final Proprietary proprietary = norm.getMeta().getOrCreateProprietary();
     final MetadatenDs metadatenDs = proprietary.getOrCreateMetadatenDs();
 
     metadatenDs.updateSingleElementSimpleMetadatum(
-        Einzelelement.Metadata.ART_DER_NORM,
-        query.eid(),
-        query.atDate(),
-        query.metadata().artDerNorm());
+      Einzelelement.Metadata.ART_DER_NORM,
+      query.eid(),
+      query.atDate(),
+      query.metadata().artDerNorm()
+    );
 
     updateNormPort.updateNorm(new UpdateNormPort.Command(norm));
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/ReleaseService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/ReleaseService.java
@@ -15,22 +15,23 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class ReleaseService implements ReleaseAnnouncementUseCase {
+
   private final LoadAnnouncementByNormEliPort loadAnnouncementByNormEliPort;
   private final UpdateAnnouncementPort updateAnnouncementPort;
 
   public ReleaseService(
-      LoadAnnouncementByNormEliPort loadAnnouncementByNormEliPort,
-      UpdateAnnouncementPort updateAnnouncementPort) {
+    LoadAnnouncementByNormEliPort loadAnnouncementByNormEliPort,
+    UpdateAnnouncementPort updateAnnouncementPort
+  ) {
     this.loadAnnouncementByNormEliPort = loadAnnouncementByNormEliPort;
     this.updateAnnouncementPort = updateAnnouncementPort;
   }
 
   @Override
   public Announcement releaseAnnouncement(ReleaseAnnouncementUseCase.Query query) {
-    var announcement =
-        loadAnnouncementByNormEliPort
-            .loadAnnouncementByNormEli(new LoadAnnouncementByNormEliPort.Command(query.eli()))
-            .orElseThrow(() -> new AnnouncementNotFoundException(query.eli()));
+    var announcement = loadAnnouncementByNormEliPort
+      .loadAnnouncementByNormEli(new LoadAnnouncementByNormEliPort.Command(query.eli()))
+      .orElseThrow(() -> new AnnouncementNotFoundException(query.eli()));
 
     announcement.setReleasedByDocumentalistAt(Instant.now());
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/SingleModValidator.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/SingleModValidator.java
@@ -25,32 +25,40 @@ public class SingleModValidator {
    * @throws ValidationException if a validation step fails
    */
   public void validate(final Norm zf0Norm, final Mod activeMod) throws ValidationException {
-
     final String modEId = activeMod.getMandatoryEid();
     final String zf0NormEli = zf0Norm.getEli();
 
-    final TextualMod affectedPassiveMod =
-        zf0Norm.getMeta().getOrCreateAnalysis().getPassiveModifications().stream()
-            .filter(f -> f.getSourceHref().orElseThrow().getEId().orElseThrow().equals(modEId))
-            .findFirst()
-            .orElseThrow();
+    final TextualMod affectedPassiveMod = zf0Norm
+      .getMeta()
+      .getOrCreateAnalysis()
+      .getPassiveModifications()
+      .stream()
+      .filter(f -> f.getSourceHref().orElseThrow().getEId().orElseThrow().equals(modEId))
+      .findFirst()
+      .orElseThrow();
 
-    final String targetNodeEid =
-        affectedPassiveMod.getDestinationHref().orElseThrow().getEId().orElseThrow();
-    final Node zf0TargetedNode =
-        zf0Norm
-            .getNodeByEId(targetNodeEid)
-            .orElseThrow(
-                () ->
-                    new ValidationException(
-                        "Target node with eid %s not present in ZF0 norm with eli %s."
-                            .formatted(targetNodeEid, zf0NormEli)));
+    final String targetNodeEid = affectedPassiveMod
+      .getDestinationHref()
+      .orElseThrow()
+      .getEId()
+      .orElseThrow();
+    final Node zf0TargetedNode = zf0Norm
+      .getNodeByEId(targetNodeEid)
+      .orElseThrow(() ->
+        new ValidationException(
+          "Target node with eid %s not present in ZF0 norm with eli %s.".formatted(
+              targetNodeEid,
+              zf0NormEli
+            )
+        )
+      );
     if (activeMod.usesQuotedText()) {
       validateQuotedText(
-          zf0NormEli,
-          affectedPassiveMod,
-          StringUtils.normalizeSpace(activeMod.getMandatoryOldText()),
-          zf0TargetedNode);
+        zf0NormEli,
+        affectedPassiveMod,
+        StringUtils.normalizeSpace(activeMod.getMandatoryOldText()),
+        zf0TargetedNode
+      );
     }
     if (activeMod.usesQuotedStructure()) {
       validateQuotedStructure(affectedPassiveMod, zf0Norm, targetNodeEid, zf0TargetedNode);
@@ -58,75 +66,99 @@ public class SingleModValidator {
   }
 
   private void validateQuotedText(
-      final String zf0NormEli,
-      final TextualMod passivemod,
-      String amendingNormOldText,
-      Node targetNode)
-      throws ValidationException {
-
+    final String zf0NormEli,
+    final TextualMod passivemod,
+    String amendingNormOldText,
+    Node targetNode
+  ) throws ValidationException {
     final Href destinationHref = passivemod.getDestinationHref().orElseThrow();
     final String passiveModEid = passivemod.getEid().orElseThrow();
-    final CharacterRange characterRange =
-        destinationHref
-            .getCharacterRange()
-            .orElseThrow(
-                () ->
-                    new ValidationException(
-                        "Destination href with value %s of passive mod with eId %s within ZF0 norm with eli %s not present."
-                            .formatted(destinationHref, passiveModEid, zf0NormEli)));
+    final CharacterRange characterRange = destinationHref
+      .getCharacterRange()
+      .orElseThrow(() ->
+        new ValidationException(
+          "Destination href with value %s of passive mod with eId %s within ZF0 norm with eli %s not present.".formatted(
+              destinationHref,
+              passiveModEid,
+              zf0NormEli
+            )
+        )
+      );
 
-    if (!characterRange.isValidCharacterRange())
-      throw new ValidationException(
-          "The character range %s of passive mod with eId %s within ZF0 norm with eli %s has invalid format."
-              .formatted(characterRange, passiveModEid, zf0NormEli));
+    if (!characterRange.isValidCharacterRange()) throw new ValidationException(
+      "The character range %s of passive mod with eId %s within ZF0 norm with eli %s has invalid format.".formatted(
+          characterRange,
+          passiveModEid,
+          zf0NormEli
+        )
+    );
 
     try {
-      if (!characterRange.findTextInNode(targetNode).equals(amendingNormOldText))
-        throw new ValidationException(
-            "The character range %s of passive mod with eId %s within ZF0 norm with eli %s does not resolve to the targeted text to be replaced."
-                .formatted(characterRange, passiveModEid, zf0NormEli));
+      if (
+        !characterRange.findTextInNode(targetNode).equals(amendingNormOldText)
+      ) throw new ValidationException(
+        "The character range %s of passive mod with eId %s within ZF0 norm with eli %s does not resolve to the targeted text to be replaced.".formatted(
+            characterRange,
+            passiveModEid,
+            zf0NormEli
+          )
+      );
     } catch (IndexOutOfBoundsException exception) {
       throw new ValidationException(
-          "The character range %s of passive mod with eId %s within ZF0 norm with eli %s is not within the target node."
-              .formatted(characterRange, passiveModEid, zf0NormEli));
+        "The character range %s of passive mod with eId %s within ZF0 norm with eli %s is not within the target node.".formatted(
+            characterRange,
+            passiveModEid,
+            zf0NormEli
+          )
+      );
     }
   }
 
   private void validateQuotedStructure(
-      final TextualMod affectedPassiveMod,
-      final Norm zf0Norm,
-      final String targetNodeEid,
-      final Node targetNode)
-      throws ValidationException {
-
+    final TextualMod affectedPassiveMod,
+    final Norm zf0Norm,
+    final String targetNodeEid,
+    final Node targetNode
+  ) throws ValidationException {
     affectedPassiveMod
-        .getDestinationUpTo()
-        .ifPresent(
-            upToHref -> {
-              final String targetUpToNodeEid = upToHref.getEId().orElseThrow();
+      .getDestinationUpTo()
+      .ifPresent(upToHref -> {
+        final String targetUpToNodeEid = upToHref.getEId().orElseThrow();
 
-              final Node zf0TargetedUpToNode =
-                  zf0Norm
-                      .getNodeByEId(targetUpToNodeEid)
-                      .orElseThrow(
-                          () ->
-                              new ValidationException(
-                                  "Target upTo node with eid %s not present in ZF0 norm with eli %s."
-                                      .formatted(targetUpToNodeEid, zf0Norm.getEli())));
+        final Node zf0TargetedUpToNode = zf0Norm
+          .getNodeByEId(targetUpToNodeEid)
+          .orElseThrow(() ->
+            new ValidationException(
+              "Target upTo node with eid %s not present in ZF0 norm with eli %s.".formatted(
+                  targetUpToNodeEid,
+                  zf0Norm.getEli()
+                )
+            )
+          );
 
-              if (targetNode.getParentNode() != zf0TargetedUpToNode.getParentNode()) {
-                throw new ValidationException(
-                    "Target node with eid %s and target upTo node with eid %s are not siblings in ZF0 norm with eli %s."
-                        .formatted(targetNodeEid, targetUpToNodeEid, zf0Norm.getEli()));
-              }
+        if (targetNode.getParentNode() != zf0TargetedUpToNode.getParentNode()) {
+          throw new ValidationException(
+            "Target node with eid %s and target upTo node with eid %s are not siblings in ZF0 norm with eli %s.".formatted(
+                targetNodeEid,
+                targetUpToNodeEid,
+                zf0Norm.getEli()
+              )
+          );
+        }
 
-              if ((targetNode.compareDocumentPosition(zf0TargetedUpToNode)
-                      & Node.DOCUMENT_POSITION_FOLLOWING)
-                  == 0) {
-                throw new ValidationException(
-                    "Target node with eid %s does not appear before target upTo node with eid %s in ZF0 norm with eli %s."
-                        .formatted(targetNodeEid, targetUpToNodeEid, zf0Norm.getEli()));
-              }
-            });
+        if (
+          (targetNode.compareDocumentPosition(zf0TargetedUpToNode) &
+            Node.DOCUMENT_POSITION_FOLLOWING) ==
+          0
+        ) {
+          throw new ValidationException(
+            "Target node with eid %s does not appear before target upTo node with eid %s in ZF0 norm with eli %s.".formatted(
+                targetNodeEid,
+                targetUpToNodeEid,
+                zf0Norm.getEli()
+              )
+          );
+        }
+      });
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeBoundaryService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeBoundaryService.java
@@ -19,15 +19,13 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 public class TimeBoundaryService
-    implements LoadTimeBoundariesUseCase,
-        LoadTimeBoundariesAmendedByUseCase,
-        UpdateTimeBoundariesUseCase {
+  implements
+    LoadTimeBoundariesUseCase, LoadTimeBoundariesAmendedByUseCase, UpdateTimeBoundariesUseCase {
 
   private final LoadNormPort loadNormPort;
   private final UpdateNormPort updateNormPort;
 
   public TimeBoundaryService(LoadNormPort loadNormPort, UpdateNormPort updateNormPort) {
-
     this.loadNormPort = loadNormPort;
     this.updateNormPort = updateNormPort;
   }
@@ -39,38 +37,43 @@ public class TimeBoundaryService
   @Override
   public List<TimeBoundary> loadTimeBoundariesOfNorm(LoadTimeBoundariesUseCase.Query query) {
     return loadNormPort
-        .loadNorm(new LoadNormPort.Command(query.eli()))
-        .orElseThrow(() -> new NormNotFoundException(query.eli()))
-        .getTimeBoundaries();
+      .loadNorm(new LoadNormPort.Command(query.eli()))
+      .orElseThrow(() -> new NormNotFoundException(query.eli()))
+      .getTimeBoundaries();
   }
 
   @Override
   public List<TimeBoundary> loadTimeBoundariesAmendedBy(
-      LoadTimeBoundariesAmendedByUseCase.Query query) {
+    LoadTimeBoundariesAmendedByUseCase.Query query
+  ) {
+    final Norm norm = loadNormPort
+      .loadNorm(new LoadNormPort.Command(query.eli()))
+      .orElseThrow(() -> new NormNotFoundException(query.eli()));
 
-    final Norm norm =
-        loadNormPort
-            .loadNorm(new LoadNormPort.Command(query.eli()))
-            .orElseThrow(() -> new NormNotFoundException(query.eli()));
+    final List<String> temporalGroupEidAmendedBy = norm
+      .getMeta()
+      .getOrCreateAnalysis()
+      .getPassiveModifications()
+      .stream()
+      .filter(f ->
+        f
+          .getSourceHref()
+          .map(href ->
+            href.getEli().isPresent() && href.getEli().get().equals(query.amendingLawEli())
+          )
+          .orElse(false)
+      )
+      .map(m -> m.getForcePeriodEid().orElse(null))
+      .filter(Objects::nonNull)
+      .toList();
 
-    final List<String> temporalGroupEidAmendedBy =
-        norm.getMeta().getOrCreateAnalysis().getPassiveModifications().stream()
-            .filter(
-                f ->
-                    f.getSourceHref()
-                        .map(
-                            href ->
-                                href.getEli().isPresent()
-                                    && href.getEli().get().equals(query.amendingLawEli()))
-                        .orElse(false))
-            .map(m -> m.getForcePeriodEid().orElse(null))
-            .filter(Objects::nonNull)
-            .toList();
-
-    final List<TemporalGroup> temporalGroups =
-        norm.getMeta().getTemporalData().getTemporalGroups().stream()
-            .filter(f -> temporalGroupEidAmendedBy.contains(f.getEid().orElseThrow()))
-            .toList();
+    final List<TemporalGroup> temporalGroups = norm
+      .getMeta()
+      .getTemporalData()
+      .getTemporalGroups()
+      .stream()
+      .filter(f -> temporalGroupEidAmendedBy.contains(f.getEid().orElseThrow()))
+      .toList();
     return norm.getTimeBoundaries(temporalGroups);
   }
 
@@ -83,15 +86,16 @@ public class TimeBoundaryService
     Optional<Norm> norm = loadNormPort.loadNorm(new LoadNormPort.Command(query.eli()));
     Optional<Norm> normResponse = Optional.empty();
     if (norm.isPresent()) {
-
       // At first time boundaries that shall be deleted need to be selected
       // if we would delete first, there are cases where the next possible eId could not be safely
       // calculated
       // example norm: only one date exists (2023-01-01, id2). That date gets deleted and a new date
       // (2024-01-01, null)
       // is being added. Then id3 could not be calculated.
-      List<TimeBoundaryChangeData> timeBoundariesToDelete =
-          selectTimeBoundariesToDelete(query.timeBoundaries(), norm.get());
+      List<TimeBoundaryChangeData> timeBoundariesToDelete = selectTimeBoundariesToDelete(
+        query.timeBoundaries(),
+        norm.get()
+      );
 
       // Add TimeBoundaries where eid is null|empty
       addTimeBoundaries(query.timeBoundaries(), norm.get());
@@ -109,88 +113,100 @@ public class TimeBoundaryService
   }
 
   private void editTimeBoundaries(List<TimeBoundaryChangeData> timeBoundaryChangeData, Norm norm) {
+    List<TimeBoundaryChangeData> datesToUpdate = timeBoundaryChangeData
+      .stream()
+      .filter(tb -> tb.eid() != null && !tb.eid().isEmpty())
+      .toList();
 
-    List<TimeBoundaryChangeData> datesToUpdate =
-        timeBoundaryChangeData.stream()
-            .filter(tb -> tb.eid() != null && !tb.eid().isEmpty())
-            .toList();
+    List<TimeBoundary> timeBoundariesToUpdate = norm
+      .getTimeBoundaries()
+      .stream()
+      .filter(tb -> tb.getEventRefEid().isPresent())
+      .filter(tb ->
+        datesToUpdate
+          .stream()
+          .map(TimeBoundaryChangeData::eid)
+          .toList()
+          .contains(tb.getEventRefEid().get())
+      )
+      .toList();
 
-    List<TimeBoundary> timeBoundariesToUpdate =
-        norm.getTimeBoundaries().stream()
-            .filter(tb -> tb.getEventRefEid().isPresent())
-            .filter(
-                tb ->
-                    datesToUpdate.stream()
-                        .map(TimeBoundaryChangeData::eid)
-                        .toList()
-                        .contains(tb.getEventRefEid().get()))
-            .toList();
-
-    timeBoundariesToUpdate.forEach(
-        tb -> {
-          LocalDate newDate =
-              datesToUpdate.stream()
-                  .filter(date -> date.eid().equals(tb.getEventRefEid().get()))
-                  .map(TimeBoundaryChangeData::date)
-                  .findFirst()
-                  .orElse(LocalDate.MIN);
-          tb.setEventRefDate(newDate);
-        });
+    timeBoundariesToUpdate.forEach(tb -> {
+      LocalDate newDate = datesToUpdate
+        .stream()
+        .filter(date -> date.eid().equals(tb.getEventRefEid().get()))
+        .map(TimeBoundaryChangeData::date)
+        .findFirst()
+        .orElse(LocalDate.MIN);
+      tb.setEventRefDate(newDate);
+    });
 
     logChangeDataWithoutCorrespondingEidInXml(norm, datesToUpdate);
   }
 
   private void logChangeDataWithoutCorrespondingEidInXml(
-      Norm norm, List<TimeBoundaryChangeData> datesToUpdate) {
-    List<String> timeBoundaryEids =
-        norm.getTimeBoundaries().stream()
-            .map(TimeBoundary::getEventRefEid)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .toList();
+    Norm norm,
+    List<TimeBoundaryChangeData> datesToUpdate
+  ) {
+    List<String> timeBoundaryEids = norm
+      .getTimeBoundaries()
+      .stream()
+      .map(TimeBoundary::getEventRefEid)
+      .filter(Optional::isPresent)
+      .map(Optional::get)
+      .toList();
 
-    List<TimeBoundaryChangeData> timeBoundariesListedButNotUpdated =
-        datesToUpdate.stream()
-            .filter(changeData -> changeData.eid() != null && !changeData.eid().isEmpty())
-            .filter(changeData -> changeData.date() != null)
-            .filter(changeData -> !timeBoundaryEids.contains(changeData.eid()))
-            .toList();
+    List<TimeBoundaryChangeData> timeBoundariesListedButNotUpdated = datesToUpdate
+      .stream()
+      .filter(changeData -> changeData.eid() != null && !changeData.eid().isEmpty())
+      .filter(changeData -> changeData.date() != null)
+      .filter(changeData -> !timeBoundaryEids.contains(changeData.eid()))
+      .toList();
 
     if (!timeBoundariesListedButNotUpdated.isEmpty()) {
       log.error(
-          "The following time boundaries should be changed but the eId was not found: {}",
-          timeBoundariesListedButNotUpdated);
+        "The following time boundaries should be changed but the eId was not found: {}",
+        timeBoundariesListedButNotUpdated
+      );
     }
   }
 
   private void addTimeBoundaries(List<TimeBoundaryChangeData> timeBoundaryChangeData, Norm norm) {
-    timeBoundaryChangeData.stream()
-        .filter(tb -> tb.eid() == null || tb.eid().isEmpty())
-        .map(TimeBoundaryChangeData::date)
-        .forEach(date -> norm.addTimeBoundary(date, EventRefType.GENERATION));
+    timeBoundaryChangeData
+      .stream()
+      .filter(tb -> tb.eid() == null || tb.eid().isEmpty())
+      .map(TimeBoundaryChangeData::date)
+      .forEach(date -> norm.addTimeBoundary(date, EventRefType.GENERATION));
   }
 
   private List<TimeBoundaryChangeData> selectTimeBoundariesToDelete(
-      List<TimeBoundaryChangeData> timeBoundaryChangeData, Norm norm) {
+    List<TimeBoundaryChangeData> timeBoundaryChangeData,
+    Norm norm
+  ) {
+    List<String> allChangeDateEids = timeBoundaryChangeData
+      .stream()
+      .map(TimeBoundaryChangeData::eid)
+      .toList();
 
-    List<String> allChangeDateEids =
-        timeBoundaryChangeData.stream().map(TimeBoundaryChangeData::eid).toList();
+    List<String> allEventRefEidsToDelete = norm
+      .getTimeBoundaries()
+      .stream()
+      .map(TimeBoundary::getEventRefEid)
+      .filter(Optional::isPresent)
+      .map(Optional::get)
+      .filter(eid -> !allChangeDateEids.contains(eid))
+      .toList();
 
-    List<String> allEventRefEidsToDelete =
-        norm.getTimeBoundaries().stream()
-            .map(TimeBoundary::getEventRefEid)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .filter(eid -> !allChangeDateEids.contains(eid))
-            .toList();
-
-    return allEventRefEidsToDelete.stream()
-        .map(eid -> new TimeBoundaryChangeData(eid, null))
-        .toList();
+    return allEventRefEidsToDelete
+      .stream()
+      .map(eid -> new TimeBoundaryChangeData(eid, null))
+      .toList();
   }
 
   private void deleteTimeBoundaries(
-      List<TimeBoundaryChangeData> timeBoundariesToDelete, Norm norm) {
+    List<TimeBoundaryChangeData> timeBoundariesToDelete,
+    Norm norm
+  ) {
     timeBoundariesToDelete.forEach(norm::deleteTimeBoundary);
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineService.java
@@ -42,12 +42,12 @@ public class TimeMachineService implements ApplyPassiveModificationsUseCase {
    * @return the Norm with the applied passive modifications that are in effect before the date
    */
   public Norm applyPassiveModifications(ApplyPassiveModificationsUseCase.Query query) {
-
     var norm = query.norm();
     var date = query.date();
-    var customNorms =
-        query.customNorms().stream()
-            .collect(Collectors.toMap(Norm::getEli, customNorm -> customNorm));
+    var customNorms = query
+      .customNorms()
+      .stream()
+      .collect(Collectors.toMap(Norm::getEli, customNorm -> customNorm));
 
     var actualDate = date.equals(Instant.MAX) ? Instant.MAX : date.plus(Duration.ofDays(1));
 
@@ -57,62 +57,67 @@ public class TimeMachineService implements ApplyPassiveModificationsUseCase {
       return norm;
     }
 
-    norm.getMeta()
-        .getAnalysis()
-        .map(analysis -> analysis.getPassiveModifications().stream())
-        .orElse(Stream.empty())
-        .filter(
-            (TextualMod passiveModification) -> {
-              final var startDate =
-                  passiveModification
-                      .getForcePeriodEid()
-                      .flatMap(norm::getStartDateForTemporalGroup)
-                      .map(dateString -> Instant.parse(dateString + "T00:00:00.000Z"));
+    norm
+      .getMeta()
+      .getAnalysis()
+      .map(analysis -> analysis.getPassiveModifications().stream())
+      .orElse(Stream.empty())
+      .filter((TextualMod passiveModification) -> {
+        final var startDate = passiveModification
+          .getForcePeriodEid()
+          .flatMap(norm::getStartDateForTemporalGroup)
+          .map(dateString -> Instant.parse(dateString + "T00:00:00.000Z"));
 
-              // when no start date exists we do not want to apply the mod
-              return startDate.isPresent() && startDate.get().isBefore(actualDate);
-            })
-        .sorted(
-            Comparator.comparing(
-                (TextualMod passiveModification) ->
-                    passiveModification
-                        .getForcePeriodEid()
-                        .flatMap(norm::getStartDateForTemporalGroup)
-                        .orElseThrow(
-                            () ->
-                                new ValidationException(
-                                    "Did not find a start date for textual mod with eId %s"
-                                        .formatted(passiveModification.getEid())))))
-        .flatMap(
-            (TextualMod passiveModification) -> {
-              var sourceEli =
-                  passiveModification
-                      .getSourceHref()
-                      .flatMap(Href::getEli)
-                      .orElseThrow(
-                          () ->
-                              new ValidationException(
-                                  "Did not find source href for textual mod with eId %s"
-                                      .formatted(passiveModification.getEid())));
+        // when no start date exists we do not want to apply the mod
+        return startDate.isPresent() && startDate.get().isBefore(actualDate);
+      })
+      .sorted(
+        Comparator.comparing((TextualMod passiveModification) ->
+          passiveModification
+            .getForcePeriodEid()
+            .flatMap(norm::getStartDateForTemporalGroup)
+            .orElseThrow(() ->
+              new ValidationException(
+                "Did not find a start date for textual mod with eId %s".formatted(
+                    passiveModification.getEid()
+                  )
+              )
+            )
+        )
+      )
+      .flatMap((TextualMod passiveModification) -> {
+        var sourceEli = passiveModification
+          .getSourceHref()
+          .flatMap(Href::getEli)
+          .orElseThrow(() ->
+            new ValidationException(
+              "Did not find source href for textual mod with eId %s".formatted(
+                  passiveModification.getEid()
+                )
+            )
+          );
 
-              Norm amendingLaw;
-              if (customNorms.containsKey(sourceEli)) {
-                amendingLaw = customNorms.get(sourceEli);
-              } else {
-                amendingLaw = normService.loadNorm(new LoadNormUseCase.Query(sourceEli));
-              }
+        Norm amendingLaw;
+        if (customNorms.containsKey(sourceEli)) {
+          amendingLaw = customNorms.get(sourceEli);
+        } else {
+          amendingLaw = normService.loadNorm(new LoadNormUseCase.Query(sourceEli));
+        }
 
-              var sourceEid = passiveModification.getSourceHref().flatMap(Href::getEId);
-              return amendingLaw.getMods().stream()
-                  .filter(mod -> mod.getEid().equals(sourceEid))
-                  .map(
-                      mod ->
-                          new ModData(
-                              passiveModification.getDestinationHref(),
-                              passiveModification.getDestinationUpTo(),
-                              mod));
-            })
-        .forEach(modData -> applyMod(modData, norm));
+        var sourceEid = passiveModification.getSourceHref().flatMap(Href::getEId);
+        return amendingLaw
+          .getMods()
+          .stream()
+          .filter(mod -> mod.getEid().equals(sourceEid))
+          .map(mod ->
+            new ModData(
+              passiveModification.getDestinationHref(),
+              passiveModification.getDestinationUpTo(),
+              mod
+            )
+          );
+      })
+      .forEach(modData -> applyMod(modData, norm));
 
     EidConsistencyGuardian.correctEids(norm.getDocument());
 
@@ -127,9 +132,10 @@ public class TimeMachineService implements ApplyPassiveModificationsUseCase {
     }
 
     final var targetEid = modData.targetHref().get().getEId().get();
-    final var targetNode =
-        NodeParser.getNodeFromExpression(
-            String.format("//*[@eId='%s']", targetEid), targetZf0Norm.getDocument());
+    final var targetNode = NodeParser.getNodeFromExpression(
+      String.format("//*[@eId='%s']", targetEid),
+      targetZf0Norm.getDocument()
+    );
 
     if (targetNode.isEmpty()) {
       return;
@@ -140,8 +146,9 @@ public class TimeMachineService implements ApplyPassiveModificationsUseCase {
         applyQuotedText(modData, targetNode.get());
       } catch (IllegalArgumentException | IndexOutOfBoundsException exception) {
         log.info(
-            "Could not apply quoted text mod (%s)".formatted(modData.mod().getMandatoryEid()),
-            exception);
+          "Could not apply quoted text mod (%s)".formatted(modData.mod().getMandatoryEid()),
+          exception
+        );
       }
     } else if (modData.mod().getQuotedStructure().isPresent()) {
       applyQuotedStructure(modData, targetNode.get(), targetZf0Norm);
@@ -149,31 +156,33 @@ public class TimeMachineService implements ApplyPassiveModificationsUseCase {
   }
 
   private void applyQuotedText(final ModData modData, Node targetNode)
-      throws IllegalArgumentException, IndexOutOfBoundsException {
+    throws IllegalArgumentException, IndexOutOfBoundsException {
     final Mod mod = modData.mod();
-    final Node secondQuotedTextNode =
-        mod.getSecondQuotedText()
-            .orElseThrow(
-                () -> new IllegalArgumentException("Second quoted text (new text) is empty."));
-    final var targetHref =
-        modData
-            .targetHref()
-            .orElseThrow(() -> new IllegalArgumentException("Target href is empty."));
-    final var characterRange =
-        targetHref
-            .getCharacterRange()
-            .orElseThrow(
-                () ->
-                    new IllegalArgumentException(
-                        "Destination has empty character range (%s)".formatted(targetHref)));
-    final var oldText =
-        mod.getOldText().orElseThrow(() -> new IllegalArgumentException("Old text is empty."));
+    final Node secondQuotedTextNode = mod
+      .getSecondQuotedText()
+      .orElseThrow(() -> new IllegalArgumentException("Second quoted text (new text) is empty."));
+    final var targetHref = modData
+      .targetHref()
+      .orElseThrow(() -> new IllegalArgumentException("Target href is empty."));
+    final var characterRange = targetHref
+      .getCharacterRange()
+      .orElseThrow(() ->
+        new IllegalArgumentException(
+          "Destination has empty character range (%s)".formatted(targetHref)
+        )
+      );
+    final var oldText = mod
+      .getOldText()
+      .orElseThrow(() -> new IllegalArgumentException("Old text is empty."));
 
     if (!Objects.equals(characterRange.findTextInNode(targetNode), oldText)) {
       throw new IllegalArgumentException(
-          "Old text (%s) is not the same as the text of the character range (%s). Text of the node: %s"
-              .formatted(
-                  oldText, characterRange.findTextInNode(targetNode), targetNode.getTextContent()));
+        "Old text (%s) is not the same as the text of the character range (%s). Text of the node: %s".formatted(
+            oldText,
+            characterRange.findTextInNode(targetNode),
+            targetNode.getTextContent()
+          )
+      );
     }
 
     final var nodesToBeReplaced = characterRange.getNodesInRange(targetNode);
@@ -182,18 +191,21 @@ public class TimeMachineService implements ApplyPassiveModificationsUseCase {
 
     // Import content of quotedText from amending law (which include akn:refs) using importNode
     // because of different documents
-    NodeParser.nodeListToList(secondQuotedTextNode.getChildNodes())
-        .forEach(
-            child -> {
-              final Node importedChild = targetNode.getOwnerDocument().importNode(child, true);
-              newChildFragment.appendChild(importedChild);
-            });
+    NodeParser
+      .nodeListToList(secondQuotedTextNode.getChildNodes())
+      .forEach(child -> {
+        final Node importedChild = targetNode.getOwnerDocument().importNode(child, true);
+        newChildFragment.appendChild(importedChild);
+      });
 
     replaceNodes(nodesToBeReplaced, newChildFragment);
   }
 
   private void applyQuotedStructure(
-      final ModData modData, final Node targetNode, final Norm targetZf0Norm) {
+    final ModData modData,
+    final Node targetNode,
+    final Norm targetZf0Norm
+  ) {
     final Mod mod = modData.mod();
     if (mod.getQuotedStructure().isEmpty()) return;
 
@@ -204,23 +216,25 @@ public class TimeMachineService implements ApplyPassiveModificationsUseCase {
       } else {
         final var upToTargetNodeEid = modData.targetUpToRef().get().getEId().get();
         upToTargetNode =
-            NodeParser.getNodeFromExpression(
-                String.format("//*[@eId='%s']", upToTargetNodeEid), targetZf0Norm.getDocument());
+        NodeParser.getNodeFromExpression(
+          String.format("//*[@eId='%s']", upToTargetNodeEid),
+          targetZf0Norm.getDocument()
+        );
         if (upToTargetNode.isEmpty()) {
           return;
         }
       }
     }
 
-    final List<Node> newQuotedStructureContent =
-        NodeParser.nodeListToList(mod.getQuotedStructure().get().getChildNodes());
+    final List<Node> newQuotedStructureContent = NodeParser.nodeListToList(
+      mod.getQuotedStructure().get().getChildNodes()
+    );
 
     final Node newChildFragment = targetNode.getOwnerDocument().createDocumentFragment();
-    newQuotedStructureContent.forEach(
-        node -> {
-          Node importedChild = targetNode.getOwnerDocument().importNode(node, true);
-          newChildFragment.appendChild(importedChild);
-        });
+    newQuotedStructureContent.forEach(node -> {
+      Node importedChild = targetNode.getOwnerDocument().importNode(node, true);
+      newChildFragment.appendChild(importedChild);
+    });
 
     // Collect nodes to be replaced
     final List<Node> nodesToReplace = new ArrayList<>();

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/XsltTransformationService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/XsltTransformationService.java
@@ -42,14 +42,15 @@ public class XsltTransformationService implements TransformLegalDocMlToHtmlUseCa
       String inputXml = query.xml();
       if (query.snippet()) {
         inputXml =
-            "<akn:akomaNtoso xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\">"
-                + inputXml
-                + "</akn:akomaNtoso>";
+        "<akn:akomaNtoso xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\">" +
+        inputXml +
+        "</akn:akomaNtoso>";
       }
       StringWriter output = new StringWriter();
       transformer.transform(
-          new StreamSource(new ByteArrayInputStream(inputXml.getBytes())),
-          new StreamResult(output));
+        new StreamSource(new ByteArrayInputStream(inputXml.getBytes())),
+        new StreamResult(output)
+      );
       return output.toString();
     } catch (IOException | TransformerException e) {
       throw new XmlProcessingException(e.getMessage(), e);

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/config/CustomTracesSamplerCallback.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/config/CustomTracesSamplerCallback.java
@@ -10,14 +10,16 @@ import org.springframework.stereotype.Component;
 /** Custom filter for sentry traces. Removes all traces for the actuator endpoints. */
 @Component
 public class CustomTracesSamplerCallback implements TracesSamplerCallback {
+
   @Override
   public @Nullable Double sample(@NotNull SamplingContext context) {
     if (context.getCustomSamplingContext() == null) {
       return null;
     }
 
-    ServerHttpRequest request =
-        (ServerHttpRequest) context.getCustomSamplingContext().get("request");
+    ServerHttpRequest request = (ServerHttpRequest) context
+      .getCustomSamplingContext()
+      .get("request");
 
     if (request == null) {
       return null;

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/config/SecurityConfig.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/config/SecurityConfig.java
@@ -26,25 +26,27 @@ public class SecurityConfig {
    */
   @Bean
   public SecurityFilterChain apiFilterChain(HttpSecurity http) throws Exception {
-    http.authorizeHttpRequests(
-            authorize ->
-                authorize
-                    .requestMatchers(
-                        "/.well-known/security.txt",
-                        "/favicon.svg",
-                        "/actuator/health/**",
-                        "/actuator/prometheus",
-                        "/api/**",
-                        "/index.html",
-                        "/",
-                        "/assets/**")
-                    .permitAll()
-                    .anyRequest()
-                    .denyAll())
-        .csrf(AbstractHttpConfigurer::disable)
-        .sessionManagement(
-            sessionManagement ->
-                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.ALWAYS));
+    http
+      .authorizeHttpRequests(authorize ->
+        authorize
+          .requestMatchers(
+            "/.well-known/security.txt",
+            "/favicon.svg",
+            "/actuator/health/**",
+            "/actuator/prometheus",
+            "/api/**",
+            "/index.html",
+            "/",
+            "/assets/**"
+          )
+          .permitAll()
+          .anyRequest()
+          .denyAll()
+      )
+      .csrf(AbstractHttpConfigurer::disable)
+      .sessionManagement(sessionManagement ->
+        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.ALWAYS)
+      );
     return http.build();
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Analysis.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Analysis.java
@@ -23,9 +23,11 @@ public class Analysis {
    * @return a list of active modifications.
    */
   public List<TextualMod> getActiveModifications() {
-    return NodeParser.getNodesFromExpression("./activeModifications/textualMod", node).stream()
-        .map(TextualMod::new)
-        .toList();
+    return NodeParser
+      .getNodesFromExpression("./activeModifications/textualMod", node)
+      .stream()
+      .map(TextualMod::new)
+      .toList();
   }
 
   /**
@@ -34,9 +36,11 @@ public class Analysis {
    * @return a list of passive modifications.
    */
   public List<TextualMod> getPassiveModifications() {
-    return NodeParser.getNodesFromExpression("./passiveModifications/textualMod", node).stream()
-        .map(TextualMod::new)
-        .toList();
+    return NodeParser
+      .getNodesFromExpression("./passiveModifications/textualMod", node)
+      .stream()
+      .map(TextualMod::new)
+      .toList();
   }
 
   /**
@@ -45,8 +49,9 @@ public class Analysis {
    * @return the akn:passiveModifications element of the norm
    */
   public Node getOrCreatePassiveModificationsNode() {
-    return NodeParser.getNodeFromExpression("./passiveModifications", node)
-        .orElseGet(() -> NodeCreator.createElementWithEidAndGuid("akn:passiveModifications", node));
+    return NodeParser
+      .getNodeFromExpression("./passiveModifications", node)
+      .orElseGet(() -> NodeCreator.createElementWithEidAndGuid("akn:passiveModifications", node));
   }
 
   /**
@@ -61,15 +66,18 @@ public class Analysis {
    * @return the newly create passive modification
    */
   public TextualMod addPassiveModification(
-      String type,
-      String sourceHref,
-      String destinationHref,
-      String periodHref,
-      String destinationUpTo) {
+    String type,
+    String sourceHref,
+    String destinationHref,
+    String periodHref,
+    String destinationUpTo
+  ) {
     var passiveModificationsNode = getOrCreatePassiveModificationsNode();
 
-    var textualMod =
-        NodeCreator.createElementWithEidAndGuid("akn:textualMod", passiveModificationsNode);
+    var textualMod = NodeCreator.createElementWithEidAndGuid(
+      "akn:textualMod",
+      passiveModificationsNode
+    );
     textualMod.setAttribute("type", type);
     passiveModificationsNode.appendChild(textualMod);
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Announcement.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Announcement.java
@@ -13,6 +13,7 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @Data
 public class Announcement {
+
   private Instant releasedByDocumentalistAt;
 
   private Norm norm;

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Article.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Article.java
@@ -17,6 +17,7 @@ import org.w3c.dom.Node;
 @SuperBuilder(toBuilder = true)
 @AllArgsConstructor
 public class Article {
+
   private final Node node;
 
   /**
@@ -80,8 +81,10 @@ public class Article {
    * @param href The ELI of the affected document of the article
    */
   public void setAffectedDocumentEli(String href) {
-    Optional<Node> articleAffectedDocument =
-        NodeParser.getNodeFromExpression(".//affectedDocument/@href", this.node);
+    Optional<Node> articleAffectedDocument = NodeParser.getNodeFromExpression(
+      ".//affectedDocument/@href",
+      this.node
+    );
     articleAffectedDocument.ifPresent(value -> value.setTextContent(href));
   }
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/CharacterRange.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/CharacterRange.java
@@ -66,8 +66,10 @@ public record CharacterRange(String characterRange) {
    * @return the text-content of the range
    */
   public String findTextInNode(Node node) {
-    var text =
-        getNodesInRange(node).stream().map(Node::getTextContent).collect(Collectors.joining());
+    var text = getNodesInRange(node)
+      .stream()
+      .map(Node::getTextContent)
+      .collect(Collectors.joining());
     node.normalize();
     return text;
   }
@@ -89,25 +91,27 @@ public record CharacterRange(String characterRange) {
     // text before selection
     if (start != 0) {
       textNode
-          .getParentNode()
-          .insertBefore(
-              textNode.getOwnerDocument().createTextNode(textContent.substring(0, start)),
-              textNode);
+        .getParentNode()
+        .insertBefore(
+          textNode.getOwnerDocument().createTextNode(textContent.substring(0, start)),
+          textNode
+        );
     }
 
     // selected text
     final var rangeTextContent = textContent.substring(start, Math.min(textContent.length(), end));
-    final var rangeNode =
-        textNode
-            .getParentNode()
-            .insertBefore(textNode.getOwnerDocument().createTextNode(rangeTextContent), textNode);
+    final var rangeNode = textNode
+      .getParentNode()
+      .insertBefore(textNode.getOwnerDocument().createTextNode(rangeTextContent), textNode);
 
     // text after selection
     if (end < textContent.length()) {
       textNode
-          .getParentNode()
-          .insertBefore(
-              textNode.getOwnerDocument().createTextNode(textContent.substring(end)), textNode);
+        .getParentNode()
+        .insertBefore(
+          textNode.getOwnerDocument().createTextNode(textContent.substring(end)),
+          textNode
+        );
     }
 
     textNode.getParentNode().removeChild(textNode);
@@ -127,14 +131,20 @@ public record CharacterRange(String characterRange) {
   public List<Node> getNodesInRange(Node node) throws IndexOutOfBoundsException {
     if (node.getTextContent().length() < getStart()) {
       throw new IndexOutOfBoundsException(
-          "Start (%d) is after the end of the text content (length: %d)."
-              .formatted(getStart(), node.getTextContent().length()));
+        "Start (%d) is after the end of the text content (length: %d).".formatted(
+            getStart(),
+            node.getTextContent().length()
+          )
+      );
     }
 
     if (node.getTextContent().length() < getEnd()) {
       throw new IndexOutOfBoundsException(
-          "End (%d) is after the end of the text content (length: %d)."
-              .formatted(getEnd(), node.getTextContent().length()));
+        "End (%d) is after the end of the text content (length: %d).".formatted(
+            getEnd(),
+            node.getTextContent().length()
+          )
+      );
     }
 
     if (getStart() == 0 && getEnd() == node.getTextContent().length()) {
@@ -154,11 +164,10 @@ public record CharacterRange(String characterRange) {
         for (Node childNode : NodeParser.nodeListToList(node.getChildNodes())) {
           int textContentLength = childNode.getTextContent().length();
           if (start < textContentLength) {
-            var newRange =
-                new Builder()
-                    .start(Math.max(0, start))
-                    .end(Math.min(textContentLength, end))
-                    .build();
+            var newRange = new Builder()
+              .start(Math.max(0, start))
+              .end(Math.min(textContentLength, end))
+              .build();
 
             nodesInRange.addAll(newRange.getNodesInRange(childNode));
           }
@@ -172,15 +181,18 @@ public record CharacterRange(String characterRange) {
         }
 
         throw new IndexOutOfBoundsException(
-            "Expected end (%d) to be <= 0 after iterating all child nodes.".formatted(end));
+          "Expected end (%d) to be <= 0 after iterating all child nodes.".formatted(end)
+        );
       }
-      default ->
-          throw new UnsupportedOperationException("Unsupported node type: " + node.getNodeType());
+      default -> throw new UnsupportedOperationException(
+        "Unsupported node type: " + node.getNodeType()
+      );
     }
   }
 
   /** Builder for creating a new {@link CharacterRange}. */
   public static class Builder {
+
     private int start;
     private int end;
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/EId.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/EId.java
@@ -84,40 +84,43 @@ public record EId(String value) {
       return Optional.empty();
     }
 
-    var newEIdPart =
-        new EIdPart(eIdPartType.get().getName(), findEIdPosition(node, eIdPartType.get()));
+    var newEIdPart = new EIdPart(
+      eIdPartType.get().getName(),
+      findEIdPosition(node, eIdPartType.get())
+    );
 
     return parentEId
-        .map(eId -> eId.addPart(newEIdPart))
-        .or(() -> Optional.of(new EId(newEIdPart.value())));
+      .map(eId -> eId.addPart(newEIdPart))
+      .or(() -> Optional.of(new EId(newEIdPart.value())));
   }
 
   private static String findEIdPosition(Node node, EIdPartType eIdPartType) {
-    if (node.getNodeName().equals("akn:li")
-        && node.getParentNode().getNodeName().equals("akn:ol")) {
+    if (
+      node.getNodeName().equals("akn:li") && node.getParentNode().getNodeName().equals("akn:ol")
+    ) {
       return node.getAttributes().getNamedItem("value").getNodeValue().replace(".", "");
     }
 
-    return NodeParser.getValueFromExpression("./num/marker/@name", node)
-        .orElseGet(
-            () -> {
-              var position = 1;
-              var previousSibling = node.getPreviousSibling();
-              while (previousSibling != null) {
-                var eId = EId.fromNode(previousSibling);
+    return NodeParser
+      .getValueFromExpression("./num/marker/@name", node)
+      .orElseGet(() -> {
+        var position = 1;
+        var previousSibling = node.getPreviousSibling();
+        while (previousSibling != null) {
+          var eId = EId.fromNode(previousSibling);
 
-                if (eId.isPresent()) {
-                  var previousSiblingEIdType = eId.get().getParts().getLast().getType();
+          if (eId.isPresent()) {
+            var previousSiblingEIdType = eId.get().getParts().getLast().getType();
 
-                  if (previousSiblingEIdType.equals(eIdPartType.getName())) {
-                    position++;
-                  }
-                }
+            if (previousSiblingEIdType.equals(eIdPartType.getName())) {
+              position++;
+            }
+          }
 
-                previousSibling = previousSibling.getPreviousSibling();
-              }
+          previousSibling = previousSibling.getPreviousSibling();
+        }
 
-              return "%d".formatted(position);
-            });
+        return "%d".formatted(position);
+      });
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/EIdPartType.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/EIdPartType.java
@@ -60,9 +60,7 @@ public enum EIdPartType {
   FRBRAUTHOR("frbrauthor", List.of("akn:FRBRauthor")),
   FRBRCOUNTRY("frbrcountry", List.of("akn:FRBRcountry")),
   FRBRDATE("frbrdate", List.of("akn:FRBRdate")),
-  FRBRERSIONNUMBER(
-      "frbrersionnumber",
-      List.of("akn:FRBRversionNumber")), // TODO: (Malte Laukötter, 2024-08-28) change to
+  FRBRERSIONNUMBER("frbrersionnumber", List.of("akn:FRBRversionNumber")), // TODO: (Malte Laukötter, 2024-08-28) change to
   // "frbrversionnumber" for LDML.de 1.7
   FRBREXPRESSION("frbrexpression", List.of("akn:FRBRExpression")),
   FRBRFORMAT("frbrformat", List.of("akn:FRBRformat")),
@@ -139,11 +137,7 @@ public enum EIdPartType {
   UNTERGL("untergl", List.of("akn:list")),
   UTITEL("utitel", List.of("akn:subtitle")),
   VERWEIS("verweis", List.of("akn:documentRef")),
-  ZAEHLBEZ(
-      "zaehlbez",
-      List.of(
-          "akn:marker")) // TODO: (Malte Laukötter, 2024-08-28) change to "marker" for LDML.de 1.7
-;
+  ZAEHLBEZ("zaehlbez", List.of("akn:marker")); // TODO: (Malte Laukötter, 2024-08-28) change to "marker" for LDML.de 1.7
 
   /** Name for the part type to use in the eId. */
   private final String name;
@@ -168,14 +162,17 @@ public enum EIdPartType {
       return Optional.of(forAknArticle(aknElement));
     }
 
-    return Arrays.stream(EIdPartType.values())
-        .filter(partType -> partType.aknElements.contains(aknElement.getNodeName()))
-        .findFirst();
+    return Arrays
+      .stream(EIdPartType.values())
+      .filter(partType -> partType.aknElements.contains(aknElement.getNodeName()))
+      .findFirst();
   }
 
   private static EIdPartType forAknArticle(Node aknArticleElement) {
-    var isInQuotedStructure =
-        NodeParser.getNodeFromExpression("ancestor::quotedStructure", aknArticleElement);
+    var isInQuotedStructure = NodeParser.getNodeFromExpression(
+      "ancestor::quotedStructure",
+      aknArticleElement
+    );
 
     var refersToAttribute = aknArticleElement.getAttributes().getNamedItem("refersTo");
     var typ = Optional.ofNullable(refersToAttribute).map(Node::getNodeValue).orElse("");
@@ -189,21 +186,23 @@ public enum EIdPartType {
       return EIdPartType.PARA;
     }
 
-    var form =
-        NodeParser.getValueFromExpression(
-            "//akomaNtoso/*/meta/proprietary/legalDocML.de_metadaten/form", aknArticleElement);
+    var form = NodeParser.getValueFromExpression(
+      "//akomaNtoso/*/meta/proprietary/legalDocML.de_metadaten/form",
+      aknArticleElement
+    );
 
     if (form.isEmpty()) {
       throw new IllegalArgumentException(
-          "Could not determine expected eId for akn:article node. No meta:form found.");
+        "Could not determine expected eId for akn:article node. No meta:form found."
+      );
     }
 
     switch (form.get()) {
-        // SCH-00570-000 (second part)
+      // SCH-00570-000 (second part)
       case "eingebundene-stammform" -> {
         return EIdPartType.PARA;
       }
-        // SCH-00570-010
+      // SCH-00570-010
       case "mantelform" -> {
         return EIdPartType.ART;
       }
@@ -216,10 +215,11 @@ public enum EIdPartType {
         // SCH-00570-000 (first part)
         return EIdPartType.PARA;
       }
-      default ->
-          throw new IllegalArgumentException(
-              "Could not determine expected eId for akn:article node. Unexpected form (%s)"
-                  .formatted(form));
+      default -> throw new IllegalArgumentException(
+        "Could not determine expected eId for akn:article node. Unexpected form (%s)".formatted(
+            form
+          )
+      );
     }
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Eli.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Eli.java
@@ -18,6 +18,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class Eli {
+
   private String agent;
   private String year;
   private String naturalIdentifier;
@@ -27,10 +28,11 @@ public class Eli {
   private String subtype;
 
   public Eli(String eli) {
-    Matcher matcher =
-        Pattern.compile(
-                "eli/bund/(?<agent>[^/]+)/(?<year>[^/]+)/(?<naturalIdentifier>[^/]+)/(?<pointInTime>[^/]+)/(?<version>[^/]+)/(?<language>[^/]+)/(?<subtype>[^/.]+)(\\.xml)?")
-            .matcher(eli);
+    Matcher matcher = Pattern
+      .compile(
+        "eli/bund/(?<agent>[^/]+)/(?<year>[^/]+)/(?<naturalIdentifier>[^/]+)/(?<pointInTime>[^/]+)/(?<version>[^/]+)/(?<language>[^/]+)/(?<subtype>[^/.]+)(\\.xml)?"
+      )
+      .matcher(eli);
 
     if (!matcher.matches()) {
       throw new IllegalArgumentException("Invalid Eli");
@@ -46,19 +48,21 @@ public class Eli {
   }
 
   public String getValue() {
-    return "eli/bund/"
-        + agent
-        + "/"
-        + year
-        + "/"
-        + naturalIdentifier
-        + "/"
-        + pointInTime
-        + "/"
-        + version
-        + "/"
-        + language
-        + "/"
-        + subtype;
+    return (
+      "eli/bund/" +
+      agent +
+      "/" +
+      year +
+      "/" +
+      naturalIdentifier +
+      "/" +
+      pointInTime +
+      "/" +
+      version +
+      "/" +
+      language +
+      "/" +
+      subtype
+    );
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/EventRef.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/EventRef.java
@@ -13,6 +13,7 @@ import org.w3c.dom.Node;
 @AllArgsConstructor
 @SuperBuilder(toBuilder = true)
 public class EventRef {
+
   private final Node node;
 
   public EId getEid() {

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/FRBR.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/FRBR.java
@@ -16,6 +16,7 @@ import org.w3c.dom.Node;
 @AllArgsConstructor
 @SuperBuilder(toBuilder = true)
 public abstract class FRBR {
+
   private final Node node;
 
   /**
@@ -33,10 +34,11 @@ public abstract class FRBR {
    * @param eli - the new ELI
    */
   public void setEli(final String eli) {
-    NodeParser.getMandatoryNodeFromExpression("./FRBRthis", node)
-        .getAttributes()
-        .getNamedItem("value")
-        .setNodeValue(eli);
+    NodeParser
+      .getMandatoryNodeFromExpression("./FRBRthis", node)
+      .getAttributes()
+      .getNamedItem("value")
+      .setNodeValue(eli);
   }
 
   /**
@@ -55,8 +57,9 @@ public abstract class FRBR {
    * @param name - the new name
    */
   public void setFBRDate(final String date, final String name) {
-    final NamedNodeMap attributes =
-        NodeParser.getMandatoryNodeFromExpression("./FRBRdate", node).getAttributes();
+    final NamedNodeMap attributes = NodeParser
+      .getMandatoryNodeFromExpression("./FRBRdate", node)
+      .getAttributes();
     attributes.getNamedItem("date").setNodeValue(date);
     attributes.getNamedItem("name").setNodeValue(name);
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/FRBRExpression.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/FRBRExpression.java
@@ -26,9 +26,9 @@ public class FRBRExpression extends FRBR {
    * @return the uuid
    */
   public Optional<UUID> getFRBRaliasPreviousVersionId() {
-    return NodeParser.getValueFromExpression(
-            "./FRBRalias[@name='vorherige-version-id']/@value", getNode())
-        .map(UUID::fromString);
+    return NodeParser
+      .getValueFromExpression("./FRBRalias[@name='vorherige-version-id']/@value", getNode())
+      .map(UUID::fromString);
   }
 
   /**
@@ -37,19 +37,21 @@ public class FRBRExpression extends FRBR {
    * @param uuid the new uuid
    */
   public void setFRBRaliasPreviousVersionId(final UUID uuid) {
-    NodeParser.getNodeFromExpression("./FRBRalias[@name='vorherige-version-id']", getNode())
-        .orElseGet(
-            () -> {
-              final Element newElement =
-                  NodeCreator.createElementWithEidAndGuid("akn:FRBRalias", getNode());
-              newElement.setAttribute("name", "vorherige-version-id");
-              newElement.setAttribute(VALUE_ATTIBUTE, uuid.toString());
-              getNode().appendChild(newElement);
-              return newElement;
-            })
-        .getAttributes()
-        .getNamedItem(VALUE_ATTIBUTE)
-        .setNodeValue(uuid.toString());
+    NodeParser
+      .getNodeFromExpression("./FRBRalias[@name='vorherige-version-id']", getNode())
+      .orElseGet(() -> {
+        final Element newElement = NodeCreator.createElementWithEidAndGuid(
+          "akn:FRBRalias",
+          getNode()
+        );
+        newElement.setAttribute("name", "vorherige-version-id");
+        newElement.setAttribute(VALUE_ATTIBUTE, uuid.toString());
+        getNode().appendChild(newElement);
+        return newElement;
+      })
+      .getAttributes()
+      .getNamedItem(VALUE_ATTIBUTE)
+      .setNodeValue(uuid.toString());
   }
 
   /**
@@ -59,8 +61,11 @@ public class FRBRExpression extends FRBR {
    */
   public UUID getFRBRaliasCurrentVersionId() {
     return UUID.fromString(
-        NodeParser.getValueFromMandatoryNodeFromExpression(
-            "./FRBRalias[@name='aktuelle-version-id']/@value", getNode()));
+      NodeParser.getValueFromMandatoryNodeFromExpression(
+        "./FRBRalias[@name='aktuelle-version-id']/@value",
+        getNode()
+      )
+    );
   }
 
   /**
@@ -69,10 +74,11 @@ public class FRBRExpression extends FRBR {
    * @param uuid the new uuid
    */
   public void setFRBRaliasCurrentVersionId(final UUID uuid) {
-    NodeParser.getMandatoryNodeFromExpression("./FRBRalias[@name='aktuelle-version-id']", getNode())
-        .getAttributes()
-        .getNamedItem(VALUE_ATTIBUTE)
-        .setNodeValue(uuid.toString());
+    NodeParser
+      .getMandatoryNodeFromExpression("./FRBRalias[@name='aktuelle-version-id']", getNode())
+      .getAttributes()
+      .getNamedItem(VALUE_ATTIBUTE)
+      .setNodeValue(uuid.toString());
   }
 
   /**
@@ -82,8 +88,11 @@ public class FRBRExpression extends FRBR {
    */
   public UUID getFRBRaliasNextVersionId() {
     return UUID.fromString(
-        NodeParser.getValueFromMandatoryNodeFromExpression(
-            "./FRBRalias[@name='nachfolgende-version-id']/@value", getNode()));
+      NodeParser.getValueFromMandatoryNodeFromExpression(
+        "./FRBRalias[@name='nachfolgende-version-id']/@value",
+        getNode()
+      )
+    );
   }
 
   /**
@@ -92,10 +101,10 @@ public class FRBRExpression extends FRBR {
    * @param uuid the new uuid
    */
   public void setFRBRaliasNextVersionId(final UUID uuid) {
-    NodeParser.getMandatoryNodeFromExpression(
-            "./FRBRalias[@name='nachfolgende-version-id']", getNode())
-        .getAttributes()
-        .getNamedItem(VALUE_ATTIBUTE)
-        .setNodeValue(uuid.toString());
+    NodeParser
+      .getMandatoryNodeFromExpression("./FRBRalias[@name='nachfolgende-version-id']", getNode())
+      .getAttributes()
+      .getNamedItem(VALUE_ATTIBUTE)
+      .setNodeValue(uuid.toString());
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/FRBRWork.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/FRBRWork.java
@@ -23,11 +23,9 @@ public class FRBRWork extends FRBR {
   public Optional<String> getFRBRname() {
     Optional<String> fRBRname = NodeParser.getValueFromExpression("./FRBRname/@value", getNode());
 
-    return fRBRname.map(
-        s ->
-            s.replace("bgbl-1", "BGBl. I")
-                .replace("bgbl-2", "BGBl. II")
-                .replace("banz-at", "BAnz AT"));
+    return fRBRname.map(s ->
+      s.replace("bgbl-1", "BGBl. I").replace("bgbl-2", "BGBl. II").replace("banz-at", "BAnz AT")
+    );
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Href.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Href.java
@@ -35,11 +35,14 @@ public record Href(String value) {
       return Optional.empty();
     }
 
-    return Optional.of(
-            Arrays.stream(value().split("/"))
-                .limit(NUMBER_OF_ELI_PARTS)
-                .collect(Collectors.joining("/")))
-        .map(Href::removeFileExtension);
+    return Optional
+      .of(
+        Arrays
+          .stream(value().split("/"))
+          .limit(NUMBER_OF_ELI_PARTS)
+          .collect(Collectors.joining("/"))
+      )
+      .map(Href::removeFileExtension);
   }
 
   /**
@@ -103,12 +106,13 @@ public record Href(String value) {
     }
 
     return Optional.of(
-        new CharacterRange(
-            Href.removeFileExtension(splitHref[ABSOLUTE_POSITION_OF_CHARACTER_RANGE])));
+      new CharacterRange(Href.removeFileExtension(splitHref[ABSOLUTE_POSITION_OF_CHARACTER_RANGE]))
+    );
   }
 
   /** Builder for creating a new {@link Href}. */
   public static class Builder {
+
     private String eli;
     private String eId;
     private CharacterRange characterRange;

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Lifecycle.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Lifecycle.java
@@ -21,8 +21,10 @@ public class Lifecycle {
    * @return the list of {@link EventRef}
    */
   public List<EventRef> getEventRefs() {
-    return NodeParser.getNodesFromExpression("./eventRef", node).stream()
-        .map(EventRef::new)
-        .toList();
+    return NodeParser
+      .getNodesFromExpression("./eventRef", node)
+      .stream()
+      .map(EventRef::new)
+      .toList();
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Meta.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Meta.java
@@ -14,8 +14,9 @@ import org.w3c.dom.Node;
 @AllArgsConstructor
 @SuperBuilder(toBuilder = true)
 public class Meta {
+
   private static final String ATTRIBUTSEMANTIK_NOCH_UNDEFINIERT =
-      "attributsemantik-noch-undefiniert";
+    "attributsemantik-noch-undefiniert";
 
   private static final String SOURCE_ATTIBUTE = "source";
 
@@ -28,7 +29,8 @@ public class Meta {
    */
   public FRBRWork getFRBRWork() {
     return new FRBRWork(
-        NodeParser.getMandatoryNodeFromExpression("./identification/FRBRWork", node));
+      NodeParser.getMandatoryNodeFromExpression("./identification/FRBRWork", node)
+    );
   }
 
   /**
@@ -38,7 +40,8 @@ public class Meta {
    */
   public FRBRExpression getFRBRExpression() {
     return new FRBRExpression(
-        NodeParser.getMandatoryNodeFromExpression("./identification/FRBRExpression", node));
+      NodeParser.getMandatoryNodeFromExpression("./identification/FRBRExpression", node)
+    );
   }
 
   /**
@@ -48,7 +51,8 @@ public class Meta {
    */
   public FRBRManifestation getFRBRManifestation() {
     return new FRBRManifestation(
-        NodeParser.getMandatoryNodeFromExpression("./identification/FRBRManifestation", node));
+      NodeParser.getMandatoryNodeFromExpression("./identification/FRBRManifestation", node)
+    );
   }
 
   /**
@@ -100,12 +104,11 @@ public class Meta {
    */
   public Analysis getOrCreateAnalysis() {
     return getAnalysis()
-        .orElseGet(
-            () -> {
-              final var newElement = NodeCreator.createElementWithEidAndGuid("akn:analysis", node);
-              newElement.setAttribute(SOURCE_ATTIBUTE, ATTRIBUTSEMANTIK_NOCH_UNDEFINIERT);
-              return new Analysis(newElement);
-            });
+      .orElseGet(() -> {
+        final var newElement = NodeCreator.createElementWithEidAndGuid("akn:analysis", node);
+        newElement.setAttribute(SOURCE_ATTIBUTE, ATTRIBUTSEMANTIK_NOCH_UNDEFINIERT);
+        return new Analysis(newElement);
+      });
   }
 
   /**
@@ -114,14 +117,13 @@ public class Meta {
    * @return the akn:proprietary element of the norm
    */
   public Proprietary getOrCreateProprietary() {
-    return NodeParser.getNodeFromExpression("./proprietary", node)
-        .map(Proprietary::new)
-        .orElseGet(
-            () -> {
-              final var newElement =
-                  NodeCreator.createElementWithEidAndGuid("akn:proprietary", node);
-              newElement.setAttribute(SOURCE_ATTIBUTE, ATTRIBUTSEMANTIK_NOCH_UNDEFINIERT);
-              return new Proprietary(newElement);
-            });
+    return NodeParser
+      .getNodeFromExpression("./proprietary", node)
+      .map(Proprietary::new)
+      .orElseGet(() -> {
+        final var newElement = NodeCreator.createElementWithEidAndGuid("akn:proprietary", node);
+        newElement.setAttribute(SOURCE_ATTIBUTE, ATTRIBUTSEMANTIK_NOCH_UNDEFINIERT);
+        return new Proprietary(newElement);
+      });
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/MetadatenDs.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/MetadatenDs.java
@@ -71,9 +71,11 @@ public class MetadatenDs extends Metadaten<MetadatenDs.Metadata> {
    * @return an optional string value of the attribute, if found
    */
   public Optional<String> getAttributeOfSimpleMetadatumAt(
-      final MetadatenDs.Attribute attribute, final LocalDate date) {
+    final MetadatenDs.Attribute attribute,
+    final LocalDate date
+  ) {
     return getSimpleNodeAt(attribute.simpleMetadatum, date)
-        .flatMap(m -> m.getAttribute(attribute.name));
+      .flatMap(m -> m.getAttribute(attribute.name));
   }
 
   /**
@@ -84,16 +86,18 @@ public class MetadatenDs extends Metadaten<MetadatenDs.Metadata> {
    * @param newValue the new value
    */
   public void setAttributeOfSimpleMetadatum(
-      final MetadatenDs.Attribute attribute, final LocalDate date, final String newValue) {
+    final MetadatenDs.Attribute attribute,
+    final LocalDate date,
+    final String newValue
+  ) {
     getSimpleNodeAt(attribute.simpleMetadatum, date)
-        .ifPresent(
-            m -> {
-              if (m.getValue().isEmpty()) {
-                m.removeAttribute(attribute.name);
-              } else {
-                m.setAttribute(attribute.name, newValue);
-              }
-            });
+      .ifPresent(m -> {
+        if (m.getValue().isEmpty()) {
+          m.removeAttribute(attribute.name);
+        } else {
+          m.setAttribute(attribute.name, newValue);
+        }
+      });
   }
 
   /**
@@ -106,10 +110,13 @@ public class MetadatenDs extends Metadaten<MetadatenDs.Metadata> {
    * @return value of the requested metadata element or empty if it doesn't exist
    */
   public Optional<String> getSingleElementSimpleMetadatum(
-      final Einzelelement.Metadata metadatumSingleElement, final String eid, final LocalDate date) {
-    return NodeParser.getNodeFromExpression(
-            "./einzelelement[@href='#%s']".formatted(eid), this.getNode())
-        .flatMap(node -> new Einzelelement(node).getSimpleMetadatum(metadatumSingleElement, date));
+    final Einzelelement.Metadata metadatumSingleElement,
+    final String eid,
+    final LocalDate date
+  ) {
+    return NodeParser
+      .getNodeFromExpression("./einzelelement[@href='#%s']".formatted(eid), this.getNode())
+      .flatMap(node -> new Einzelelement(node).getSimpleMetadatum(metadatumSingleElement, date));
   }
 
   /**
@@ -123,40 +130,45 @@ public class MetadatenDs extends Metadaten<MetadatenDs.Metadata> {
    * @param newValue the new value
    */
   public void updateSingleElementSimpleMetadatum(
-      final Einzelelement.Metadata metadatumSingleElement,
-      final String eid,
-      final LocalDate date,
-      final String newValue) {
-    NodeParser.getNodeFromExpression("./einzelelement[@href='#%s']".formatted(eid), this.getNode())
-        .ifPresentOrElse(
-            nodeFound -> {
-              Einzelelement e = new Einzelelement(nodeFound);
-              e.updateSimpleMetadatum(metadatumSingleElement, date, newValue);
+    final Einzelelement.Metadata metadatumSingleElement,
+    final String eid,
+    final LocalDate date,
+    final String newValue
+  ) {
+    NodeParser
+      .getNodeFromExpression("./einzelelement[@href='#%s']".formatted(eid), this.getNode())
+      .ifPresentOrElse(
+        nodeFound -> {
+          Einzelelement e = new Einzelelement(nodeFound);
+          e.updateSimpleMetadatum(metadatumSingleElement, date, newValue);
 
-              var nodeList = nodeFound.getChildNodes();
-              boolean nodeIsEmpty = true;
+          var nodeList = nodeFound.getChildNodes();
+          boolean nodeIsEmpty = true;
 
-              // all child nodes need to be not of type ELEMENT_NODE
-              for (int i = 0; i < nodeList.getLength(); i++) {
-                if (nodeList.item(i).getNodeType() == Node.ELEMENT_NODE) {
-                  nodeIsEmpty = false;
-                  break;
-                }
-              }
+          // all child nodes need to be not of type ELEMENT_NODE
+          for (int i = 0; i < nodeList.getLength(); i++) {
+            if (nodeList.item(i).getNodeType() == Node.ELEMENT_NODE) {
+              nodeIsEmpty = false;
+              break;
+            }
+          }
 
-              if (nodeIsEmpty) {
-                nodeFound.getParentNode().removeChild(nodeFound);
-              }
-            },
-            () -> {
-              if (StringUtils.isNotEmpty(newValue)) {
-                // Create and set the new element
-                final Element newElement =
-                    NodeCreator.createElement("meta:einzelelement", this.getNode());
-                newElement.setAttribute("href", "#%s".formatted(eid));
-                new Einzelelement(newElement)
-                    .updateSimpleMetadatum(metadatumSingleElement, date, newValue);
-              }
-            });
+          if (nodeIsEmpty) {
+            nodeFound.getParentNode().removeChild(nodeFound);
+          }
+        },
+        () -> {
+          if (StringUtils.isNotEmpty(newValue)) {
+            // Create and set the new element
+            final Element newElement = NodeCreator.createElement(
+              "meta:einzelelement",
+              this.getNode()
+            );
+            newElement.setAttribute("href", "#%s".formatted(eid));
+            new Einzelelement(newElement)
+              .updateSimpleMetadatum(metadatumSingleElement, date, newValue);
+          }
+        }
+      );
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Mod.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Mod.java
@@ -22,6 +22,7 @@ import org.w3c.dom.Node;
 @SuperBuilder(toBuilder = true)
 @EqualsAndHashCode
 public class Mod {
+
   private final Node node;
 
   private static final String REF_XPATH = "./ref";
@@ -61,7 +62,9 @@ public class Mod {
    */
   public String getMandatoryOldText() {
     return NodeParser.getValueFromMandatoryNodeFromExpression(
-        "normalize-space(./quotedText[1])", this.node);
+      "normalize-space(./quotedText[1])",
+      this.node
+    );
   }
 
   /**
@@ -70,9 +73,10 @@ public class Mod {
    * @param replacementText the text that should be replaced by this modification
    */
   public void setOldText(String replacementText) {
-    NodeParser.getNodeFromExpression("./quotedText[1]", this.node)
-        .orElseThrow()
-        .setTextContent(replacementText);
+    NodeParser
+      .getNodeFromExpression("./quotedText[1]", this.node)
+      .orElseThrow()
+      .setTextContent(replacementText);
   }
 
   /**
@@ -99,11 +103,12 @@ public class Mod {
    * @param newHref - the new ELI + eId of the target law
    */
   public void setTargetRefHref(final String newHref) {
-    NodeParser.getNodeFromExpression(REF_XPATH, this.node)
-        .orElseThrow()
-        .getAttributes()
-        .getNamedItem("href")
-        .setNodeValue(newHref);
+    NodeParser
+      .getNodeFromExpression(REF_XPATH, this.node)
+      .orElseThrow()
+      .getAttributes()
+      .getNamedItem("href")
+      .setNodeValue(newHref);
   }
 
   /**
@@ -121,11 +126,12 @@ public class Mod {
    * @param newFrom - the new ELI + eId of the target law
    */
   public void setTargetRrefFrom(final String newFrom) {
-    NodeParser.getNodeFromExpression(RREF_XPATH, this.node)
-        .orElseThrow()
-        .getAttributes()
-        .getNamedItem("from")
-        .setNodeValue(newFrom);
+    NodeParser
+      .getNodeFromExpression(RREF_XPATH, this.node)
+      .orElseThrow()
+      .getAttributes()
+      .getNamedItem("from")
+      .setNodeValue(newFrom);
   }
 
   /**
@@ -134,8 +140,9 @@ public class Mod {
    * @param newContent - the replacing text
    */
   public void setNewText(final String newContent) {
-    final Node newContentNode =
-        NodeParser.getNodeFromExpression("./quotedText[2]", this.node).orElseThrow();
+    final Node newContentNode = NodeParser
+      .getNodeFromExpression("./quotedText[2]", this.node)
+      .orElseThrow();
     newContentNode.setTextContent(newContent);
   }
 
@@ -180,8 +187,10 @@ public class Mod {
    * @return is it using a quotedText structure
    */
   public boolean usesQuotedText() {
-    final Optional<Node> newContentNode =
-        NodeParser.getNodeFromExpression("./quotedText", this.node);
+    final Optional<Node> newContentNode = NodeParser.getNodeFromExpression(
+      "./quotedText",
+      this.node
+    );
     return newContentNode.isPresent();
   }
 
@@ -191,8 +200,10 @@ public class Mod {
    * @return is it using a quotedStructure
    */
   public boolean usesQuotedStructure() {
-    final Optional<Node> newContentNode =
-        NodeParser.getNodeFromExpression("./quotedStructure", this.node);
+    final Optional<Node> newContentNode = NodeParser.getNodeFromExpression(
+      "./quotedStructure",
+      this.node
+    );
     return newContentNode.isPresent();
   }
 
@@ -221,11 +232,12 @@ public class Mod {
    * @param destinationUpTo - the UpTo attribute that should be updated
    */
   public void setTargetRrefUpTo(final String destinationUpTo) {
-    NodeParser.getNodeFromExpression(RREF_XPATH, this.node)
-        .orElseThrow()
-        .getAttributes()
-        .getNamedItem("upTo")
-        .setNodeValue(destinationUpTo);
+    NodeParser
+      .getNodeFromExpression(RREF_XPATH, this.node)
+      .orElseThrow()
+      .getAttributes()
+      .getNamedItem("upTo")
+      .setNodeValue(destinationUpTo);
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Norm.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Norm.java
@@ -33,12 +33,13 @@ public class Norm {
    * @return An Eli
    */
   public String getEli() {
-    return NodeParser.getValueFromExpression("//FRBRExpression/FRBRthis/@value", document)
-        .orElseGet(
-            () ->
-                NodeParser.getValueFromMandatoryNodeFromExpression(
-                        "//FRBRManifestation/FRBRthis/@value", document)
-                    .replace(".xml", ""));
+    return NodeParser
+      .getValueFromExpression("//FRBRExpression/FRBRthis/@value", document)
+      .orElseGet(() ->
+        NodeParser
+          .getValueFromMandatoryNodeFromExpression("//FRBRManifestation/FRBRthis/@value", document)
+          .replace(".xml", "")
+      );
   }
 
   /**
@@ -47,9 +48,10 @@ public class Norm {
    * @return An GUID of the norm (of the expression level)
    */
   public UUID getGuid() {
-    var guid =
-        NodeParser.getValueFromMandatoryNodeFromExpression(
-            "//FRBRExpression/FRBRalias[@name='aktuelle-version-id']/@value", document);
+    var guid = NodeParser.getValueFromMandatoryNodeFromExpression(
+      "//FRBRExpression/FRBRalias[@name='aktuelle-version-id']/@value",
+      document
+    );
 
     return UUID.fromString(guid);
   }
@@ -69,9 +71,12 @@ public class Norm {
    * @return The short title
    */
   public Optional<String> getShortTitle() {
-    return NodeParser.getValueFromExpression(
-            "//longTitle/*/shortTitle/*[@refersTo=\"amtliche-abkuerzung\"]", document)
-        .or(() -> NodeParser.getValueFromExpression("//longTitle/*/shortTitle", document));
+    return NodeParser
+      .getValueFromExpression(
+        "//longTitle/*/shortTitle/*[@refersTo=\"amtliche-abkuerzung\"]",
+        document
+      )
+      .or(() -> NodeParser.getValueFromExpression("//longTitle/*/shortTitle", document));
   }
 
   /**
@@ -90,9 +95,10 @@ public class Norm {
    * @return The list of articles
    */
   public List<Article> getArticles() {
-    return getNodesFromExpression("//body//article[not(ancestor-or-self::mod)]", document).stream()
-        .map(Article::new)
-        .toList();
+    return getNodesFromExpression("//body//article[not(ancestor-or-self::mod)]", document)
+      .stream()
+      .map(Article::new)
+      .toList();
   }
 
   /**
@@ -122,24 +128,26 @@ public class Norm {
    * @return a list of {@link TimeBoundary} containing dates and event IDs.
    */
   public List<TimeBoundary> getTimeBoundaries(final List<TemporalGroup> temporalGroups) {
-    return temporalGroups.stream()
-        .map(
-            temporalGroup -> {
-              final TimeInterval timeInterval = temporalGroup.getTimeInterval();
-              final String eventRefEId = timeInterval.getEventRefEId().orElseThrow();
-              final EventRef eventRef =
-                  getMeta().getLifecycle().getEventRefs().stream()
-                      .filter(f -> Objects.equals(f.getEid().value(), eventRefEId))
-                      .findFirst()
-                      .orElseThrow();
-              return (TimeBoundary)
-                  TimeBoundary.builder()
-                      .temporalGroup(temporalGroup)
-                      .timeInterval(timeInterval)
-                      .eventRef(eventRef)
-                      .build();
-            })
-        .toList();
+    return temporalGroups
+      .stream()
+      .map(temporalGroup -> {
+        final TimeInterval timeInterval = temporalGroup.getTimeInterval();
+        final String eventRefEId = timeInterval.getEventRefEId().orElseThrow();
+        final EventRef eventRef = getMeta()
+          .getLifecycle()
+          .getEventRefs()
+          .stream()
+          .filter(f -> Objects.equals(f.getEid().value(), eventRefEId))
+          .findFirst()
+          .orElseThrow();
+        return (TimeBoundary) TimeBoundary
+          .builder()
+          .temporalGroup(temporalGroup)
+          .timeInterval(timeInterval)
+          .eventRef(eventRef)
+          .build();
+      })
+      .toList();
   }
 
   /**
@@ -148,7 +156,7 @@ public class Norm {
    */
   public Optional<String> getStartDateForTemporalGroup(String temporalGroupEid) {
     return getStartEventRefForTemporalGroup(temporalGroupEid)
-        .flatMap(this::getStartDateForEventRef);
+      .flatMap(this::getStartDateForEventRef);
   }
 
   /**
@@ -156,12 +164,15 @@ public class Norm {
    * @return eid of the event ref of the start of the temporal group
    */
   public Optional<String> getStartEventRefForTemporalGroup(final String temporalGroupEid) {
-    return getMeta().getTemporalData().getTemporalGroups().stream()
-        .filter(
-            temporalGroup ->
-                temporalGroup.getEid().map(eid -> eid.equals(temporalGroupEid)).orElse(false))
-        .findFirst()
-        .flatMap(m -> m.getTimeInterval().getEventRefEId());
+    return getMeta()
+      .getTemporalData()
+      .getTemporalGroups()
+      .stream()
+      .filter(temporalGroup ->
+        temporalGroup.getEid().map(eid -> eid.equals(temporalGroupEid)).orElse(false)
+      )
+      .findFirst()
+      .flatMap(m -> m.getTimeInterval().getEventRefEId());
   }
 
   /**
@@ -169,11 +180,14 @@ public class Norm {
    * @return Start date of the event ref
    */
   public Optional<String> getStartDateForEventRef(String eId) {
-    return getMeta().getLifecycle().getEventRefs().stream()
-        .filter(eventRef -> Objects.equals(eventRef.getEid().value(), eId))
-        .findFirst()
-        .flatMap(EventRef::getDate)
-        .map(LocalDate::toString);
+    return getMeta()
+      .getLifecycle()
+      .getEventRefs()
+      .stream()
+      .filter(eventRef -> Objects.equals(eventRef.getEid().value(), eId))
+      .findFirst()
+      .flatMap(EventRef::getDate)
+      .map(LocalDate::toString);
   }
 
   /**
@@ -196,16 +210,22 @@ public class Norm {
 
     // Create new temporalGroup node
     final TemporalData temporalData = getMeta().getTemporalData();
-    final Element temporalGroup =
-        NodeCreator.createElementWithEidAndGuid("akn:temporalGroup", temporalData.getNode());
+    final Element temporalGroup = NodeCreator.createElementWithEidAndGuid(
+      "akn:temporalGroup",
+      temporalData.getNode()
+    );
 
     // Create new timeInterval node
-    final Element timeInterval =
-        NodeCreator.createElementWithEidAndGuid("akn:timeInterval", temporalGroup);
+    final Element timeInterval = NodeCreator.createElementWithEidAndGuid(
+      "akn:timeInterval",
+      temporalGroup
+    );
     timeInterval.setAttribute("refersTo", "geltungszeit");
     final var eventRefEId = eventRef.getAttribute("eId");
     timeInterval.setAttribute(
-        "start", new Href.Builder().setEId(eventRefEId).buildInternalReference().value());
+      "start",
+      new Href.Builder().setEId(eventRefEId).buildInternalReference().value()
+    );
 
     return new TemporalGroup(temporalGroup);
   }
@@ -228,7 +248,9 @@ public class Norm {
    */
   public Optional<Node> getNodeByEId(String eId) {
     return NodeParser.getNodeFromExpression(
-        String.format("//*[@eId='%s']", eId), this.getDocument());
+      String.format("//*[@eId='%s']", eId),
+      this.getDocument()
+    );
   }
 
   /**
@@ -249,8 +271,10 @@ public class Norm {
    * @return the deleted temporal group or empty if nothing was deleted
    */
   public Optional<TemporalGroup> deleteTemporalGroupIfUnused(String eId) {
-    final var nodesUsingTemporalData =
-        getNodesFromExpression(String.format("//*[@period='#%s']", eId), getDocument());
+    final var nodesUsingTemporalData = getNodesFromExpression(
+      String.format("//*[@period='#%s']", eId),
+      getDocument()
+    );
 
     if (!nodesUsingTemporalData.isEmpty()) {
       return Optional.empty();
@@ -266,9 +290,10 @@ public class Norm {
    * @return the deleted temporal ref node or empty if nothing was deleted
    */
   public Optional<Node> deleteEventRefIfUnused(String eId) {
-    final var nodesUsingTemporalData =
-        getNodesFromExpression(
-            String.format("//*[@start='#%s' or @end='#%s']", eId, eId), getDocument());
+    final var nodesUsingTemporalData = getNodesFromExpression(
+      String.format("//*[@start='#%s' or @end='#%s']", eId, eId),
+      getDocument()
+    );
 
     if (!nodesUsingTemporalData.isEmpty()) {
       return Optional.empty();
@@ -287,11 +312,14 @@ public class Norm {
     deleteByEId(timeBoundaryToDelete.eid());
 
     // delete temporalGroup node and its timeInterval node children
-    String timeIntervalNodeExpression =
-        String.format(
-            "//temporalData/temporalGroup/timeInterval[@start='#%s']", timeBoundaryToDelete.eid());
-    Optional<Node> timeIntervalNode =
-        NodeParser.getNodeFromExpression(timeIntervalNodeExpression, document);
+    String timeIntervalNodeExpression = String.format(
+      "//temporalData/temporalGroup/timeInterval[@start='#%s']",
+      timeBoundaryToDelete.eid()
+    );
+    Optional<Node> timeIntervalNode = NodeParser.getNodeFromExpression(
+      timeIntervalNodeExpression,
+      document
+    );
 
     if (timeIntervalNode.isEmpty()) {
       return;

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Proprietary.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Proprietary.java
@@ -17,6 +17,7 @@ import org.w3c.dom.Node;
 @SuperBuilder(toBuilder = true)
 @AllArgsConstructor
 public class Proprietary {
+
   private final Node node;
 
   /**
@@ -25,8 +26,9 @@ public class Proprietary {
    * @return an optional with a {@link MetadatenDe}
    */
   public Optional<MetadatenDe> getMetadatenDe() {
-    return NodeParser.getNodeFromExpression("./legalDocML.de_metadaten", node)
-        .map(MetadatenDe::new);
+    return NodeParser
+      .getNodeFromExpression("./legalDocML.de_metadaten", node)
+      .map(MetadatenDe::new);
   }
 
   /**
@@ -35,15 +37,14 @@ public class Proprietary {
    * @return the retrieved {@link MetadatenDe} or the newly created one.
    */
   public MetadatenDe getOrCreateMetadatenDe() {
-    return NodeParser.getNodeFromExpression("./legalDocML.de_metadaten", node)
-        .map(MetadatenDe::new)
-        .orElseGet(
-            () -> {
-              final var newElement =
-                  NodeCreator.createElement("meta:legalDocML.de_metadaten", node);
-              newElement.setAttribute("xmlns:meta", "http://Metadaten.LegalDocML.de/1.6/");
-              return new MetadatenDe(newElement);
-            });
+    return NodeParser
+      .getNodeFromExpression("./legalDocML.de_metadaten", node)
+      .map(MetadatenDe::new)
+      .orElseGet(() -> {
+        final var newElement = NodeCreator.createElement("meta:legalDocML.de_metadaten", node);
+        newElement.setAttribute("xmlns:meta", "http://Metadaten.LegalDocML.de/1.6/");
+        return new MetadatenDe(newElement);
+      });
   }
 
   /**
@@ -52,8 +53,9 @@ public class Proprietary {
    * @return an optional with a {@link MetadatenDs}
    */
   public Optional<MetadatenDs> getMetadatenDs() {
-    return NodeParser.getNodeFromExpression("./legalDocML.de_metadaten_ds", node)
-        .map(MetadatenDs::new);
+    return NodeParser
+      .getNodeFromExpression("./legalDocML.de_metadaten_ds", node)
+      .map(MetadatenDs::new);
   }
 
   /**
@@ -62,15 +64,14 @@ public class Proprietary {
    * @return the retrieved {@link MetadatenDs} or the newly created one.
    */
   public MetadatenDs getOrCreateMetadatenDs() {
-    return NodeParser.getNodeFromExpression("./legalDocML.de_metadaten_ds", node)
-        .map(MetadatenDs::new)
-        .orElseGet(
-            () -> {
-              final var newElement =
-                  NodeCreator.createElement("meta:legalDocML.de_metadaten_ds", node);
-              newElement.setAttribute("xmlns:meta", "http://DS.Metadaten.LegalDocML.de/1.6/");
-              return new MetadatenDs(newElement);
-            });
+    return NodeParser
+      .getNodeFromExpression("./legalDocML.de_metadaten_ds", node)
+      .map(MetadatenDs::new)
+      .orElseGet(() -> {
+        final var newElement = NodeCreator.createElement("meta:legalDocML.de_metadaten_ds", node);
+        newElement.setAttribute("xmlns:meta", "http://DS.Metadaten.LegalDocML.de/1.6/");
+        return new MetadatenDs(newElement);
+      });
   }
 
   /**
@@ -91,8 +92,8 @@ public class Proprietary {
    */
   public Optional<String> getFna(final LocalDate date) {
     return getMetadatenDs()
-        .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.FNA, date))
-        .or(this::getFna);
+      .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.FNA, date))
+      .or(this::getFna);
   }
 
   private Optional<String> getArt() {
@@ -108,8 +109,8 @@ public class Proprietary {
    */
   public Optional<String> getArt(final LocalDate date) {
     return getMetadatenDs()
-        .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.ART, date))
-        .or(this::getArt);
+      .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.ART, date))
+      .or(this::getArt);
   }
 
   private Optional<String> getTyp() {
@@ -125,8 +126,8 @@ public class Proprietary {
    */
   public Optional<String> getTyp(final LocalDate date) {
     return getMetadatenDs()
-        .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.TYP, date))
-        .or(this::getTyp);
+      .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.TYP, date))
+      .or(this::getTyp);
   }
 
   /**
@@ -148,7 +149,7 @@ public class Proprietary {
    */
   public Optional<String> getBezeichnungInVorlage(final LocalDate date) {
     return getMetadatenDs()
-        .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.BEZEICHNUNG_IN_VORLAGE, date));
+      .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.BEZEICHNUNG_IN_VORLAGE, date));
   }
 
   /**
@@ -160,7 +161,7 @@ public class Proprietary {
    */
   public Optional<String> getArtDerNorm(final LocalDate date) {
     return getMetadatenDs()
-        .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.ART_DER_NORM, date));
+      .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.ART_DER_NORM, date));
   }
 
   /**
@@ -173,8 +174,9 @@ public class Proprietary {
    */
   public Optional<String> getArtDerNorm(final LocalDate date, final String eid) {
     return getMetadatenDs()
-        .flatMap(
-            m -> m.getSingleElementSimpleMetadatum(Einzelelement.Metadata.ART_DER_NORM, eid, date));
+      .flatMap(m ->
+        m.getSingleElementSimpleMetadatum(Einzelelement.Metadata.ART_DER_NORM, eid, date)
+      );
   }
 
   /**
@@ -198,7 +200,7 @@ public class Proprietary {
    */
   public Optional<String> getBeschliessendesOrgan(final LocalDate date) {
     return getMetadatenDs()
-        .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.BESCHLIESSENDES_ORGAN, date));
+      .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.BESCHLIESSENDES_ORGAN, date));
   }
 
   /**
@@ -210,11 +212,11 @@ public class Proprietary {
    */
   public Optional<Boolean> getQualifizierteMehrheit(final LocalDate date) {
     return getMetadatenDs()
-        .flatMap(
-            m ->
-                m.getAttributeOfSimpleMetadatumAt(
-                        MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, date)
-                    .map(Boolean::parseBoolean));
+      .flatMap(m ->
+        m
+          .getAttributeOfSimpleMetadatumAt(MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, date)
+          .map(Boolean::parseBoolean)
+      );
   }
 
   /**
@@ -237,6 +239,6 @@ public class Proprietary {
    */
   public Optional<String> getOrganisationsEinheit(final LocalDate date) {
     return getMetadatenDs()
-        .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.ORGANISATIONS_EINHEIT, date));
+      .flatMap(m -> m.getSimpleMetadatum(MetadatenDs.Metadata.ORGANISATIONS_EINHEIT, date));
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/SimpleProprietary.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/SimpleProprietary.java
@@ -14,6 +14,7 @@ import org.w3c.dom.Node;
 @SuperBuilder(toBuilder = true)
 @AllArgsConstructor
 public class SimpleProprietary {
+
   private final Node node;
 
   /**
@@ -31,9 +32,10 @@ public class SimpleProprietary {
    * @return the optional value of @start in {@link LocalDate}
    */
   public Optional<LocalDate> getStart() {
-    return NodeParser.getValueFromExpression("./@start", node)
-        .map(LocalDate::parse)
-        .or(this::getAb);
+    return NodeParser
+      .getValueFromExpression("./@start", node)
+      .map(LocalDate::parse)
+      .or(this::getAb);
   }
 
   /**
@@ -64,15 +66,15 @@ public class SimpleProprietary {
   }
 
   private Optional<LocalDate> getEndOrBis(final String attributeName) {
-    return NodeParser.getValueFromExpression("./@%s".formatted(attributeName), node)
-        .map(
-            m -> {
-              if (m.equals("unbestimmt")) {
-                return LocalDate.MAX;
-              } else {
-                return LocalDate.parse(m);
-              }
-            });
+    return NodeParser
+      .getValueFromExpression("./@%s".formatted(attributeName), node)
+      .map(m -> {
+        if (m.equals("unbestimmt")) {
+          return LocalDate.MAX;
+        } else {
+          return LocalDate.parse(m);
+        }
+      });
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TemporalData.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TemporalData.java
@@ -21,8 +21,10 @@ public class TemporalData {
    * @return the list of {@link TemporalGroup}
    */
   public List<TemporalGroup> getTemporalGroups() {
-    return NodeParser.getNodesFromExpression("./temporalGroup", node).stream()
-        .map(TemporalGroup::new)
-        .toList();
+    return NodeParser
+      .getNodesFromExpression("./temporalGroup", node)
+      .stream()
+      .map(TemporalGroup::new)
+      .toList();
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TemporalGroup.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TemporalGroup.java
@@ -12,6 +12,7 @@ import org.w3c.dom.Node;
 @AllArgsConstructor
 @SuperBuilder(toBuilder = true)
 public class TemporalGroup {
+
   private final Node node;
 
   /**
@@ -29,8 +30,9 @@ public class TemporalGroup {
    * @return the TimeInterval node as {@link TimeInterval}
    */
   public TimeInterval getTimeInterval() {
-    return NodeParser.getNodeFromExpression("./timeInterval", node)
-        .map(TimeInterval::new)
-        .orElseThrow();
+    return NodeParser
+      .getNodeFromExpression("./timeInterval", node)
+      .map(TimeInterval::new)
+      .orElseThrow();
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TextualMod.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TextualMod.java
@@ -15,6 +15,7 @@ import org.w3c.dom.Node;
 @AllArgsConstructor
 @SuperBuilder(toBuilder = true)
 public class TextualMod {
+
   private final Node node;
 
   /**
@@ -63,19 +64,18 @@ public class TextualMod {
   }
 
   private Node getOrCreateDestinationNode() {
-    return NodeParser.getNodeFromExpression("./destination", this.node)
-        .orElseGet(
-            () -> {
-              var newElement = getNode().getOwnerDocument().createElement("akn:destination");
-              newElement.setAttribute(
-                  "eId",
-                  new EId(this.getEid().orElseThrow())
-                      .addPart(new EIdPart("destination", "1"))
-                      .value());
-              newElement.setAttribute("GUID", UUID.randomUUID().toString());
-              getNode().appendChild(newElement);
-              return newElement;
-            });
+    return NodeParser
+      .getNodeFromExpression("./destination", this.node)
+      .orElseGet(() -> {
+        var newElement = getNode().getOwnerDocument().createElement("akn:destination");
+        newElement.setAttribute(
+          "eId",
+          new EId(this.getEid().orElseThrow()).addPart(new EIdPart("destination", "1")).value()
+        );
+        newElement.setAttribute("GUID", UUID.randomUUID().toString());
+        getNode().appendChild(newElement);
+        return newElement;
+      });
   }
 
   /**
@@ -108,25 +108,25 @@ public class TextualMod {
    * @return The force eid of the modification
    */
   public Optional<String> getForcePeriodEid() {
-    return NodeParser.getValueFromExpression("./force/@period", this.node)
-        .map(Href::new)
-        .flatMap(Href::getEId);
+    return NodeParser
+      .getValueFromExpression("./force/@period", this.node)
+      .map(Href::new)
+      .flatMap(Href::getEId);
   }
 
   private Node getOrCreateForceNode() {
-    return NodeParser.getNodeFromExpression("./force", getNode())
-        .orElseGet(
-            () -> {
-              var newElement = getNode().getOwnerDocument().createElement("akn:force");
-              newElement.setAttribute(
-                  "eId",
-                  new EId(this.getEid().orElseThrow())
-                      .addPart(new EIdPart("gelzeitnachw", "1"))
-                      .value());
-              newElement.setAttribute("GUID", UUID.randomUUID().toString());
-              getNode().appendChild(newElement);
-              return newElement;
-            });
+    return NodeParser
+      .getNodeFromExpression("./force", getNode())
+      .orElseGet(() -> {
+        var newElement = getNode().getOwnerDocument().createElement("akn:force");
+        newElement.setAttribute(
+          "eId",
+          new EId(this.getEid().orElseThrow()).addPart(new EIdPart("gelzeitnachw", "1")).value()
+        );
+        newElement.setAttribute("GUID", UUID.randomUUID().toString());
+        getNode().appendChild(newElement);
+        return newElement;
+      });
   }
 
   /**
@@ -136,11 +136,12 @@ public class TextualMod {
    */
   public void setForcePeriodEid(final String periodEid) {
     getOrCreateForceNode()
-        .getAttributes()
-        .getNamedItem("period")
-        .setNodeValue(
-            periodEid == null
-                ? ""
-                : new Href.Builder().setEId(periodEid).buildInternalReference().value());
+      .getAttributes()
+      .getNamedItem("period")
+      .setNodeValue(
+        periodEid == null
+          ? ""
+          : new Href.Builder().setEId(periodEid).buildInternalReference().value()
+      );
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TimeBoundary.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TimeBoundary.java
@@ -12,6 +12,7 @@ import org.w3c.dom.Node;
 @AllArgsConstructor
 @SuperBuilder(toBuilder = true)
 public class TimeBoundary {
+
   private final TimeInterval timeInterval;
   private final EventRef eventRef;
   private final TemporalGroup temporalGroup;

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TimeInterval.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TimeInterval.java
@@ -12,6 +12,7 @@ import org.w3c.dom.Node;
 @AllArgsConstructor
 @SuperBuilder(toBuilder = true)
 public class TimeInterval {
+
   private final Node node;
 
   /**
@@ -20,8 +21,9 @@ public class TimeInterval {
    * @return The eId of the event ref of this temporal group
    */
   public Optional<String> getEventRefEId() {
-    return NodeParser.getValueFromExpression("./@start", this.node)
-        .map(Href::new)
-        .flatMap(Href::getEId);
+    return NodeParser
+      .getValueFromExpression("./@start", this.node)
+      .map(Href::new)
+      .flatMap(Href::getEId);
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/utils/EidConsistencyGuardian.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/utils/EidConsistencyGuardian.java
@@ -31,19 +31,26 @@ public final class EidConsistencyGuardian {
     Element rootElement = currentXml.getDocumentElement();
     if (rootElement != null) {
       setRemovedReferencesToEmptyStringNew(
-          "//textualMod/force", "period", "//temporalData/temporalGroup", "eId", rootElement);
+        "//textualMod/force",
+        "period",
+        "//temporalData/temporalGroup",
+        "eId",
+        rootElement
+      );
       setRemovedReferencesToEmptyStringNew(
-          "//proprietary/legalDocML.de_metadaten_ds/*",
-          "start",
-          "//lifecycle/eventRef",
-          "eId",
-          rootElement);
+        "//proprietary/legalDocML.de_metadaten_ds/*",
+        "start",
+        "//lifecycle/eventRef",
+        "eId",
+        rootElement
+      );
       setRemovedReferencesToEmptyStringNew(
-          "//proprietary/legalDocML.de_metadaten_ds/*",
-          "end",
-          "//lifecycle/eventRef",
-          "eId",
-          rootElement);
+        "//proprietary/legalDocML.de_metadaten_ds/*",
+        "end",
+        "//lifecycle/eventRef",
+        "eId",
+        rootElement
+      );
     }
   }
 
@@ -85,29 +92,33 @@ public final class EidConsistencyGuardian {
   }
 
   private static void setRemovedReferencesToEmptyStringNew(
-      final String elementXPath,
-      final String attribute,
-      final String targetXpath,
-      final String targetAttribute,
-      final Element rootElement) {
+    final String elementXPath,
+    final String attribute,
+    final String targetXpath,
+    final String targetAttribute,
+    final Element rootElement
+  ) {
     // Traverse the document to find the elements with the specified XPath expression
     final List<Node> nodeList = NodeParser.getNodesFromExpression(elementXPath, rootElement);
     for (Node node : nodeList) {
       final Element targetElement = (Element) node;
       final String attributeValue = targetElement.getAttribute(attribute);
       // Check if the attribute contains references
-      if (!attributeValue.isEmpty()
-          && (!isReferenceValid(attributeValue, targetXpath, targetAttribute, rootElement))) {
+      if (
+        !attributeValue.isEmpty() &&
+        (!isReferenceValid(attributeValue, targetXpath, targetAttribute, rootElement))
+      ) {
         targetElement.setAttribute(attribute, "");
       }
     }
   }
 
   private static boolean isReferenceValid(
-      final String reference,
-      final String targetXpath,
-      final String targetAttribute,
-      final Element rootElement) {
+    final String reference,
+    final String targetXpath,
+    final String targetAttribute,
+    final Element rootElement
+  ) {
     // Check if the reference exists within the XML document
     final List<Node> nodeList = NodeParser.getNodesFromExpression(targetXpath, rootElement);
     for (Node node : nodeList) {
@@ -121,7 +132,9 @@ public final class EidConsistencyGuardian {
   }
 
   private static void updateReferencesInAttributes(
-      final Node element, final Map<String, String> oldToNewEIdMap) {
+    final Node element,
+    final Map<String, String> oldToNewEIdMap
+  ) {
     final NamedNodeMap attributes = element.getAttributes();
 
     if (attributes != null) {
@@ -141,8 +154,9 @@ public final class EidConsistencyGuardian {
 
     // Recursively traverse child elements
     final List<Node> childNodes = NodeParser.nodeListToList(element.getChildNodes());
-    childNodes.stream()
-        .filter(node -> node.getNodeType() == Node.ELEMENT_NODE)
-        .forEach(node -> updateReferencesInAttributes(node, oldToNewEIdMap));
+    childNodes
+      .stream()
+      .filter(node -> node.getNodeType() == Node.ELEMENT_NODE)
+      .forEach(node -> updateReferencesInAttributes(node, oldToNewEIdMap));
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/utils/NodeCreator.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/utils/NodeCreator.java
@@ -52,7 +52,10 @@ public class NodeCreator {
    * @return the newly created element
    */
   public static Element createElementWithStaticEidAndGuidNoAppend(
-      final String tagName, final String eidPartName, final Node parentNode) {
+    final String tagName,
+    final String eidPartName,
+    final Node parentNode
+  ) {
     var newElement = parentNode.getOwnerDocument().createElement(tagName);
     newElement.setAttribute("eId", EId.fromMandatoryNode(parentNode) + "_" + eidPartName);
     newElement.setAttribute("GUID", UUID.randomUUID().toString());

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/utils/NodeParser.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/utils/NodeParser.java
@@ -16,11 +16,13 @@ import org.w3c.dom.NodeList;
 
 /** Util class that is responsible for parsing a {@link Node}. */
 public final class NodeParser {
+
   // the XPathFactory is not thread safe so every thread gets its own one. It should not be a
   // problem that we do not call remove() on it as it can be reused even after returning the thread
   // to a ThreadPool.
-  private static final ThreadLocal<XPathFactory> xPathFactory =
-      ThreadLocal.withInitial(XPathFactory::newInstance);
+  private static final ThreadLocal<XPathFactory> xPathFactory = ThreadLocal.withInitial(
+    XPathFactory::newInstance
+  );
 
   private NodeParser() {
     // Should not be instantiated as an object
@@ -67,9 +69,11 @@ public final class NodeParser {
    * @return the Node identified by the <code>xPathExpression</code>
    */
   public static String getValueFromMandatoryNodeFromExpression(
-      String xPathExpression, Node sourceNode) {
+    String xPathExpression,
+    Node sourceNode
+  ) {
     return getValueFromExpression(xPathExpression, sourceNode)
-        .orElseThrow(() -> throwMandatoryNotFoundException(xPathExpression, sourceNode));
+      .orElseThrow(() -> throwMandatoryNotFoundException(xPathExpression, sourceNode));
   }
 
   /**
@@ -84,12 +88,10 @@ public final class NodeParser {
     try {
       // should be invoked on every method call since: An XPath object is not thread-safe and not
       // reentrant.
-      final NodeList nodeList =
-          (NodeList)
-              xPathFactory
-                  .get()
-                  .newXPath()
-                  .evaluate(xPathExpression, sourceNode, XPathConstants.NODESET);
+      final NodeList nodeList = (NodeList) xPathFactory
+        .get()
+        .newXPath()
+        .evaluate(xPathExpression, sourceNode, XPathConstants.NODESET);
       return nodeListToList(nodeList);
     } catch (XPathExpressionException | NoSuchElementException e) {
       throw new XmlProcessingException(e.getMessage(), e);
@@ -129,7 +131,7 @@ public final class NodeParser {
    */
   public static Node getMandatoryNodeFromExpression(String xPathExpression, Node sourceNode) {
     return getNodeFromExpression(xPathExpression, sourceNode)
-        .orElseThrow(() -> throwMandatoryNotFoundException(xPathExpression, sourceNode));
+      .orElseThrow(() -> throwMandatoryNotFoundException(xPathExpression, sourceNode));
   }
 
   /**
@@ -154,28 +156,31 @@ public final class NodeParser {
   }
 
   private static MandatoryNodeNotFoundException throwMandatoryNotFoundException(
-      String xPathExpression, Node sourceNode) {
-    final Optional<String> optionalEli =
-        sourceNode.getOwnerDocument() == null
-            ? getEli((Document) sourceNode)
-            : getEli(sourceNode.getOwnerDocument());
+    String xPathExpression,
+    Node sourceNode
+  ) {
+    final Optional<String> optionalEli = sourceNode.getOwnerDocument() == null
+      ? getEli((Document) sourceNode)
+      : getEli(sourceNode.getOwnerDocument());
 
     final String nodeName = sourceNode.getNodeName();
 
     return optionalEli
-        .map(
-            eli ->
-                "#document".equals(nodeName)
-                    ? new MandatoryNodeNotFoundException(xPathExpression, eli)
-                    : new MandatoryNodeNotFoundException(xPathExpression, nodeName, eli))
-        .orElseGet(() -> new MandatoryNodeNotFoundException(xPathExpression));
+      .map(eli ->
+        "#document".equals(nodeName)
+          ? new MandatoryNodeNotFoundException(xPathExpression, eli)
+          : new MandatoryNodeNotFoundException(xPathExpression, nodeName, eli)
+      )
+      .orElseGet(() -> new MandatoryNodeNotFoundException(xPathExpression));
   }
 
   private static Optional<String> getEli(final Document document) {
-    return NodeParser.getValueFromExpression("//FRBRExpression/FRBRthis/@value", document)
-        .or(
-            () ->
-                NodeParser.getValueFromExpression("//FRBRManifestation/FRBRthis/@value", document)
-                    .map(m -> m.replace(".xml", "")));
+    return NodeParser
+      .getValueFromExpression("//FRBRExpression/FRBRthis/@value", document)
+      .or(() ->
+        NodeParser
+          .getValueFromExpression("//FRBRManifestation/FRBRthis/@value", document)
+          .map(m -> m.replace(".xml", ""))
+      );
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/utils/XmlMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/utils/XmlMapper.java
@@ -47,7 +47,6 @@ public class XmlMapper {
    * @return the resulting {@link Document}
    */
   public static Document toDocument(String xmlText, boolean validateSchema) {
-
     var factory = DocumentBuilderFactory.newInstance();
 
     try {
@@ -59,11 +58,11 @@ public class XmlMapper {
       if (validateSchema) {
         factory.setNamespaceAware(true);
         factory.setSchema(
-            SchemaFactory.newDefaultInstance()
-                .newSchema(
-                    XmlMapper.class.getResource("/schema/fixtures/ldml1.6_ds_regelungstext.xsd")));
-        factory.setIgnoringElementContentWhitespace(
-            true); // does only work when a schema is provided
+          SchemaFactory
+            .newDefaultInstance()
+            .newSchema(XmlMapper.class.getResource("/schema/fixtures/ldml1.6_ds_regelungstext.xsd"))
+        );
+        factory.setIgnoringElementContentWhitespace(true); // does only work when a schema is provided
       }
 
       final DocumentBuilder builder = factory.newDocumentBuilder();
@@ -96,8 +95,8 @@ public class XmlMapper {
 
     try {
       new TransformerFactoryImpl()
-          .newTransformer()
-          .transform(new DOMSource(node), new StreamResult(writer));
+        .newTransformer()
+        .transform(new DOMSource(node), new StreamResult(writer));
     } catch (TransformerException e) {
       throw new XmlProcessingException(e.getMessage(), e);
     }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/utils/exceptions/MandatoryNodeNotFoundException.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/utils/exceptions/MandatoryNodeNotFoundException.java
@@ -19,7 +19,12 @@ public class MandatoryNodeNotFoundException extends RuntimeException {
 
   public MandatoryNodeNotFoundException(String xpath, String nodeName, String normEli) {
     super(
-        String.format(
-            "Element with xpath '%s' not found in '%s' of norm '%s'", xpath, nodeName, normEli));
+      String.format(
+        "Element with xpath '%s' not found in '%s' of norm '%s'",
+        xpath,
+        nodeName,
+        normEli
+      )
+    );
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/utils/exceptions/XmlProcessingException.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/utils/exceptions/XmlProcessingException.java
@@ -2,6 +2,7 @@ package de.bund.digitalservice.ris.norms.utils.exceptions;
 
 /** This exception indicates that something went wrong while processing the xml e.g. parsing */
 public class XmlProcessingException extends RuntimeException {
+
   public XmlProcessingException(String message, Exception e) {
     super(message, e);
   }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/AnnouncementControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/AnnouncementControllerTest.java
@@ -34,15 +34,20 @@ import org.springframework.test.web.servlet.MockMvc;
 @Import(SecurityConfig.class)
 class AnnouncementControllerTest {
 
-  @Autowired private MockMvc mockMvc;
+  @Autowired
+  private MockMvc mockMvc;
 
-  @MockBean private LoadAllAnnouncementsUseCase loadAllAnnouncementsUseCase;
-  @MockBean private LoadAnnouncementByNormEliUseCase loadAnnouncementByNormEliUseCase;
+  @MockBean
+  private LoadAllAnnouncementsUseCase loadAllAnnouncementsUseCase;
+
+  @MockBean
+  private LoadAnnouncementByNormEliUseCase loadAnnouncementByNormEliUseCase;
 
   @MockBean
   private LoadTargetNormsAffectedByAnnouncementUseCase loadTargetNormsAffectedByAnnouncementUseCase;
 
-  @MockBean private ReleaseAnnouncementUseCase releaseAnnouncementUseCase;
+  @MockBean
+  private ReleaseAnnouncementUseCase releaseAnnouncementUseCase;
 
   @Nested
   class getAllAnnouncements {
@@ -50,117 +55,129 @@ class AnnouncementControllerTest {
     @Test
     void itReturnsAnnouncements() throws Exception {
       // Given
-      var announcement1 =
-          Announcement.builder()
-              .norm(
-                  Norm.builder()
-                      .document(
-                          XmlMapper.toDocument(
-                              """
-                                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                                         <akn:act name="regelungstext">
-                                            <!-- Metadaten -->
-                                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                                  <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                                     <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
-                                                     <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
-                                                     <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
-                                                  </akn:FRBRWork>
-                                                  <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                                     <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                                     <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                                                     <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                                                     <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                                                  </akn:FRBRExpression>
-                                              </akn:identification>
-                                            </akn:meta>
+      var announcement1 = Announcement
+        .builder()
+        .norm(
+          Norm
+            .builder()
+            .document(
+              XmlMapper.toDocument(
+                """
+                    <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+                    <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                           http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                       <akn:act name="regelungstext">
+                          <!-- Metadaten -->
+                          <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                             <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                                <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                                   <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                                   <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                                   <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                                </akn:FRBRWork>
+                                <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                                   <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                                   <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                                   <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                                   <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                                </akn:FRBRExpression>
+                            </akn:identification>
+                          </akn:meta>
 
-                                            <akn:preface eId="einleitung-1" GUID="fc10e89f-fde4-44bf-aa98-b6bdea01f0ea">
-                                               <akn:longTitle eId="einleitung-1_doktitel-1" GUID="abbb08de-e7e2-40ab-aba0-079ce786e6d6">
-                                                  <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="3e7c2134-d82c-44ba-b50d-bad9790375a0">
-                                                     <akn:docTitle
-                                                        eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="8c4eabab-9893-455e-b83b-c46f2453f2fb">Gesetz zur Regelung des öffentlichen Vereinsrechts</akn:docTitle>
-                                                  </akn:p>
-                                               </akn:longTitle>
-                                            </akn:preface>
-                                         </akn:act>
-                                      </akn:akomaNtoso>
-                                  """))
-                      .build())
-              .releasedByDocumentalistAt(null)
-              .build();
+                          <akn:preface eId="einleitung-1" GUID="fc10e89f-fde4-44bf-aa98-b6bdea01f0ea">
+                             <akn:longTitle eId="einleitung-1_doktitel-1" GUID="abbb08de-e7e2-40ab-aba0-079ce786e6d6">
+                                <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="3e7c2134-d82c-44ba-b50d-bad9790375a0">
+                                   <akn:docTitle
+                                      eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="8c4eabab-9893-455e-b83b-c46f2453f2fb">Gesetz zur Regelung des öffentlichen Vereinsrechts</akn:docTitle>
+                                </akn:p>
+                             </akn:longTitle>
+                          </akn:preface>
+                       </akn:act>
+                    </akn:akomaNtoso>
+                """
+              )
+            )
+            .build()
+        )
+        .releasedByDocumentalistAt(null)
+        .build();
 
-      var announcement2 =
-          Announcement.builder()
-              .norm(
-                  Norm.builder()
-                      .document(
-                          XmlMapper.toDocument(
-                              """
-                                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                                         <akn:act name="regelungstext">
-                                            <!-- Metadaten -->
-                                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                                  <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                                     <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="413" />
-                                                     <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
-                                                     <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="2023-12-29" name="verkuendungsfassung" />
-                                                  </akn:FRBRWork>
-                                                  <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                                     <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
-                                                     <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                                                     <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                                                     <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                                                  </akn:FRBRExpression>
-                                              </akn:identification>
-                                            </akn:meta>
+      var announcement2 = Announcement
+        .builder()
+        .norm(
+          Norm
+            .builder()
+            .document(
+              XmlMapper.toDocument(
+                """
+                    <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+                    <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                           http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                       <akn:act name="regelungstext">
+                          <!-- Metadaten -->
+                          <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                             <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                                <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                                   <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="413" />
+                                   <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                                   <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="2023-12-29" name="verkuendungsfassung" />
+                                </akn:FRBRWork>
+                                <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                                   <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
+                                   <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                                   <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                                   <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                                </akn:FRBRExpression>
+                            </akn:identification>
+                          </akn:meta>
 
-                                            <akn:preface eId="einleitung-1" GUID="fc10e89f-fde4-44bf-aa98-b6bdea01f0ea">
-                                               <akn:longTitle eId="einleitung-1_doktitel-1" GUID="abbb08de-e7e2-40ab-aba0-079ce786e6d6">
-                                                  <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="3e7c2134-d82c-44ba-b50d-bad9790375a0">
-                                                     <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Gesetz zum ersten Teil der Reform des Nachrichtendienstrechts</akn:docTitle>
-                                                  </akn:p>
-                                               </akn:longTitle>
-                                            </akn:preface>
-                                         </akn:act>
-                                      </akn:akomaNtoso>
-                                  """))
-                      .build())
-              .releasedByDocumentalistAt(null)
-              .build();
+                          <akn:preface eId="einleitung-1" GUID="fc10e89f-fde4-44bf-aa98-b6bdea01f0ea">
+                             <akn:longTitle eId="einleitung-1_doktitel-1" GUID="abbb08de-e7e2-40ab-aba0-079ce786e6d6">
+                                <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="3e7c2134-d82c-44ba-b50d-bad9790375a0">
+                                   <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Gesetz zum ersten Teil der Reform des Nachrichtendienstrechts</akn:docTitle>
+                                </akn:p>
+                             </akn:longTitle>
+                          </akn:preface>
+                       </akn:act>
+                    </akn:akomaNtoso>
+                """
+              )
+            )
+            .build()
+        )
+        .releasedByDocumentalistAt(null)
+        .build();
 
       // When
       when(loadAllAnnouncementsUseCase.loadAllAnnouncements())
-          .thenReturn(List.of(announcement1, announcement2));
+        .thenReturn(List.of(announcement1, announcement2));
 
       // When // Then
       mockMvc
-          .perform(get("/api/v1/announcements").accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$[1]").exists())
-          .andExpect(jsonPath("$[2]").doesNotExist())
-          .andExpect(
-              jsonPath("$[0].title", equalTo("Gesetz zur Regelung des öffentlichen Vereinsrechts")))
-          .andExpect(
-              jsonPath(
-                  "$[0].eli",
-                  equalTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")))
-          .andExpect(
-              jsonPath(
-                  "$[1].title",
-                  equalTo("Gesetz zum ersten Teil der Reform des Nachrichtendienstrechts")))
-          .andExpect(
-              jsonPath(
-                  "$[1].eli",
-                  equalTo("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1")));
+        .perform(get("/api/v1/announcements").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[1]").exists())
+        .andExpect(jsonPath("$[2]").doesNotExist())
+        .andExpect(
+          jsonPath("$[0].title", equalTo("Gesetz zur Regelung des öffentlichen Vereinsrechts"))
+        )
+        .andExpect(
+          jsonPath(
+            "$[0].eli",
+            equalTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+          )
+        )
+        .andExpect(
+          jsonPath(
+            "$[1].title",
+            equalTo("Gesetz zum ersten Teil der Reform des Nachrichtendienstrechts")
+          )
+        )
+        .andExpect(
+          jsonPath("$[1].eli", equalTo("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1"))
+        );
     }
   }
 
@@ -170,120 +187,132 @@ class AnnouncementControllerTest {
     @Test
     void itReturnsRelease() throws Exception {
       // Given
-      var amendingNorm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                               <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                             <akn:act name="regelungstext">
+      var amendingNorm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+                 <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+               <akn:act name="regelungstext">
 
-                                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                      </akn:FRBRExpression>
-                                   </akn:identification>
-                                </akn:meta>
-                                <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                   <!-- Artikel 1 : Hauptänderung -->
-                                   <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                      <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                         <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                                      <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                                      <!-- Absatz (1) -->
-                                      <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                                         <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                                            <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                                         </akn:num>
-                                         <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                            <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                               <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                                     href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                            </akn:intro>
-                                         </akn:list>
-                                      </akn:paragraph>
-                                   </akn:article>
-                                    <!-- Artikel 3: Geltungszeitregel-->
-                                    <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                       <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                          <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
-                                       <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                                       <!-- Absatz (1) -->
-                                       <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                          <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-                                             <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
-                                          </akn:num>
-                                          <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                             <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                                nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                          </akn:content>
-                                       </akn:paragraph>
-                                    </akn:article>
-                                </akn:body>
-                             </akn:act>
-                          </akn:akomaNtoso>
-                          """))
-              .build();
-      var affectedNormZf0 =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                               <akn:act name="regelungstext">
-                                  <!-- Metadaten -->
-                                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
-                                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
-                                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
-                                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
-                                        </akn:FRBRExpression>
-                                    </akn:identification>
-                                  </akn:meta>
-                               </akn:act>
-                            </akn:akomaNtoso>
-                          """))
-              .build();
-      var announcement =
-          Announcement.builder()
-              .norm(amendingNorm)
-              .releasedByDocumentalistAt(Instant.parse("2024-01-02T10:20:30.0Z"))
-              .build();
+                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                        </akn:FRBRExpression>
+                     </akn:identification>
+                  </akn:meta>
+                  <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                     <!-- Artikel 1 : Hauptänderung -->
+                     <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                        <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                           <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                        <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                        <!-- Absatz (1) -->
+                        <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                           <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                              <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                           </akn:num>
+                           <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                              <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                                 <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                       href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                              </akn:intro>
+                           </akn:list>
+                        </akn:paragraph>
+                     </akn:article>
+                      <!-- Artikel 3: Geltungszeitregel-->
+                      <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                         <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
+                            <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
+                         <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+                         <!-- Absatz (1) -->
+                         <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
+                            <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
+                               <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
+                            </akn:num>
+                            <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
+                               <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
+                                  nach der Verkündung</akn:date> in Kraft. </akn:p>
+                            </akn:content>
+                         </akn:paragraph>
+                      </akn:article>
+                  </akn:body>
+               </akn:act>
+            </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
+      var affectedNormZf0 = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
+      var announcement = Announcement
+        .builder()
+        .norm(amendingNorm)
+        .releasedByDocumentalistAt(Instant.parse("2024-01-02T10:20:30.0Z"))
+        .build();
 
       when(loadAnnouncementByNormEliUseCase.loadAnnouncementByNormEli(any()))
-          .thenReturn(announcement);
-      when(loadTargetNormsAffectedByAnnouncementUseCase.loadTargetNormsAffectedByAnnouncement(
-              any()))
-          .thenReturn(List.of(affectedNormZf0));
+        .thenReturn(announcement);
+      when(
+        loadTargetNormsAffectedByAnnouncementUseCase.loadTargetNormsAffectedByAnnouncement(any())
+      )
+        .thenReturn(List.of(affectedNormZf0));
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/announcements/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/release")
-                  .accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("releaseAt", equalTo("2024-01-02T10:20:30Z")))
-          .andExpect(
-              jsonPath(
-                  "amendingLawEli",
-                  equalTo("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1")))
-          .andExpect(jsonPath("zf0Elis[0]").exists())
-          .andExpect(jsonPath("zf0Elis[1]").doesNotExist())
-          .andExpect(
-              jsonPath(
-                  "zf0Elis[0]",
-                  equalTo("eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1")));
+        .perform(
+          get(
+            "/api/v1/announcements/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/release"
+          )
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("releaseAt", equalTo("2024-01-02T10:20:30Z")))
+        .andExpect(
+          jsonPath(
+            "amendingLawEli",
+            equalTo("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1")
+          )
+        )
+        .andExpect(jsonPath("zf0Elis[0]").exists())
+        .andExpect(jsonPath("zf0Elis[1]").doesNotExist())
+        .andExpect(
+          jsonPath(
+            "zf0Elis[0]",
+            equalTo("eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1")
+          )
+        );
     }
   }
 
@@ -293,119 +322,131 @@ class AnnouncementControllerTest {
     @Test
     void itReleaseAnAnnouncement() throws Exception {
       // Given
-      var amendingNorm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                               <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                             <akn:act name="regelungstext">
+      var amendingNorm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+                 <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+               <akn:act name="regelungstext">
 
-                                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                      </akn:FRBRExpression>
-                                   </akn:identification>
-                                </akn:meta>
-                                <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                   <!-- Artikel 1 : Hauptänderung -->
-                                   <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                      <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                         <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                                      <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                                      <!-- Absatz (1) -->
-                                      <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                                         <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                                            <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                                         </akn:num>
-                                         <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                            <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                               <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                                     href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                            </akn:intro>
-                                         </akn:list>
-                                      </akn:paragraph>
-                                   </akn:article>
-                                    <!-- Artikel 3: Geltungszeitregel-->
-                                    <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                       <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                          <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
-                                       <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                                       <!-- Absatz (1) -->
-                                       <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                          <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-                                             <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
-                                          </akn:num>
-                                          <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                             <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                                nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                          </akn:content>
-                                       </akn:paragraph>
-                                    </akn:article>
-                                </akn:body>
-                             </akn:act>
-                          </akn:akomaNtoso>
-                          """))
-              .build();
-      var affectedNormZf0 =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                               <akn:act name="regelungstext">
-                                  <!-- Metadaten -->
-                                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
-                                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
-                                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
-                                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
-                                        </akn:FRBRExpression>
-                                    </akn:identification>
-                                  </akn:meta>
-                               </akn:act>
-                            </akn:akomaNtoso>
-                          """))
-              .build();
-      var announcement =
-          Announcement.builder()
-              .norm(amendingNorm)
-              .releasedByDocumentalistAt(Instant.parse("2024-01-02T10:20:30.0Z"))
-              .build();
+                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                        </akn:FRBRExpression>
+                     </akn:identification>
+                  </akn:meta>
+                  <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                     <!-- Artikel 1 : Hauptänderung -->
+                     <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                        <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                           <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                        <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                        <!-- Absatz (1) -->
+                        <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                           <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                              <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                           </akn:num>
+                           <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                              <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                                 <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                       href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                              </akn:intro>
+                           </akn:list>
+                        </akn:paragraph>
+                     </akn:article>
+                      <!-- Artikel 3: Geltungszeitregel-->
+                      <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                         <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
+                            <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
+                         <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+                         <!-- Absatz (1) -->
+                         <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
+                            <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
+                               <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
+                            </akn:num>
+                            <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
+                               <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
+                                  nach der Verkündung</akn:date> in Kraft. </akn:p>
+                            </akn:content>
+                         </akn:paragraph>
+                      </akn:article>
+                  </akn:body>
+               </akn:act>
+            </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
+      var affectedNormZf0 = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
+      var announcement = Announcement
+        .builder()
+        .norm(amendingNorm)
+        .releasedByDocumentalistAt(Instant.parse("2024-01-02T10:20:30.0Z"))
+        .build();
 
       when(releaseAnnouncementUseCase.releaseAnnouncement(any())).thenReturn(announcement);
-      when(loadTargetNormsAffectedByAnnouncementUseCase.loadTargetNormsAffectedByAnnouncement(
-              any()))
-          .thenReturn(List.of(affectedNormZf0));
+      when(
+        loadTargetNormsAffectedByAnnouncementUseCase.loadTargetNormsAffectedByAnnouncement(any())
+      )
+        .thenReturn(List.of(affectedNormZf0));
 
       // When // Then
       mockMvc
-          .perform(
-              put("/api/v1/announcements/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/release")
-                  .accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("releaseAt", equalTo("2024-01-02T10:20:30Z")))
-          .andExpect(
-              jsonPath(
-                  "amendingLawEli",
-                  equalTo("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1")))
-          .andExpect(jsonPath("zf0Elis[0]").exists())
-          .andExpect(jsonPath("zf0Elis[1]").doesNotExist())
-          .andExpect(
-              jsonPath(
-                  "zf0Elis[0]",
-                  equalTo("eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1")));
+        .perform(
+          put(
+            "/api/v1/announcements/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/release"
+          )
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("releaseAt", equalTo("2024-01-02T10:20:30Z")))
+        .andExpect(
+          jsonPath(
+            "amendingLawEli",
+            equalTo("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1")
+          )
+        )
+        .andExpect(jsonPath("zf0Elis[0]").exists())
+        .andExpect(jsonPath("zf0Elis[1]").doesNotExist())
+        .andExpect(
+          jsonPath(
+            "zf0Elis[0]",
+            equalTo("eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1")
+          )
+        );
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ArticleControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ArticleControllerTest.java
@@ -29,14 +29,26 @@ import org.springframework.test.web.servlet.MockMvc;
 @Import(SecurityConfig.class)
 class ArticleControllerTest {
 
-  @Autowired private MockMvc mockMvc;
+  @Autowired
+  private MockMvc mockMvc;
 
-  @MockBean private LoadNormUseCase loadNormUseCase;
-  @MockBean private LoadArticlesFromNormUseCase loadArticlesFromNormUseCase;
-  @MockBean private LoadSpecificArticlesXmlFromNormUseCase loadSpecificArticlesXmlFromNormUseCase;
-  @MockBean private TransformLegalDocMlToHtmlUseCase transformLegalDocMlToHtmlUseCase;
-  @MockBean private LoadArticleHtmlUseCase loadArticleHtmlUseCase;
-  @MockBean private LoadZf0UseCase loadZf0UseCase;
+  @MockBean
+  private LoadNormUseCase loadNormUseCase;
+
+  @MockBean
+  private LoadArticlesFromNormUseCase loadArticlesFromNormUseCase;
+
+  @MockBean
+  private LoadSpecificArticlesXmlFromNormUseCase loadSpecificArticlesXmlFromNormUseCase;
+
+  @MockBean
+  private TransformLegalDocMlToHtmlUseCase transformLegalDocMlToHtmlUseCase;
+
+  @MockBean
+  private LoadArticleHtmlUseCase loadArticleHtmlUseCase;
+
+  @MockBean
+  private LoadZf0UseCase loadZf0UseCase;
 
   @Nested
   class getArticles {
@@ -44,83 +56,87 @@ class ArticleControllerTest {
     @Test
     void itReturnsArticles() throws Exception {
       // Given
-      var norm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                               <akn:act name="regelungstext">
-                               <akn:meta></akn:meta>
-                                  <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                     <!-- Artikel 1 : Hauptänderung -->
-                                     <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                        <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                           <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                                        <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                                        <!-- Absatz (1) -->
-                                        <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                                           <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                                              <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                                           </akn:num>
-                                           <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                              <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                                 <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                                       href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                              </akn:intro>
-                                           </akn:list>
-                                        </akn:paragraph>
-                                     </akn:article>
-                                      <!-- Artikel 3: Geltungszeitregel-->
-                                      <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                         <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                            <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
-                                         <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                                         <!-- Absatz (1) -->
-                                         <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                            <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-                                               <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
-                                            </akn:num>
-                                            <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                               <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                                  nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                            </akn:content>
-                                         </akn:paragraph>
-                                      </akn:article>
-                                  </akn:body>
-                               </akn:act>
-                            </akn:akomaNtoso>
-                          """))
-              .build();
+      var norm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                 <akn:meta></akn:meta>
+                    <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                       <!-- Artikel 1 : Hauptänderung -->
+                       <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                          <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                             <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                          <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                          <!-- Absatz (1) -->
+                          <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                             <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                                <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                             </akn:num>
+                             <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                                <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                                   <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                         href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                                </akn:intro>
+                             </akn:list>
+                          </akn:paragraph>
+                       </akn:article>
+                        <!-- Artikel 3: Geltungszeitregel-->
+                        <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                           <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
+                              <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
+                           <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+                           <!-- Absatz (1) -->
+                           <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
+                              <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
+                                 <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
+                              </akn:num>
+                              <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
+                                 <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
+                                    nach der Verkündung</akn:date> in Kraft. </akn:p>
+                              </akn:content>
+                           </akn:paragraph>
+                        </akn:article>
+                    </akn:body>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
-      var normZf0 =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                               <akn:act name="regelungstext">
-                                  <!-- Metadaten -->
-                                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
-                                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
-                                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
-                                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
-                                        </akn:FRBRExpression>
-                                    </akn:identification>
-                                  </akn:meta>
-                               </akn:act>
-                            </akn:akomaNtoso>
-                          """))
-              .build();
+      var normZf0 = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
       when(loadNormUseCase.loadNorm(any())).thenReturn(norm);
       when(loadZf0UseCase.loadOrCreateZf0(any())).thenReturn(normZf0);
@@ -128,34 +144,39 @@ class ArticleControllerTest {
 
       // When
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles")
-                  .accept(MediaType.APPLICATION_JSON))
-          // Then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$[0]").exists())
-          .andExpect(jsonPath("$[0].eid").value("hauptteil-1_art-1"))
-          .andExpect(
-              jsonPath("$[0].affectedDocumentEli")
-                  .value("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"))
-          .andExpect(
-              jsonPath("$[0].affectedDocumentZf0Eli")
-                  .value("eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1"))
-          .andExpect(jsonPath("$[1]").exists())
-          .andExpect(jsonPath("$[1].eid").value("hauptteil-1_art-3"))
-          .andExpect(jsonPath("$[1].affectedDocumentEli").doesNotExist())
-          .andExpect(jsonPath("$[1].affectedDocumentZf0Eli").doesNotExist())
-          .andExpect(jsonPath("$[2]").doesNotExist());
+        .perform(
+          get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles")
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        // Then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0]").exists())
+        .andExpect(jsonPath("$[0].eid").value("hauptteil-1_art-1"))
+        .andExpect(
+          jsonPath("$[0].affectedDocumentEli")
+            .value("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+        )
+        .andExpect(
+          jsonPath("$[0].affectedDocumentZf0Eli")
+            .value("eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1")
+        )
+        .andExpect(jsonPath("$[1]").exists())
+        .andExpect(jsonPath("$[1].eid").value("hauptteil-1_art-3"))
+        .andExpect(jsonPath("$[1].affectedDocumentEli").doesNotExist())
+        .andExpect(jsonPath("$[1].affectedDocumentZf0Eli").doesNotExist())
+        .andExpect(jsonPath("$[2]").doesNotExist());
 
       verify(loadNormUseCase, times(1))
-          .loadNorm(
-              argThat(
-                  argument ->
-                      Objects.equals(
-                          argument.eli(),
-                          "eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1")));
+        .loadNorm(
+          argThat(argument ->
+            Objects.equals(
+              argument.eli(),
+              "eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1"
+            )
+          )
+        );
       verify(loadZf0UseCase, times(1))
-          .loadOrCreateZf0(argThat(argument -> Objects.equals(argument.amendingLaw(), norm)));
+        .loadOrCreateZf0(argThat(argument -> Objects.equals(argument.amendingLaw(), norm)));
     }
 
     @Test
@@ -166,28 +187,36 @@ class ArticleControllerTest {
       when(loadNormUseCase.loadNorm(any())).thenReturn(norm);
 
       when(loadArticlesFromNormUseCase.loadArticlesFromNorm(any()))
-          .thenReturn(
-              norm.getArticles().stream()
-                  .filter(article -> article.getEid().get().equals("hauptteil-1_para-20"))
-                  .toList());
+        .thenReturn(
+          norm
+            .getArticles()
+            .stream()
+            .filter(article -> article.getEid().get().equals("hauptteil-1_para-20"))
+            .toList()
+        );
 
       // When
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles?amendedAt=meta-1_lebzykl-1_ereignis-4")
-                  .accept(MediaType.APPLICATION_JSON))
-          // Then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$[0]").exists())
-          .andExpect(jsonPath("$[0].eid").value("hauptteil-1_para-20"))
-          .andExpect(jsonPath("$[1]").doesNotExist());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles?amendedAt=meta-1_lebzykl-1_ereignis-4"
+          )
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        // Then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0]").exists())
+        .andExpect(jsonPath("$[0].eid").value("hauptteil-1_para-20"))
+        .andExpect(jsonPath("$[1]").doesNotExist());
 
       verify(loadArticlesFromNormUseCase, times(1))
-          .loadArticlesFromNorm(
-              new LoadArticlesFromNormUseCase.Query(
-                  "eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1",
-                  null,
-                  "meta-1_lebzykl-1_ereignis-4"));
+        .loadArticlesFromNorm(
+          new LoadArticlesFromNormUseCase.Query(
+            "eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1",
+            null,
+            "meta-1_lebzykl-1_ereignis-4"
+          )
+        );
     }
 
     @Test
@@ -198,28 +227,36 @@ class ArticleControllerTest {
       when(loadNormUseCase.loadNorm(any())).thenReturn(norm);
 
       when(loadArticlesFromNormUseCase.loadArticlesFromNorm(any()))
-          .thenReturn(
-              norm.getArticles().stream()
-                  .filter(article -> article.getEid().get().equals("hauptteil-1_para-1"))
-                  .toList());
+        .thenReturn(
+          norm
+            .getArticles()
+            .stream()
+            .filter(article -> article.getEid().get().equals("hauptteil-1_para-1"))
+            .toList()
+        );
 
       // When
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles?amendedBy=eli/bund/bgbl-1/2017/s815/1995-03-15/1/deu/regelungstext-1")
-                  .accept(MediaType.APPLICATION_JSON))
-          // Then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$[0]").exists())
-          .andExpect(jsonPath("$[0].eid").value("hauptteil-1_para-1"))
-          .andExpect(jsonPath("$[1]").doesNotExist());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles?amendedBy=eli/bund/bgbl-1/2017/s815/1995-03-15/1/deu/regelungstext-1"
+          )
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        // Then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0]").exists())
+        .andExpect(jsonPath("$[0].eid").value("hauptteil-1_para-1"))
+        .andExpect(jsonPath("$[1]").doesNotExist());
 
       verify(loadArticlesFromNormUseCase, times(1))
-          .loadArticlesFromNorm(
-              new LoadArticlesFromNormUseCase.Query(
-                  "eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1",
-                  "eli/bund/bgbl-1/2017/s815/1995-03-15/1/deu/regelungstext-1",
-                  null));
+        .loadArticlesFromNorm(
+          new LoadArticlesFromNormUseCase.Query(
+            "eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1",
+            "eli/bund/bgbl-1/2017/s815/1995-03-15/1/deu/regelungstext-1",
+            null
+          )
+        );
     }
   }
 
@@ -234,21 +271,21 @@ class ArticleControllerTest {
       final String html = "<div></div>";
 
       when(loadSpecificArticlesXmlFromNormUseCase.loadSpecificArticlesXmlFromNorm(any()))
-          .thenReturn(List.of(xml));
+        .thenReturn(List.of(xml));
       when(transformLegalDocMlToHtmlUseCase.transformLegalDocMlToHtml(any())).thenReturn(html);
 
       // When
       mockMvc
-          .perform(
-              get("/api/v1/norms/{eli}/articles?refersTo=something", eli)
-                  .accept(MediaType.TEXT_HTML))
-          // Then
-          .andExpect(status().isOk())
-          .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-          .andExpect(content().string("<div>\n" + html + "\n</div>\n"));
+        .perform(
+          get("/api/v1/norms/{eli}/articles?refersTo=something", eli).accept(MediaType.TEXT_HTML)
+        )
+        // Then
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+        .andExpect(content().string("<div>\n" + html + "\n</div>\n"));
 
       verify(transformLegalDocMlToHtmlUseCase, times(1))
-          .transformLegalDocMlToHtml(argThat(query -> query.xml().equals(xml)));
+        .transformLegalDocMlToHtml(argThat(query -> query.xml().equals(xml)));
     }
   }
 
@@ -258,184 +295,202 @@ class ArticleControllerTest {
     @Test
     void itReturnsArticle() throws Exception {
       // Given
-      var norm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                               <akn:act name="regelungstext">
-                                  <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                     <!-- Artikel 1 : Hauptänderung -->
-                                     <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                        <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                           <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                                        <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                                        <!-- Absatz (1) -->
-                                        <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                                           <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                                              <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                                           </akn:num>
-                                           <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                              <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                                 <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                                       href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                              </akn:intro>
-                                           </akn:list>
-                                        </akn:paragraph>
-                                     </akn:article>
-                                      <!-- Artikel 3: Geltungszeitregel-->
-                                      <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                         <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                            <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
-                                         <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                                         <!-- Absatz (1) -->
-                                         <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                            <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-                                               <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
-                                            </akn:num>
-                                            <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                               <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                                  nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                            </akn:content>
-                                         </akn:paragraph>
-                                      </akn:article>
-                                  </akn:body>
-                               </akn:act>
-                            </akn:akomaNtoso>
-                          """))
-              .build();
+      var norm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                       <!-- Artikel 1 : Hauptänderung -->
+                       <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                          <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                             <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                          <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                          <!-- Absatz (1) -->
+                          <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                             <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                                <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                             </akn:num>
+                             <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                                <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                                   <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                         href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                                </akn:intro>
+                             </akn:list>
+                          </akn:paragraph>
+                       </akn:article>
+                        <!-- Artikel 3: Geltungszeitregel-->
+                        <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                           <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
+                              <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
+                           <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+                           <!-- Absatz (1) -->
+                           <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
+                              <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
+                                 <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
+                              </akn:num>
+                              <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
+                                 <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
+                                    nach der Verkündung</akn:date> in Kraft. </akn:p>
+                              </akn:content>
+                           </akn:paragraph>
+                        </akn:article>
+                    </akn:body>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
-      var normZf0 =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                               <akn:act name="regelungstext">
-                                  <!-- Metadaten -->
-                                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
-                                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
-                                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
-                                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
-                                        </akn:FRBRExpression>
-                                    </akn:identification>
-                                  </akn:meta>
-                               </akn:act>
-                            </akn:akomaNtoso>
-                          """))
-              .build();
+      var normZf0 = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
       when(loadNormUseCase.loadNorm(any())).thenReturn(norm);
       when(loadZf0UseCase.loadOrCreateZf0(any())).thenReturn(normZf0);
 
       // When
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles/hauptteil-1_art-1")
-                  .accept(MediaType.APPLICATION_JSON))
-          // Then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("eid").value("hauptteil-1_art-1"))
-          .andExpect(
-              jsonPath("affectedDocumentEli")
-                  .value("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"))
-          .andExpect(
-              jsonPath("affectedDocumentZf0Eli")
-                  .value("eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1"));
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles/hauptteil-1_art-1"
+          )
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        // Then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("eid").value("hauptteil-1_art-1"))
+        .andExpect(
+          jsonPath("affectedDocumentEli")
+            .value("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+        )
+        .andExpect(
+          jsonPath("affectedDocumentZf0Eli")
+            .value("eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1")
+        );
 
       verify(loadNormUseCase, times(1))
-          .loadNorm(
-              argThat(
-                  argument ->
-                      Objects.equals(
-                          argument.eli(),
-                          "eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1")));
+        .loadNorm(
+          argThat(argument ->
+            Objects.equals(
+              argument.eli(),
+              "eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1"
+            )
+          )
+        );
       verify(loadZf0UseCase, times(1))
-          .loadOrCreateZf0(argThat(argument -> Objects.equals(argument.amendingLaw(), norm)));
+        .loadOrCreateZf0(argThat(argument -> Objects.equals(argument.amendingLaw(), norm)));
     }
 
     @Test
     void itReturnsNothingIfArticleDoesNotExists() throws Exception {
       // Given
-      var norm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                               <akn:act name="regelungstext">
-                                  <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                     <!-- Artikel 1 : Hauptänderung -->
-                                     <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                        <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                           <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                                        <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                                        <!-- Absatz (1) -->
-                                        <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                                           <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                                              <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                                           </akn:num>
-                                           <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                              <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                                 <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                                       href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                              </akn:intro>
-                                           </akn:list>
-                                        </akn:paragraph>
-                                     </akn:article>
-                                      <!-- Artikel 3: Geltungszeitregel-->
-                                      <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                         <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                            <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
-                                         <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                                         <!-- Absatz (1) -->
-                                         <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                            <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-                                               <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
-                                            </akn:num>
-                                            <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                               <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                                  nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                            </akn:content>
-                                         </akn:paragraph>
-                                      </akn:article>
-                                  </akn:body>
-                               </akn:act>
-                            </akn:akomaNtoso>
-                          """))
-              .build();
+      var norm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                       <!-- Artikel 1 : Hauptänderung -->
+                       <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                          <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                             <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                          <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                          <!-- Absatz (1) -->
+                          <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                             <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                                <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                             </akn:num>
+                             <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                                <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                                   <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                         href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                                </akn:intro>
+                             </akn:list>
+                          </akn:paragraph>
+                       </akn:article>
+                        <!-- Artikel 3: Geltungszeitregel-->
+                        <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                           <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
+                              <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
+                           <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+                           <!-- Absatz (1) -->
+                           <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
+                              <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
+                                 <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
+                              </akn:num>
+                              <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
+                                 <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
+                                    nach der Verkündung</akn:date> in Kraft. </akn:p>
+                              </akn:content>
+                           </akn:paragraph>
+                        </akn:article>
+                    </akn:body>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
       // When
       when(loadNormUseCase.loadNorm(any())).thenReturn(norm);
 
       // When
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles/hauptteil-1_art-4523")
-                  .accept(MediaType.APPLICATION_JSON))
-          // Then
-          .andExpect(status().isNotFound());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles/hauptteil-1_art-4523"
+          )
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        // Then
+        .andExpect(status().isNotFound());
 
       verify(loadNormUseCase, times(1))
-          .loadNorm(
-              argThat(
-                  argument ->
-                      Objects.equals(
-                          argument.eli(),
-                          "eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1")));
+        .loadNorm(
+          argThat(argument ->
+            Objects.equals(
+              argument.eli(),
+              "eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1"
+            )
+          )
+        );
     }
   }
 
@@ -445,56 +500,58 @@ class ArticleControllerTest {
     @Test
     void itReturnsArticleRender() throws Exception {
       // Given
-      var norm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                               <akn:act name="regelungstext">
-                                  <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                     <!-- Artikel 1 : Hauptänderung -->
-                                     <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                        <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                           <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                                        <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                                        <!-- Absatz (1) -->
-                                        <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                                           <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                                              <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                                           </akn:num>
-                                           <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                              <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                                 <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                                       href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                              </akn:intro>
-                                           </akn:list>
-                                        </akn:paragraph>
-                                     </akn:article>
-                                      <!-- Artikel 3: Geltungszeitregel-->
-                                      <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                         <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                            <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
-                                         <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                                         <!-- Absatz (1) -->
-                                         <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                            <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-                                               <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
-                                            </akn:num>
-                                            <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                               <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                                  nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                            </akn:content>
-                                         </akn:paragraph>
-                                      </akn:article>
-                                  </akn:body>
-                               </akn:act>
-                            </akn:akomaNtoso>
-                          """))
-              .build();
+      var norm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                       <!-- Artikel 1 : Hauptänderung -->
+                       <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                          <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                             <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                          <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                          <!-- Absatz (1) -->
+                          <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                             <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                                <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                             </akn:num>
+                             <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                                <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                                   <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                         href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                                </akn:intro>
+                             </akn:list>
+                          </akn:paragraph>
+                       </akn:article>
+                        <!-- Artikel 3: Geltungszeitregel-->
+                        <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                           <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
+                              <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
+                           <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+                           <!-- Absatz (1) -->
+                           <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
+                              <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
+                                 <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
+                              </akn:num>
+                              <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
+                                 <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
+                                    nach der Verkündung</akn:date> in Kraft. </akn:p>
+                              </akn:content>
+                           </akn:paragraph>
+                        </akn:article>
+                    </akn:body>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
       // When
       when(loadNormUseCase.loadNorm(any())).thenReturn(norm);
@@ -502,12 +559,15 @@ class ArticleControllerTest {
 
       // When
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles/hauptteil-1_art-1")
-                  .accept(MediaType.TEXT_HTML))
-          // Then
-          .andExpect(status().isOk())
-          .andExpect(content().string("<div></div>"));
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles/hauptteil-1_art-1"
+          )
+            .accept(MediaType.TEXT_HTML)
+        )
+        // Then
+        .andExpect(status().isOk())
+        .andExpect(content().string("<div></div>"));
     }
 
     @Test
@@ -516,12 +576,15 @@ class ArticleControllerTest {
       when(loadArticleHtmlUseCase.loadArticleHtml(any())).thenReturn("<div></div>");
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles/hauptteil-1_para-20?atIsoDate=2017-03-01T00:00:00.000Z")
-                  .accept(MediaType.TEXT_HTML))
-          // Then
-          .andExpect(status().isOk())
-          .andExpect(content().string("<div></div>"));
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles/hauptteil-1_para-20?atIsoDate=2017-03-01T00:00:00.000Z"
+          )
+            .accept(MediaType.TEXT_HTML)
+        )
+        // Then
+        .andExpect(status().isOk())
+        .andExpect(content().string("<div></div>"));
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ElementControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ElementControllerTest.java
@@ -28,12 +28,20 @@ import org.springframework.test.web.servlet.MockMvc;
 @Import(SecurityConfig.class)
 class ElementControllerTest {
 
-  @Autowired private MockMvc mockMvc;
+  @Autowired
+  private MockMvc mockMvc;
 
-  @MockBean private LoadElementFromNormUseCase loadElementFromNormUseCase;
-  @MockBean private LoadElementHtmlFromNormUseCase loadElementHtmlFromNormUseCase;
-  @MockBean private LoadElementsByTypeFromNormUseCase loadElementsByTypeFromNormUseCase;
-  @MockBean private LoadElementHtmlAtDateFromNormUseCase loadElementHtmlAtDateFromNormUseCase;
+  @MockBean
+  private LoadElementFromNormUseCase loadElementFromNormUseCase;
+
+  @MockBean
+  private LoadElementHtmlFromNormUseCase loadElementHtmlFromNormUseCase;
+
+  @MockBean
+  private LoadElementsByTypeFromNormUseCase loadElementsByTypeFromNormUseCase;
+
+  @MockBean
+  private LoadElementHtmlAtDateFromNormUseCase loadElementHtmlAtDateFromNormUseCase;
 
   @Nested
   class GetSingleElement {
@@ -44,20 +52,26 @@ class ElementControllerTest {
       @Test
       void returns404IfNormNotFoundByEli() throws Exception {
         // given
-        when(loadElementFromNormUseCase.loadElementFromNorm(
-                new LoadElementFromNormUseCase.Query(
-                    "eli/bund/NONEXISTENT_NORM/1964/s593/1964-08-05/1/deu/regelungstext-1",
-                    "any-eid")))
-            .thenReturn(Optional.empty());
+        when(
+          loadElementFromNormUseCase.loadElementFromNorm(
+            new LoadElementFromNormUseCase.Query(
+              "eli/bund/NONEXISTENT_NORM/1964/s593/1964-08-05/1/deu/regelungstext-1",
+              "any-eid"
+            )
+          )
+        )
+          .thenReturn(Optional.empty());
 
         // when
         mockMvc
-            .perform(
-                get("/api/v1/norms/eli/bund/NONEXISTENT_NORM/1964/s593/1964-08-05/1/deu/regelungstext-1/elements/hauptteil-1_art-3")
-                    .accept(MediaType.TEXT_HTML))
-
-            // then
-            .andExpect(status().isNotFound());
+          .perform(
+            get(
+              "/api/v1/norms/eli/bund/NONEXISTENT_NORM/1964/s593/1964-08-05/1/deu/regelungstext-1/elements/hauptteil-1_art-3"
+            )
+              .accept(MediaType.TEXT_HTML)
+          )
+          // then
+          .andExpect(status().isNotFound());
       }
 
       // Removed test for element not found in norm as this would currently be identical to "Norm
@@ -71,10 +85,13 @@ class ElementControllerTest {
 
         // When / Then
         mockMvc
-            .perform(
-                get("/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/elements/hauptteil-1_para-20?atIsoDate=INVALID")
-                    .accept(MediaType.TEXT_HTML))
-            .andExpect(status().is5xxServerError());
+          .perform(
+            get(
+              "/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/elements/hauptteil-1_para-20?atIsoDate=INVALID"
+            )
+              .accept(MediaType.TEXT_HTML)
+          )
+          .andExpect(status().is5xxServerError());
       }
     }
 
@@ -82,57 +99,71 @@ class ElementControllerTest {
     void returnsHtmlRendering() throws Exception {
       // given
       var elementHtml = "<div></div>";
-      when(loadElementHtmlFromNormUseCase.loadElementHtmlFromNorm(
-              new LoadElementHtmlFromNormUseCase.Query(
-                  "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1",
-                  "hauptteil-1_art-1")))
-          .thenReturn(Optional.of(elementHtml));
+      when(
+        loadElementHtmlFromNormUseCase.loadElementHtmlFromNorm(
+          new LoadElementHtmlFromNormUseCase.Query(
+            "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1",
+            "hauptteil-1_art-1"
+          )
+        )
+      )
+        .thenReturn(Optional.of(elementHtml));
 
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements/hauptteil-1_art-1")
-                  .accept(MediaType.TEXT_HTML))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(content().string(elementHtml));
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements/hauptteil-1_art-1"
+          )
+            .accept(MediaType.TEXT_HTML)
+        )
+        // then
+        .andExpect(status().isOk())
+        .andExpect(content().string(elementHtml));
     }
 
     @Test
     void returnsJsonWithElementEidTitleAndType() throws Exception {
       // given
       var elementNode =
-          """
-              <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1"
-                              GUID="cdbfc728-a070-42d9-ba2f-357945afef06"
-                              period="#geltungszeitgr-1"
-                              refersTo="hauptaenderung">
-                              <akn:num eId="hauptteil-1_art-1_bezeichnung-1"
-                                  GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                  <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1"
-                                      GUID="81c9c481-9427-4f03-9f51-099aa9b2201e"
-                                      name="1" />Artikel 1 </akn:num>
-                              <akn:heading eId="hauptteil-1_art-1_überschrift-1"
-                                  GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes
-                              </akn:heading>
-                          </akn:article>
-              """;
-      when(loadElementFromNormUseCase.loadElementFromNorm(
-              new LoadElementFromNormUseCase.Query(
-                  "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1",
-                  "hauptteil-1_art-1")))
-          .thenReturn(Optional.of(XmlMapper.toNode(elementNode)));
+        """
+        <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1"
+                        GUID="cdbfc728-a070-42d9-ba2f-357945afef06"
+                        period="#geltungszeitgr-1"
+                        refersTo="hauptaenderung">
+                        <akn:num eId="hauptteil-1_art-1_bezeichnung-1"
+                            GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                            <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1"
+                                GUID="81c9c481-9427-4f03-9f51-099aa9b2201e"
+                                name="1" />Artikel 1 </akn:num>
+                        <akn:heading eId="hauptteil-1_art-1_überschrift-1"
+                            GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes
+                        </akn:heading>
+                    </akn:article>
+        """;
+      when(
+        loadElementFromNormUseCase.loadElementFromNorm(
+          new LoadElementFromNormUseCase.Query(
+            "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1",
+            "hauptteil-1_art-1"
+          )
+        )
+      )
+        .thenReturn(Optional.of(XmlMapper.toNode(elementNode)));
 
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements/hauptteil-1_art-1")
-                  .accept(MediaType.APPLICATION_JSON))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("eid").value("hauptteil-1_art-1"))
-          .andExpect(jsonPath("type").value("article"))
-          .andExpect(jsonPath("title").value("Artikel 1 Änderung des Vereinsgesetzes"));
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements/hauptteil-1_art-1"
+          )
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("eid").value("hauptteil-1_art-1"))
+        .andExpect(jsonPath("type").value("article"))
+        .andExpect(jsonPath("title").value("Artikel 1 Änderung des Vereinsgesetzes"));
     }
   }
 
@@ -148,114 +179,134 @@ class ElementControllerTest {
 
         // when
         mockMvc
-            .perform(
-                get(
-                    "/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/elements"))
-            // then
-            .andExpect(status().is5xxServerError());
+          .perform(
+            get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/elements")
+          )
+          // then
+          .andExpect(status().is5xxServerError());
       }
 
       @Test
       void itReturnsBadRequestIfTheTypeIsNotSupported() throws Exception {
         // given
         when(loadElementsByTypeFromNormUseCase.loadElementsByTypeFromNorm(any()))
-            .thenThrow(
-                new LoadElementsByTypeFromNormUseCase.UnsupportedElementTypeException(
-                    "Type not supported"));
+          .thenThrow(
+            new LoadElementsByTypeFromNormUseCase.UnsupportedElementTypeException(
+              "Type not supported"
+            )
+          );
 
         // when
         mockMvc
-            .perform(
-                get(
-                    "/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/elements?type=NOT_SUPPORTED"))
-            // then
-            .andExpect(status().isBadRequest());
+          .perform(
+            get(
+              "/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/elements?type=NOT_SUPPORTED"
+            )
+          )
+          // then
+          .andExpect(status().isBadRequest());
       }
 
       @Test
       void itReturnsNotFoundIfNormIsNotFound() throws Exception {
         // given
         when(loadElementsByTypeFromNormUseCase.loadElementsByTypeFromNorm(any()))
-            .thenThrow(new NormNotFoundException("Norm not found"));
+          .thenThrow(new NormNotFoundException("Norm not found"));
 
         // when
         mockMvc
-            .perform(
-                get(
-                    "/api/v1/norms/eli/bund/INVALID_ELI/2023/413/2023-12-29/1/deu/regelungstext-1/elements?type=article"))
-            // then
-            .andExpect(status().isNotFound());
+          .perform(
+            get(
+              "/api/v1/norms/eli/bund/INVALID_ELI/2023/413/2023-12-29/1/deu/regelungstext-1/elements?type=article"
+            )
+          )
+          // then
+          .andExpect(status().isNotFound());
       }
     }
 
     @Test
     void itReturnsEmptyListIfNoMatchingElementsAreFound() throws Exception {
       // given
-      when(loadElementsByTypeFromNormUseCase.loadElementsByTypeFromNorm(
-              new LoadElementsByTypeFromNormUseCase.Query(
-                  "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1",
-                  eq(List.of("preface")))))
-          .thenReturn(List.of());
+      when(
+        loadElementsByTypeFromNormUseCase.loadElementsByTypeFromNorm(
+          new LoadElementsByTypeFromNormUseCase.Query(
+            "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1",
+            eq(List.of("preface"))
+          )
+        )
+      )
+        .thenReturn(List.of());
 
       // when
       mockMvc
-          .perform(
-              get(
-                  "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements?type=preface"))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$[0]").doesNotExist());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements?type=preface"
+          )
+        )
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0]").doesNotExist());
     }
 
     @Test
     void itReturnsPrefacePreambleArticleAndConclusionDataInElementsResponseEntrySchema()
-        throws Exception {
-
+      throws Exception {
       // given
-      when(loadElementsByTypeFromNormUseCase.loadElementsByTypeFromNorm(
-              new LoadElementsByTypeFromNormUseCase.Query(
-                  "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1",
-                  eq(List.of("preface", "preamble", "article", "conclusions")))))
-          .thenReturn(List.of());
+      when(
+        loadElementsByTypeFromNormUseCase.loadElementsByTypeFromNorm(
+          new LoadElementsByTypeFromNormUseCase.Query(
+            "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1",
+            eq(List.of("preface", "preamble", "article", "conclusions"))
+          )
+        )
+      )
+        .thenReturn(List.of());
 
       var url =
-          "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements"
-              + "?type=preface"
-              + "&type=preamble"
-              + "&type=article"
-              + "&type=conclusions";
+        "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements" +
+        "?type=preface" +
+        "&type=preamble" +
+        "&type=article" +
+        "&type=conclusions";
 
       // when
       mockMvc
-          .perform(get(url))
-          // then
-          .andExpect(status().isOk());
+        .perform(get(url))
+        // then
+        .andExpect(status().isOk());
     }
 
     @Nested
     class GivenAnAmendingLaw {
+
       @Test
       void itReturnsOnlyTheElementsMatchingTheGivenAmendingLaw() throws Exception {
-        when(loadElementsByTypeFromNormUseCase.loadElementsByTypeFromNorm(
-                new LoadElementsByTypeFromNormUseCase.Query(
-                    "eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1",
-                    eq(List.of("preface", "preamble", "article", "conclusions")),
-                    "eli/bund/bgbl-1/2017/s815/1995-03-15/1/deu/regelungstext-1")))
-            .thenReturn(List.of());
+        when(
+          loadElementsByTypeFromNormUseCase.loadElementsByTypeFromNorm(
+            new LoadElementsByTypeFromNormUseCase.Query(
+              "eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1",
+              eq(List.of("preface", "preamble", "article", "conclusions")),
+              "eli/bund/bgbl-1/2017/s815/1995-03-15/1/deu/regelungstext-1"
+            )
+          )
+        )
+          .thenReturn(List.of());
 
         var url =
-            "/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/elements"
-                + "?type=preface"
-                + "&type=preamble"
-                + "&type=article"
-                + "&type=conclusions"
-                + "&amendedBy=eli/bund/bgbl-1/2017/s815/1995-03-15/1/deu/regelungstext-1"; // second
+          "/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/elements" +
+          "?type=preface" +
+          "&type=preamble" +
+          "&type=article" +
+          "&type=conclusions" +
+          "&amendedBy=eli/bund/bgbl-1/2017/s815/1995-03-15/1/deu/regelungstext-1"; // second
 
         // when
         mockMvc
-            .perform(get(url))
-            // then
-            .andExpect(status().isOk());
+          .perform(get(url))
+          // then
+          .andExpect(status().isOk());
       }
     }
   }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/NormControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/NormControllerTest.java
@@ -30,15 +30,29 @@ import org.springframework.test.web.servlet.MockMvc;
 @Import(SecurityConfig.class)
 class NormControllerTest {
 
-  @Autowired private MockMvc mockMvc;
+  @Autowired
+  private MockMvc mockMvc;
 
-  @MockBean private LoadNormUseCase loadNormUseCase;
-  @MockBean private LoadNormXmlUseCase loadNormXmlUseCase;
-  @MockBean private UpdateNormXmlUseCase updateNormXmlUseCase;
-  @MockBean private TransformLegalDocMlToHtmlUseCase transformLegalDocMlToHtmlUseCase;
-  @MockBean private ApplyPassiveModificationsUseCase applyPassiveModificationsUseCase;
-  @MockBean private UpdateModsUseCase updateModsUseCase;
-  @MockBean private UpdateModUseCase updateModUseCase;
+  @MockBean
+  private LoadNormUseCase loadNormUseCase;
+
+  @MockBean
+  private LoadNormXmlUseCase loadNormXmlUseCase;
+
+  @MockBean
+  private UpdateNormXmlUseCase updateNormXmlUseCase;
+
+  @MockBean
+  private TransformLegalDocMlToHtmlUseCase transformLegalDocMlToHtmlUseCase;
+
+  @MockBean
+  private ApplyPassiveModificationsUseCase applyPassiveModificationsUseCase;
+
+  @MockBean
+  private UpdateModsUseCase updateModsUseCase;
+
+  @MockBean
+  private UpdateModUseCase updateModUseCase;
 
   @Nested
   class getNorm {
@@ -46,72 +60,75 @@ class NormControllerTest {
     @Test
     void itReturnsNorm() throws Exception {
       // Given
-      var norm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                                            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                                            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                                               <akn:act name="regelungstext">
-                                                  <!-- Metadaten -->
-                                                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                                        <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                                           <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
-                                                           <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
-                                                           <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
-                                                        </akn:FRBRWork>
-                                                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                                           <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                                                           <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                                                           <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                                                        </akn:FRBRExpression>
-                                                    </akn:identification>
-                                                  </akn:meta>
+      var norm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+               <akn:act name="regelungstext">
+                  <!-- Metadaten -->
+                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                        <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                           <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                           <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                           <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                        </akn:FRBRWork>
+                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                           <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                           <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                           <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                        </akn:FRBRExpression>
+                    </akn:identification>
+                  </akn:meta>
 
-                                                  <akn:preface eId="einleitung-1" GUID="fc10e89f-fde4-44bf-aa98-b6bdea01f0ea">
-                                                     <akn:longTitle eId="einleitung-1_doktitel-1" GUID="abbb08de-e7e2-40ab-aba0-079ce786e6d6">
-                                                        <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="3e7c2134-d82c-44ba-b50d-bad9790375a0">
-                                                           <akn:docTitle
-                                                              eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="8c4eabab-9893-455e-b83b-c46f2453f2fb">Gesetz zur Regelung des öffentlichen Vereinsrechts</akn:docTitle>
-                                                        </akn:p>
-                                                     </akn:longTitle>
-                                                  </akn:preface>
-                                               </akn:act>
-                                            </akn:akomaNtoso>
-                                            """))
-              .build();
+                  <akn:preface eId="einleitung-1" GUID="fc10e89f-fde4-44bf-aa98-b6bdea01f0ea">
+                     <akn:longTitle eId="einleitung-1_doktitel-1" GUID="abbb08de-e7e2-40ab-aba0-079ce786e6d6">
+                        <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="3e7c2134-d82c-44ba-b50d-bad9790375a0">
+                           <akn:docTitle
+                              eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="8c4eabab-9893-455e-b83b-c46f2453f2fb">Gesetz zur Regelung des öffentlichen Vereinsrechts</akn:docTitle>
+                        </akn:p>
+                     </akn:longTitle>
+                  </akn:preface>
+               </akn:act>
+            </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
       // When
       when(loadNormUseCase.loadNorm(any())).thenReturn(norm);
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
-                  .accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isOk())
-          .andExpect(
-              jsonPath("eli")
-                  .value(equalTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")))
-          .andExpect(
-              jsonPath("title")
-                  .value(equalTo("Gesetz zur Regelung des öffentlichen Vereinsrechts")))
-          .andExpect(jsonPath("frbrNumber").value(equalTo("s593")))
-          .andExpect(jsonPath("frbrName").value(equalTo("BGBl. I")))
-          .andExpect(jsonPath("frbrDateVerkuendung").value(equalTo("1964-08-05")));
+        .perform(
+          get("/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isOk())
+        .andExpect(
+          jsonPath("eli")
+            .value(equalTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"))
+        )
+        .andExpect(
+          jsonPath("title").value(equalTo("Gesetz zur Regelung des öffentlichen Vereinsrechts"))
+        )
+        .andExpect(jsonPath("frbrNumber").value(equalTo("s593")))
+        .andExpect(jsonPath("frbrName").value(equalTo("BGBl. I")))
+        .andExpect(jsonPath("frbrDateVerkuendung").value(equalTo("1964-08-05")));
 
       verify(loadNormUseCase, times(1))
-          .loadNorm(
-              argThat(
-                  query ->
-                      query
-                          .eli()
-                          .equals("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")));
+        .loadNorm(
+          argThat(query ->
+            query.eli().equals("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+          )
+        );
     }
   }
 
@@ -129,9 +146,9 @@ class NormControllerTest {
 
       // When // Then
       mockMvc
-          .perform(get("/api/v1/norms/{eli}", eli).accept(MediaType.APPLICATION_XML))
-          .andExpect(status().isOk())
-          .andExpect(content().string(xml));
+        .perform(get("/api/v1/norms/{eli}", eli).accept(MediaType.APPLICATION_XML))
+        .andExpect(status().isOk())
+        .andExpect(content().string(xml));
     }
   }
 
@@ -150,14 +167,15 @@ class NormControllerTest {
 
       // When // Then
       mockMvc
-          .perform(get("/api/v1/norms/{eli}", eli).accept(MediaType.TEXT_HTML))
-          .andExpect(status().isOk())
-          .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-          .andExpect(content().string(html));
+        .perform(get("/api/v1/norms/{eli}", eli).accept(MediaType.TEXT_HTML))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+        .andExpect(content().string(html));
 
       verify(transformLegalDocMlToHtmlUseCase, times(1))
-          .transformLegalDocMlToHtml(
-              argThat(query -> query.xml().equals(xml) && !query.showMetadata()));
+        .transformLegalDocMlToHtml(
+          argThat(query -> query.xml().equals(xml) && !query.showMetadata())
+        );
     }
 
     @Test
@@ -172,14 +190,15 @@ class NormControllerTest {
 
       // When // Then
       mockMvc
-          .perform(get("/api/v1/norms/{eli}?showMetadata=true", eli).accept(MediaType.TEXT_HTML))
-          .andExpect(status().isOk())
-          .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-          .andExpect(content().string(html));
+        .perform(get("/api/v1/norms/{eli}?showMetadata=true", eli).accept(MediaType.TEXT_HTML))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+        .andExpect(content().string(html));
 
       verify(transformLegalDocMlToHtmlUseCase, times(1))
-          .transformLegalDocMlToHtml(
-              argThat(query -> query.xml().equals(xml) && query.showMetadata()));
+        .transformLegalDocMlToHtml(
+          argThat(query -> query.xml().equals(xml) && query.showMetadata())
+        );
     }
 
     @Test
@@ -191,16 +210,17 @@ class NormControllerTest {
       when(loadNormUseCase.loadNorm(any())).thenReturn(NormFixtures.loadFromDisk("SimpleNorm.xml"));
       when(transformLegalDocMlToHtmlUseCase.transformLegalDocMlToHtml(any())).thenReturn(html);
       when(applyPassiveModificationsUseCase.applyPassiveModifications(any()))
-          .thenReturn(NormFixtures.loadFromDisk("SimpleNorm.xml"));
+        .thenReturn(NormFixtures.loadFromDisk("SimpleNorm.xml"));
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/{eli}?atIsoDate=2024-04-03T00:00:00.000Z", eli)
-                  .accept(MediaType.TEXT_HTML))
-          .andExpect(status().isOk())
-          .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-          .andExpect(content().string(html));
+        .perform(
+          get("/api/v1/norms/{eli}?atIsoDate=2024-04-03T00:00:00.000Z", eli)
+            .accept(MediaType.TEXT_HTML)
+        )
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+        .andExpect(content().string(html));
 
       verify(applyPassiveModificationsUseCase, times(1)).applyPassiveModifications(any());
     }
@@ -219,17 +239,18 @@ class NormControllerTest {
 
       // When // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}", eli)
-                  .accept(MediaType.APPLICATION_XML)
-                  .contentType(MediaType.APPLICATION_XML)
-                  .content(xml))
-          .andExpect(status().isOk())
-          .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
-          .andExpect(content().string(xml));
+        .perform(
+          put("/api/v1/norms/{eli}", eli)
+            .accept(MediaType.APPLICATION_XML)
+            .contentType(MediaType.APPLICATION_XML)
+            .content(xml)
+        )
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
+        .andExpect(content().string(xml));
 
       verify(updateNormXmlUseCase, times(1))
-          .updateNormXml(argThat(query -> query.xml().equals(xml)));
+        .updateNormXml(argThat(query -> query.xml().equals(xml)));
     }
 
     @Test
@@ -239,20 +260,21 @@ class NormControllerTest {
       final String xml = "<akn:doc>new</akn:doc>";
 
       when(updateNormXmlUseCase.updateNormXml(any()))
-          .thenThrow(new UpdateNormXmlUseCase.InvalidUpdateException("Error Message"));
+        .thenThrow(new UpdateNormXmlUseCase.InvalidUpdateException("Error Message"));
 
       // When // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}", eli)
-                  .accept(MediaType.APPLICATION_XML)
-                  .contentType(MediaType.APPLICATION_XML)
-                  .content(xml))
-          .andExpect(status().isBadRequest())
-          .andExpect(content().string("Error Message"));
+        .perform(
+          put("/api/v1/norms/{eli}", eli)
+            .accept(MediaType.APPLICATION_XML)
+            .contentType(MediaType.APPLICATION_XML)
+            .content(xml)
+        )
+        .andExpect(status().isBadRequest())
+        .andExpect(content().string("Error Message"));
 
       verify(updateNormXmlUseCase, times(1))
-          .updateNormXml(argThat(query -> query.xml().equals(xml)));
+        .updateNormXml(argThat(query -> query.xml().equals(xml)));
     }
 
     @Test
@@ -265,15 +287,16 @@ class NormControllerTest {
 
       // When // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}", eli)
-                  .accept(MediaType.APPLICATION_XML)
-                  .contentType(MediaType.APPLICATION_XML)
-                  .content(xml))
-          .andExpect(status().isNotFound());
+        .perform(
+          put("/api/v1/norms/{eli}", eli)
+            .accept(MediaType.APPLICATION_XML)
+            .contentType(MediaType.APPLICATION_XML)
+            .content(xml)
+        )
+        .andExpect(status().isNotFound());
 
       verify(updateNormXmlUseCase, times(1))
-          .updateNormXml(argThat(query -> query.xml().equals(xml)));
+        .updateNormXml(argThat(query -> query.xml().equals(xml)));
     }
   }
 
@@ -290,20 +313,22 @@ class NormControllerTest {
 
       // When
       when(updateModUseCase.updateMod(any()))
-          .thenReturn(Optional.of(new UpdateModUseCase.Result(amendingNormXml, targetNormZf0Xml)));
+        .thenReturn(Optional.of(new UpdateModUseCase.Result(amendingNormXml, targetNormZf0Xml)));
 
       // When // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/" + eli + "/mods/" + modEid)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "{\"refersTo\": \"aenderungsbefehl-ersetzen\", \"timeBoundaryEid\": \"new-time-boundary-eid\", \"destinationHref\": \"new-destination-href\", \"newContent\": \"new test text\"}"))
-          .andExpect(status().isOk())
-          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-          .andExpect(jsonPath("amendingNormXml").value(amendingNormXml))
-          .andExpect(jsonPath("targetNormZf0Xml").value(targetNormZf0Xml));
+        .perform(
+          put("/api/v1/norms/" + eli + "/mods/" + modEid)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "{\"refersTo\": \"aenderungsbefehl-ersetzen\", \"timeBoundaryEid\": \"new-time-boundary-eid\", \"destinationHref\": \"new-destination-href\", \"newContent\": \"new test text\"}"
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("amendingNormXml").value(amendingNormXml))
+        .andExpect(jsonPath("targetNormZf0Xml").value(targetNormZf0Xml));
 
       verify(updateModUseCase, times(1)).updateMod(argThat(query -> !query.dryRun()));
     }
@@ -318,20 +343,22 @@ class NormControllerTest {
 
       // When
       when(updateModUseCase.updateMod(any()))
-          .thenReturn(Optional.of(new UpdateModUseCase.Result(amendingNormXml, targetNormZf0Xml)));
+        .thenReturn(Optional.of(new UpdateModUseCase.Result(amendingNormXml, targetNormZf0Xml)));
 
       // When // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/" + eli + "/mods/" + modEid + "?dryRun=true")
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "{\"refersTo\": \"aenderungsbefehl-ersetzen\", \"timeBoundaryEid\": \"new-time-boundary-eid\", \"destinationHref\": \"new-destination-href\", \"newContent\": \"new test text\"}"))
-          .andExpect(status().isOk())
-          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-          .andExpect(jsonPath("amendingNormXml").value(amendingNormXml))
-          .andExpect(jsonPath("targetNormZf0Xml").value(targetNormZf0Xml));
+        .perform(
+          put("/api/v1/norms/" + eli + "/mods/" + modEid + "?dryRun=true")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "{\"refersTo\": \"aenderungsbefehl-ersetzen\", \"timeBoundaryEid\": \"new-time-boundary-eid\", \"destinationHref\": \"new-destination-href\", \"newContent\": \"new test text\"}"
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("amendingNormXml").value(amendingNormXml))
+        .andExpect(jsonPath("targetNormZf0Xml").value(targetNormZf0Xml));
 
       verify(updateModUseCase, times(1)).updateMod(argThat(UpdateModUseCase.Query::dryRun));
     }
@@ -347,13 +374,15 @@ class NormControllerTest {
 
       // When // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/" + eli + "/mods/" + modEid)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "{\"refersTo\": \"aenderungsbefehl-ersetzen\", \"timeBoundaryEid\": \"new-time-boundary-eid\", \"destinationHref\": \"new-destination-href\", \"newContent\": \"new test text\"}"))
-          .andExpect(status().isNotFound());
+        .perform(
+          put("/api/v1/norms/" + eli + "/mods/" + modEid)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "{\"refersTo\": \"aenderungsbefehl-ersetzen\", \"timeBoundaryEid\": \"new-time-boundary-eid\", \"destinationHref\": \"new-destination-href\", \"newContent\": \"new test text\"}"
+            )
+        )
+        .andExpect(status().isNotFound());
     }
 
     @Test
@@ -367,13 +396,15 @@ class NormControllerTest {
 
       // When // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/" + eli + "/mods/" + modEid)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "{\"refersTo\": \"aenderungsbefehl-ersetzen\", \"timeBoundaryEid\": \"new-time-boundary-eid\", \"destinationHref\": \"new-destination-href\", \"newContent\": \"new test text\"}"))
-          .andExpect(status().isUnprocessableEntity());
+        .perform(
+          put("/api/v1/norms/" + eli + "/mods/" + modEid)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "{\"refersTo\": \"aenderungsbefehl-ersetzen\", \"timeBoundaryEid\": \"new-time-boundary-eid\", \"destinationHref\": \"new-destination-href\", \"newContent\": \"new test text\"}"
+            )
+        )
+        .andExpect(status().isUnprocessableEntity());
     }
 
     @Test
@@ -387,14 +418,16 @@ class NormControllerTest {
 
       // When // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/" + eli + "/mods/" + modEid)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "{\"refersTo\": \"aenderungsbefehl-ersetzen\", \"timeBoundaryEid\": \"new-time-boundary-eid\", \"destinationHref\": \"new-destination-href\", \"newContent\": \"new test text\"}"))
-          .andExpect(status().isUnprocessableEntity())
-          .andExpect(content().string("{\"message\": \"error exception\"}"));
+        .perform(
+          put("/api/v1/norms/" + eli + "/mods/" + modEid)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "{\"refersTo\": \"aenderungsbefehl-ersetzen\", \"timeBoundaryEid\": \"new-time-boundary-eid\", \"destinationHref\": \"new-destination-href\", \"newContent\": \"new test text\"}"
+            )
+        )
+        .andExpect(status().isUnprocessableEntity())
+        .andExpect(content().string("{\"message\": \"error exception\"}"));
     }
   }
 
@@ -410,21 +443,23 @@ class NormControllerTest {
 
       // When
       when(updateModsUseCase.updateMods(any()))
-          .thenReturn(Optional.of(new UpdateModsUseCase.Result(amendingNormXml, targetNormZf0Xml)));
+        .thenReturn(Optional.of(new UpdateModsUseCase.Result(amendingNormXml, targetNormZf0Xml)));
 
       // When // Then
       mockMvc
-          .perform(
-              patch("/api/v1/norms/" + eli + "/mods")
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "{\"mod-eid-1\": {\"timeBoundaryEid\": \"new-time-boundary-eid\"},\n"
-                          + "\"mod-eid-2\": {\"timeBoundaryEid\": \"new-time-boundary-eid\"}}"))
-          .andExpect(status().isOk())
-          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-          .andExpect(jsonPath("amendingNormXml").value(amendingNormXml))
-          .andExpect(jsonPath("targetNormZf0Xml").value(targetNormZf0Xml));
+        .perform(
+          patch("/api/v1/norms/" + eli + "/mods")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "{\"mod-eid-1\": {\"timeBoundaryEid\": \"new-time-boundary-eid\"},\n" +
+              "\"mod-eid-2\": {\"timeBoundaryEid\": \"new-time-boundary-eid\"}}"
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("amendingNormXml").value(amendingNormXml))
+        .andExpect(jsonPath("targetNormZf0Xml").value(targetNormZf0Xml));
 
       verify(updateModsUseCase, times(1)).updateMods(argThat(query -> !query.dryRun()));
     }
@@ -438,19 +473,20 @@ class NormControllerTest {
 
       // When
       when(updateModsUseCase.updateMods(any()))
-          .thenReturn(Optional.of(new UpdateModsUseCase.Result(amendingNormXml, targetNormZf0Xml)));
+        .thenReturn(Optional.of(new UpdateModsUseCase.Result(amendingNormXml, targetNormZf0Xml)));
 
       // When // Then
       mockMvc
-          .perform(
-              patch("/api/v1/norms/" + eli + "/mods?dryRun=true")
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content("{\"mod-eid-1\": {\"timeBoundaryEid\": \"new-time-boundary-eid\"}}"))
-          .andExpect(status().isOk())
-          .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-          .andExpect(jsonPath("amendingNormXml").value(amendingNormXml))
-          .andExpect(jsonPath("targetNormZf0Xml").value(targetNormZf0Xml));
+        .perform(
+          patch("/api/v1/norms/" + eli + "/mods?dryRun=true")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"mod-eid-1\": {\"timeBoundaryEid\": \"new-time-boundary-eid\"}}")
+        )
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("amendingNormXml").value(amendingNormXml))
+        .andExpect(jsonPath("targetNormZf0Xml").value(targetNormZf0Xml));
 
       verify(updateModsUseCase, times(1)).updateMods(argThat(UpdateModsUseCase.Query::dryRun));
     }
@@ -465,12 +501,13 @@ class NormControllerTest {
 
       // When // Then
       mockMvc
-          .perform(
-              patch("/api/v1/norms/" + eli + "/mods")
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content("{\"mod-eid-1\": {\"timeBoundaryEid\": \"new-time-boundary-eid\"}}"))
-          .andExpect(status().isUnprocessableEntity());
+        .perform(
+          patch("/api/v1/norms/" + eli + "/mods")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"mod-eid-1\": {\"timeBoundaryEid\": \"new-time-boundary-eid\"}}")
+        )
+        .andExpect(status().isUnprocessableEntity());
     }
 
     @Test
@@ -483,12 +520,13 @@ class NormControllerTest {
 
       // When // Then
       mockMvc
-          .perform(
-              patch("/api/v1/norms/" + eli + "/mods")
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content("{\"mod-eid-1\": {\"timeBoundaryEid\": \"new-time-boundary-eid\"}}"))
-          .andExpect(status().isUnprocessableEntity());
+        .perform(
+          patch("/api/v1/norms/" + eli + "/mods")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"mod-eid-1\": {\"timeBoundaryEid\": \"new-time-boundary-eid\"}}")
+        )
+        .andExpect(status().isUnprocessableEntity());
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ProprietaryControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ProprietaryControllerTest.java
@@ -35,32 +35,40 @@ import org.springframework.test.web.servlet.MockMvc;
 @Import(SecurityConfig.class)
 class ProprietaryControllerTest {
 
-  @Autowired private MockMvc mockMvc;
-
-  @MockBean private LoadProprietaryFromNormUseCase loadProprietaryFromNormUseCase;
-  @MockBean private UpdateProprietaryFrameFromNormUseCase updateProprietaryFrameFromNormUseCase;
+  @Autowired
+  private MockMvc mockMvc;
 
   @MockBean
-  private UpdateProprietarySingleElementFromNormUseCase
-      updateProprietarySingleElementFromNormUseCase;
+  private LoadProprietaryFromNormUseCase loadProprietaryFromNormUseCase;
+
+  @MockBean
+  private UpdateProprietaryFrameFromNormUseCase updateProprietaryFrameFromNormUseCase;
+
+  @MockBean
+  private UpdateProprietarySingleElementFromNormUseCase updateProprietarySingleElementFromNormUseCase;
 
   @Nested
   class getProprietaryAtDate {
+
     @Test
     void returns404IfNormNotFound() throws Exception {
       // given
       var eli = "eli/bund/NONEXISTENT_NORM/1964/s593/1964-08-05/1/deu/regelungstext-1";
       var atDateString = "2024-06-03";
-      when(loadProprietaryFromNormUseCase.loadProprietaryFromNorm(
-              new LoadProprietaryFromNormUseCase.Query(eli)))
-          .thenThrow(new NormNotFoundException(eli));
+      when(
+        loadProprietaryFromNormUseCase.loadProprietaryFromNorm(
+          new LoadProprietaryFromNormUseCase.Query(eli)
+        )
+      )
+        .thenThrow(new NormNotFoundException(eli));
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/" + eli + "/proprietary/" + atDateString)
-                  .accept(MediaType.APPLICATION_JSON_VALUE))
-          // then
-          .andExpect(status().isNotFound());
+        .perform(
+          get("/api/v1/norms/" + eli + "/proprietary/" + atDateString)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        )
+        // then
+        .andExpect(status().isNotFound());
     }
 
     @Test
@@ -70,27 +78,31 @@ class ProprietaryControllerTest {
       var atDateString = "2024-06-03";
       var normWithProprietary = NormFixtures.loadFromDisk("NormWithProprietary.xml");
       var proprietary = normWithProprietary.getMeta().getOrCreateProprietary();
-      when(loadProprietaryFromNormUseCase.loadProprietaryFromNorm(
-              new LoadProprietaryFromNormUseCase.Query(eli)))
-          .thenReturn(proprietary);
+      when(
+        loadProprietaryFromNormUseCase.loadProprietaryFromNorm(
+          new LoadProprietaryFromNormUseCase.Query(eli)
+        )
+      )
+        .thenReturn(proprietary);
 
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/" + eli + "/proprietary/" + atDateString)
-                  .accept(MediaType.APPLICATION_JSON_VALUE))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("fna").value("754-28-1"))
-          .andExpect(jsonPath("art").value("rechtsetzungsdokument"))
-          .andExpect(jsonPath("typ").value("gesetz"))
-          .andExpect(jsonPath("subtyp").value("rechtsverordnung"))
-          .andExpect(jsonPath("bezeichnungInVorlage").value("Bezeichnung gemäß Vorlage"))
-          .andExpect(jsonPath("artDerNorm").value("SN,ÄN,ÜN"))
-          .andExpect(jsonPath("staat").value("DEU"))
-          .andExpect(jsonPath("beschliessendesOrgan").value("Bundestag"))
-          .andExpect(jsonPath("qualifizierteMehrheit").value(true))
-          .andExpect(jsonPath("organisationsEinheit").value("Organisationseinheit"));
+        .perform(
+          get("/api/v1/norms/" + eli + "/proprietary/" + atDateString)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        )
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("fna").value("754-28-1"))
+        .andExpect(jsonPath("art").value("rechtsetzungsdokument"))
+        .andExpect(jsonPath("typ").value("gesetz"))
+        .andExpect(jsonPath("subtyp").value("rechtsverordnung"))
+        .andExpect(jsonPath("bezeichnungInVorlage").value("Bezeichnung gemäß Vorlage"))
+        .andExpect(jsonPath("artDerNorm").value("SN,ÄN,ÜN"))
+        .andExpect(jsonPath("staat").value("DEU"))
+        .andExpect(jsonPath("beschliessendesOrgan").value("Bundestag"))
+        .andExpect(jsonPath("qualifizierteMehrheit").value(true))
+        .andExpect(jsonPath("organisationsEinheit").value("Organisationseinheit"));
     }
 
     @Test
@@ -100,27 +112,31 @@ class ProprietaryControllerTest {
       var atDateString = "2024-06-03";
       var normWithInvalidProprietary = NormFixtures.loadFromDisk("NormWithInvalidProprietary.xml");
       var proprietary = normWithInvalidProprietary.getMeta().getOrCreateProprietary();
-      when(loadProprietaryFromNormUseCase.loadProprietaryFromNorm(
-              new LoadProprietaryFromNormUseCase.Query(eli)))
-          .thenReturn(proprietary);
+      when(
+        loadProprietaryFromNormUseCase.loadProprietaryFromNorm(
+          new LoadProprietaryFromNormUseCase.Query(eli)
+        )
+      )
+        .thenReturn(proprietary);
 
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/" + eli + "/proprietary/" + atDateString)
-                  .accept(MediaType.APPLICATION_JSON_VALUE))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("fna").isEmpty())
-          .andExpect(jsonPath("art").isEmpty())
-          .andExpect(jsonPath("typ").isEmpty())
-          .andExpect(jsonPath("subtyp").isEmpty())
-          .andExpect(jsonPath("bezeichnungInVorlage").isEmpty())
-          .andExpect(jsonPath("artDerNorm").isEmpty())
-          .andExpect(jsonPath("staat").isEmpty())
-          .andExpect(jsonPath("beschliessendesOrgan").isEmpty())
-          .andExpect(jsonPath("qualifizierteMehrheit").isEmpty())
-          .andExpect(jsonPath("organisationsEinheit").isEmpty());
+        .perform(
+          get("/api/v1/norms/" + eli + "/proprietary/" + atDateString)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        )
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("fna").isEmpty())
+        .andExpect(jsonPath("art").isEmpty())
+        .andExpect(jsonPath("typ").isEmpty())
+        .andExpect(jsonPath("subtyp").isEmpty())
+        .andExpect(jsonPath("bezeichnungInVorlage").isEmpty())
+        .andExpect(jsonPath("artDerNorm").isEmpty())
+        .andExpect(jsonPath("staat").isEmpty())
+        .andExpect(jsonPath("beschliessendesOrgan").isEmpty())
+        .andExpect(jsonPath("qualifizierteMehrheit").isEmpty())
+        .andExpect(jsonPath("organisationsEinheit").isEmpty());
     }
 
     @Test
@@ -130,27 +146,31 @@ class ProprietaryControllerTest {
       var atDateString = "2024-06-03";
       var normWithInvalidProprietary = NormFixtures.loadFromDisk("SimpleNorm.xml");
       var proprietary = normWithInvalidProprietary.getMeta().getOrCreateProprietary();
-      when(loadProprietaryFromNormUseCase.loadProprietaryFromNorm(
-              new LoadProprietaryFromNormUseCase.Query(eli)))
-          .thenReturn(proprietary);
+      when(
+        loadProprietaryFromNormUseCase.loadProprietaryFromNorm(
+          new LoadProprietaryFromNormUseCase.Query(eli)
+        )
+      )
+        .thenReturn(proprietary);
 
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/" + eli + "/proprietary/" + atDateString)
-                  .accept(MediaType.APPLICATION_JSON_VALUE))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("fna").isEmpty())
-          .andExpect(jsonPath("art").isEmpty())
-          .andExpect(jsonPath("typ").isEmpty())
-          .andExpect(jsonPath("subtyp").isEmpty())
-          .andExpect(jsonPath("bezeichnungInVorlage").isEmpty())
-          .andExpect(jsonPath("artDerNorm").isEmpty())
-          .andExpect(jsonPath("staat").isEmpty())
-          .andExpect(jsonPath("beschliessendesOrgan").isEmpty())
-          .andExpect(jsonPath("qualifizierteMehrheit").isEmpty())
-          .andExpect(jsonPath("organisationsEinheit").isEmpty());
+        .perform(
+          get("/api/v1/norms/" + eli + "/proprietary/" + atDateString)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        )
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("fna").isEmpty())
+        .andExpect(jsonPath("art").isEmpty())
+        .andExpect(jsonPath("typ").isEmpty())
+        .andExpect(jsonPath("subtyp").isEmpty())
+        .andExpect(jsonPath("bezeichnungInVorlage").isEmpty())
+        .andExpect(jsonPath("artDerNorm").isEmpty())
+        .andExpect(jsonPath("staat").isEmpty())
+        .andExpect(jsonPath("beschliessendesOrgan").isEmpty())
+        .andExpect(jsonPath("qualifizierteMehrheit").isEmpty())
+        .andExpect(jsonPath("organisationsEinheit").isEmpty());
     }
   }
 
@@ -163,84 +183,81 @@ class ProprietaryControllerTest {
       final String eli = "eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1";
       final LocalDate date = LocalDate.parse("1990-01-01");
 
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                          <akn:proprietary xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_proprietary-1" GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c" source="attributsemantik-noch-undefiniert">
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+            <akn:proprietary xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_proprietary-1" GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c" source="attributsemantik-noch-undefiniert">
 
-                                                                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                                                    <meta:fna start="1990-01-01" end="1994-12-31">new-fna</meta:fna>
-                                                                    <meta:art start="1990-01-01" end="1994-12-31">new-art</meta:art>
-                                                                    <meta:typ start="1990-01-01" end="1994-12-31">new-typ</meta:typ>
-                                                                    <meta:subtyp start="1990-01-01" end="1994-12-31">new-subtyp</meta:subtyp>
-                                                                    <meta:bezeichnungInVorlage start="1990-01-01" end="1994-12-31">new-bezeichnungInVorlage</meta:bezeichnungInVorlage>
-                                                                    <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN,ÄN,ÜN</meta:artDerNorm>
-                                                                    <meta:normgeber start="1990-01-01" end="1994-12-31">DEU</meta:normgeber>
-                                                                    <meta:beschliessendesOrgan start="1990-01-01" end="1994-12-31" qualifizierteMehrheit="true">Bundestag</meta:beschliessendesOrgan>
-                                                                    <meta:organisationsEinheit start="1990-01-01" end="1994-12-31">Andere Organisationseinheit</meta:organisationsEinheit>
-                                                                </meta:legalDocML.de_metadaten_ds>
-                                                            </akn:proprietary>
-                                                            """))
-              .build();
+                                                  <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                                                      <meta:fna start="1990-01-01" end="1994-12-31">new-fna</meta:fna>
+                                                      <meta:art start="1990-01-01" end="1994-12-31">new-art</meta:art>
+                                                      <meta:typ start="1990-01-01" end="1994-12-31">new-typ</meta:typ>
+                                                      <meta:subtyp start="1990-01-01" end="1994-12-31">new-subtyp</meta:subtyp>
+                                                      <meta:bezeichnungInVorlage start="1990-01-01" end="1994-12-31">new-bezeichnungInVorlage</meta:bezeichnungInVorlage>
+                                                      <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN,ÄN,ÜN</meta:artDerNorm>
+                                                      <meta:normgeber start="1990-01-01" end="1994-12-31">DEU</meta:normgeber>
+                                                      <meta:beschliessendesOrgan start="1990-01-01" end="1994-12-31" qualifizierteMehrheit="true">Bundestag</meta:beschliessendesOrgan>
+                                                      <meta:organisationsEinheit start="1990-01-01" end="1994-12-31">Andere Organisationseinheit</meta:organisationsEinheit>
+                                                  </meta:legalDocML.de_metadaten_ds>
+                                              </akn:proprietary>
+                                              """
+          )
+        )
+        .build();
 
       when(updateProprietaryFrameFromNormUseCase.updateProprietaryFrameFromNorm(any()))
-          .thenReturn(proprietary);
+        .thenReturn(proprietary);
 
       // When // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/proprietary/{date}", eli, date.toString())
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "{\"fna\": \"new-fna\","
-                          + "\"art\": \"new-art\","
-                          + "\"typ\": \"new-typ\","
-                          + "\"subtyp\": \"new-subtyp\","
-                          + "\"bezeichnungInVorlage\": \"new-bezeichnungInVorlage\","
-                          + "\"artDerNorm\": \"SN,ÄN,ÜN\","
-                          + "\"staat\": \"DEU\","
-                          + "\"beschliessendesOrgan\": \"Bundestag\","
-                          + "\"qualifizierteMehrheit\": true,"
-                          + "\"organisationsEinheit\": \"Andere Organisationseinheit\"}"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("fna").value("new-fna"))
-          .andExpect(jsonPath("art").value("new-art"))
-          .andExpect(jsonPath("typ").value("new-typ"))
-          .andExpect(jsonPath("subtyp").value("new-subtyp"))
-          .andExpect(jsonPath("bezeichnungInVorlage").value("new-bezeichnungInVorlage"))
-          .andExpect(jsonPath("artDerNorm").value("SN,ÄN,ÜN"))
-          .andExpect(jsonPath("staat").value("DEU"))
-          .andExpect(jsonPath("beschliessendesOrgan").value("Bundestag"))
-          .andExpect(jsonPath("qualifizierteMehrheit").value(true))
-          .andExpect(jsonPath("organisationsEinheit").value("Andere Organisationseinheit"));
+        .perform(
+          put("/api/v1/norms/{eli}/proprietary/{date}", eli, date.toString())
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "{\"fna\": \"new-fna\"," +
+              "\"art\": \"new-art\"," +
+              "\"typ\": \"new-typ\"," +
+              "\"subtyp\": \"new-subtyp\"," +
+              "\"bezeichnungInVorlage\": \"new-bezeichnungInVorlage\"," +
+              "\"artDerNorm\": \"SN,ÄN,ÜN\"," +
+              "\"staat\": \"DEU\"," +
+              "\"beschliessendesOrgan\": \"Bundestag\"," +
+              "\"qualifizierteMehrheit\": true," +
+              "\"organisationsEinheit\": \"Andere Organisationseinheit\"}"
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("fna").value("new-fna"))
+        .andExpect(jsonPath("art").value("new-art"))
+        .andExpect(jsonPath("typ").value("new-typ"))
+        .andExpect(jsonPath("subtyp").value("new-subtyp"))
+        .andExpect(jsonPath("bezeichnungInVorlage").value("new-bezeichnungInVorlage"))
+        .andExpect(jsonPath("artDerNorm").value("SN,ÄN,ÜN"))
+        .andExpect(jsonPath("staat").value("DEU"))
+        .andExpect(jsonPath("beschliessendesOrgan").value("Bundestag"))
+        .andExpect(jsonPath("qualifizierteMehrheit").value(true))
+        .andExpect(jsonPath("organisationsEinheit").value("Andere Organisationseinheit"));
 
       verify(updateProprietaryFrameFromNormUseCase, times(1))
-          .updateProprietaryFrameFromNorm(
-              argThat(
-                  query ->
-                      query
-                              .eli()
-                              .equals("eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1")
-                          && query.atDate().isEqual(date)
-                          && query.metadata().fna().equals("new-fna")
-                          && query.metadata().art().equals("new-art")
-                          && query.metadata().typ().equals("new-typ")
-                          && query.metadata().subtyp().equals("new-subtyp")
-                          && query
-                              .metadata()
-                              .bezeichnungInVorlage()
-                              .equals("new-bezeichnungInVorlage")
-                          && query.metadata().artDerNorm().equals("SN,ÄN,ÜN")
-                          && query.metadata().staat().equals("DEU")
-                          && query.metadata().beschliessendesOrgan().equals("Bundestag")
-                          && query.metadata().qualifizierterMehrheit().equals(true)
-                          && query
-                              .metadata()
-                              .organisationsEinheit()
-                              .equals("Andere Organisationseinheit")));
+        .updateProprietaryFrameFromNorm(
+          argThat(query ->
+            query.eli().equals("eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1") &&
+            query.atDate().isEqual(date) &&
+            query.metadata().fna().equals("new-fna") &&
+            query.metadata().art().equals("new-art") &&
+            query.metadata().typ().equals("new-typ") &&
+            query.metadata().subtyp().equals("new-subtyp") &&
+            query.metadata().bezeichnungInVorlage().equals("new-bezeichnungInVorlage") &&
+            query.metadata().artDerNorm().equals("SN,ÄN,ÜN") &&
+            query.metadata().staat().equals("DEU") &&
+            query.metadata().beschliessendesOrgan().equals("Bundestag") &&
+            query.metadata().qualifizierterMehrheit().equals(true) &&
+            query.metadata().organisationsEinheit().equals("Andere Organisationseinheit")
+          )
+        );
     }
 
     @Test
@@ -249,47 +266,54 @@ class ProprietaryControllerTest {
       final String eli = "eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1";
 
       when(updateProprietaryFrameFromNormUseCase.updateProprietaryFrameFromNorm(any()))
-          .thenThrow(new NormNotFoundException("Norm not found"));
+        .thenThrow(new NormNotFoundException("Norm not found"));
 
       // When // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/proprietary/{date}", eli, "1990-01-01")
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "{\"fna\": \"new-fna\","
-                          + "\"art\": \"new-art\","
-                          + "\"typ\": \"new-typ\","
-                          + "\"subtyp\": \"new-subtyp\","
-                          + "\"bezeichnungInVorlage\": \"new-bezeichnungInVorlage\","
-                          + "\"artDerNorm\": \"SN,ÄN,ÜN\","
-                          + "\"staat\": \"DEU\","
-                          + "\"beschliessendesOrgan\": \"Bundestag\","
-                          + "\"qualifizierteMehrheit\": true,"
-                          + "\"organisationsEinheit\": \"Andere Organisationseinheit\"}"))
-          .andExpect(status().isNotFound());
+        .perform(
+          put("/api/v1/norms/{eli}/proprietary/{date}", eli, "1990-01-01")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "{\"fna\": \"new-fna\"," +
+              "\"art\": \"new-art\"," +
+              "\"typ\": \"new-typ\"," +
+              "\"subtyp\": \"new-subtyp\"," +
+              "\"bezeichnungInVorlage\": \"new-bezeichnungInVorlage\"," +
+              "\"artDerNorm\": \"SN,ÄN,ÜN\"," +
+              "\"staat\": \"DEU\"," +
+              "\"beschliessendesOrgan\": \"Bundestag\"," +
+              "\"qualifizierteMehrheit\": true," +
+              "\"organisationsEinheit\": \"Andere Organisationseinheit\"}"
+            )
+        )
+        .andExpect(status().isNotFound());
     }
   }
 
   @Nested
   class getProprietaryEinzelelementAtDate {
+
     @Test
     void returns404IfNormNotFound() throws Exception {
       // given
       var eli = "eli/bund/NONEXISTENT_NORM/1964/s593/1964-08-05/1/deu/regelungstext-1";
       var eid = "hauptteil-1_abschnitt-0_para-1";
       var atDateString = "2024-06-03";
-      when(loadProprietaryFromNormUseCase.loadProprietaryFromNorm(
-              new LoadProprietaryFromNormUseCase.Query(eli)))
-          .thenThrow(new NormNotFoundException(eli));
+      when(
+        loadProprietaryFromNormUseCase.loadProprietaryFromNorm(
+          new LoadProprietaryFromNormUseCase.Query(eli)
+        )
+      )
+        .thenThrow(new NormNotFoundException(eli));
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/" + eli + "/proprietary/" + eid + "/" + atDateString)
-                  .accept(MediaType.APPLICATION_JSON_VALUE))
-          // then
-          .andExpect(status().isNotFound());
+        .perform(
+          get("/api/v1/norms/" + eli + "/proprietary/" + eid + "/" + atDateString)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        )
+        // then
+        .andExpect(status().isNotFound());
     }
 
     @Test
@@ -300,18 +324,22 @@ class ProprietaryControllerTest {
       var atDateString = "2024-06-03";
       var normWithProprietary = NormFixtures.loadFromDisk("NormWithProprietary.xml");
       var proprietary = normWithProprietary.getMeta().getOrCreateProprietary();
-      when(loadProprietaryFromNormUseCase.loadProprietaryFromNorm(
-              new LoadProprietaryFromNormUseCase.Query(eli)))
-          .thenReturn(proprietary);
+      when(
+        loadProprietaryFromNormUseCase.loadProprietaryFromNorm(
+          new LoadProprietaryFromNormUseCase.Query(eli)
+        )
+      )
+        .thenReturn(proprietary);
 
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/" + eli + "/proprietary/" + eid + "/" + atDateString)
-                  .accept(MediaType.APPLICATION_JSON_VALUE))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("artDerNorm").value("SN"));
+        .perform(
+          get("/api/v1/norms/" + eli + "/proprietary/" + eid + "/" + atDateString)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        )
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("artDerNorm").value("SN"));
     }
 
     @Test
@@ -322,18 +350,22 @@ class ProprietaryControllerTest {
       var atDateString = "2024-06-03";
       var normWithInvalidProprietary = NormFixtures.loadFromDisk("NormWithInvalidProprietary.xml");
       var proprietary = normWithInvalidProprietary.getMeta().getOrCreateProprietary();
-      when(loadProprietaryFromNormUseCase.loadProprietaryFromNorm(
-              new LoadProprietaryFromNormUseCase.Query(eli)))
-          .thenReturn(proprietary);
+      when(
+        loadProprietaryFromNormUseCase.loadProprietaryFromNorm(
+          new LoadProprietaryFromNormUseCase.Query(eli)
+        )
+      )
+        .thenReturn(proprietary);
 
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/" + eli + "/proprietary/" + eid + "/" + atDateString)
-                  .accept(MediaType.APPLICATION_JSON_VALUE))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("artDerNorm").isEmpty());
+        .perform(
+          get("/api/v1/norms/" + eli + "/proprietary/" + eid + "/" + atDateString)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        )
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("artDerNorm").isEmpty());
     }
 
     @Test
@@ -344,18 +376,22 @@ class ProprietaryControllerTest {
       var atDateString = "2024-06-03";
       var normWithInvalidProprietary = NormFixtures.loadFromDisk("SimpleNorm.xml");
       var proprietary = normWithInvalidProprietary.getMeta().getOrCreateProprietary();
-      when(loadProprietaryFromNormUseCase.loadProprietaryFromNorm(
-              new LoadProprietaryFromNormUseCase.Query(eli)))
-          .thenReturn(proprietary);
+      when(
+        loadProprietaryFromNormUseCase.loadProprietaryFromNorm(
+          new LoadProprietaryFromNormUseCase.Query(eli)
+        )
+      )
+        .thenReturn(proprietary);
 
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/" + eli + "/proprietary/" + eid + "/" + atDateString)
-                  .accept(MediaType.APPLICATION_JSON_VALUE))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("artDerNorm").isEmpty());
+        .perform(
+          get("/api/v1/norms/" + eli + "/proprietary/" + eid + "/" + atDateString)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        )
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("artDerNorm").isEmpty());
     }
   }
 
@@ -369,48 +405,51 @@ class ProprietaryControllerTest {
       var eid = "hauptteil-1_abschnitt-0_para-1";
       final LocalDate date = LocalDate.parse("1990-01-01");
 
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                          <akn:proprietary xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_proprietary-1" GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c" source="attributsemantik-noch-undefiniert">
-                                                  <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                                      <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN,ÄN,ÜN</meta:artDerNorm>
-                                                      <meta:einzelelement href="#hauptteil-1_abschnitt-0_para-1">
-                                                          <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN</meta:artDerNorm>
-                                                          <meta:artDerNorm start="1995-01-01" end="2000-12-31">ÄN</meta:artDerNorm>
-                                                          <meta:artDerNorm start="2001-01-01">ÜN</meta:artDerNorm>
-                                                      </meta:einzelelement>
-                                                  </meta:legalDocML.de_metadaten_ds>
-                                              </akn:proprietary>
-                                              """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+            <akn:proprietary xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_proprietary-1" GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c" source="attributsemantik-noch-undefiniert">
+                                    <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                                        <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN,ÄN,ÜN</meta:artDerNorm>
+                                        <meta:einzelelement href="#hauptteil-1_abschnitt-0_para-1">
+                                            <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN</meta:artDerNorm>
+                                            <meta:artDerNorm start="1995-01-01" end="2000-12-31">ÄN</meta:artDerNorm>
+                                            <meta:artDerNorm start="2001-01-01">ÜN</meta:artDerNorm>
+                                        </meta:einzelelement>
+                                    </meta:legalDocML.de_metadaten_ds>
+                                </akn:proprietary>
+                                """
+          )
+        )
+        .build();
 
-      when(updateProprietarySingleElementFromNormUseCase.updateProprietarySingleElementFromNorm(
-              any()))
-          .thenReturn(proprietary);
+      when(
+        updateProprietarySingleElementFromNormUseCase.updateProprietarySingleElementFromNorm(any())
+      )
+        .thenReturn(proprietary);
 
       // When // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/proprietary/{eid}/{date}", eli, eid, date.toString())
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content("{\"artDerNorm\": \"SN\"}"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("artDerNorm").value("SN"));
+        .perform(
+          put("/api/v1/norms/{eli}/proprietary/{eid}/{date}", eli, eid, date.toString())
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"artDerNorm\": \"SN\"}")
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("artDerNorm").value("SN"));
 
       verify(updateProprietarySingleElementFromNormUseCase, times(1))
-          .updateProprietarySingleElementFromNorm(
-              argThat(
-                  query ->
-                      query
-                              .eli()
-                              .equals("eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1")
-                          && query.eid().equals(eid)
-                          && query.atDate().isEqual(date)
-                          && query.metadata().artDerNorm().equals("SN")));
+        .updateProprietarySingleElementFromNorm(
+          argThat(query ->
+            query.eli().equals("eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1") &&
+            query.eid().equals(eid) &&
+            query.atDate().isEqual(date) &&
+            query.metadata().artDerNorm().equals("SN")
+          )
+        );
     }
 
     @Test
@@ -419,18 +458,20 @@ class ProprietaryControllerTest {
       var eid = "hauptteil-1_abschnitt-0_para-1";
       final String eli = "eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1";
 
-      when(updateProprietarySingleElementFromNormUseCase.updateProprietarySingleElementFromNorm(
-              any()))
-          .thenThrow(new NormNotFoundException("Norm not found"));
+      when(
+        updateProprietarySingleElementFromNormUseCase.updateProprietarySingleElementFromNorm(any())
+      )
+        .thenThrow(new NormNotFoundException("Norm not found"));
 
       // When // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/proprietary/{eid}/{date}", eli, eid, "1990-01-01")
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content("{\"artDerNorm\": \"SN\"}"))
-          .andExpect(status().isNotFound());
+        .perform(
+          put("/api/v1/norms/{eli}/proprietary/{eid}/{date}", eli, eid, "1990-01-01")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"artDerNorm\": \"SN\"}")
+        )
+        .andExpect(status().isNotFound());
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ReferenceControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ReferenceControllerTest.java
@@ -24,9 +24,11 @@ import org.springframework.test.web.servlet.MockMvc;
 @Import(SecurityConfig.class)
 class ReferenceControllerTest {
 
-  @Autowired private MockMvc mockMvc;
+  @Autowired
+  private MockMvc mockMvc;
 
-  @MockBean private ReferenceRecognitionUseCase referenceRecognitionUseCase;
+  @MockBean
+  private ReferenceRecognitionUseCase referenceRecognitionUseCase;
 
   @Test
   void itReturnsXml() throws Exception {
@@ -38,9 +40,9 @@ class ReferenceControllerTest {
 
     // When // Then
     mockMvc
-        .perform(post("/api/v1/references/{eli}", eli).accept(MediaType.APPLICATION_XML))
-        .andExpect(status().isOk())
-        .andExpect(content().string(xml));
+      .perform(post("/api/v1/references/{eli}", eli).accept(MediaType.APPLICATION_XML))
+      .andExpect(status().isOk())
+      .andExpect(content().string(xml));
   }
 
   @Test
@@ -49,11 +51,11 @@ class ReferenceControllerTest {
     final String eli = "eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1";
     // When
     when(referenceRecognitionUseCase.findAndCreateReferences(any()))
-        .thenThrow(new NormNotFoundException("Norm not found"));
+      .thenThrow(new NormNotFoundException("Norm not found"));
 
     // When // Then
     mockMvc
-        .perform(post("/api/v1/references/{eli}", eli).accept(MediaType.APPLICATION_XML))
-        .andExpect(status().isNotFound());
+      .perform(post("/api/v1/references/{eli}", eli).accept(MediaType.APPLICATION_XML))
+      .andExpect(status().isNotFound());
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/RenderingControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/RenderingControllerTest.java
@@ -28,377 +28,419 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(RenderingController.class)
 @Import(SecurityConfig.class)
 class RenderingControllerTest {
-  @Autowired private MockMvc mockMvc;
-  @MockBean private TransformLegalDocMlToHtmlUseCase transformLegalDocMlToHtmlUseCase;
-  @MockBean private ApplyPassiveModificationsUseCase applyPassiveModificationsUseCase;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private TransformLegalDocMlToHtmlUseCase transformLegalDocMlToHtmlUseCase;
+
+  @MockBean
+  private ApplyPassiveModificationsUseCase applyPassiveModificationsUseCase;
 
   @Nested
   class getHtmlPreview {
+
     @Test
     void getHtmlPreviewWithShowMetadataTrue() throws Exception {
       when(applyPassiveModificationsUseCase.applyPassiveModifications(any()))
-          .thenReturn(
-              Norm.builder()
-                  .document(XmlMapper.toDocument("<law>applied-passive-modification</law>"))
-                  .build());
+        .thenReturn(
+          Norm
+            .builder()
+            .document(XmlMapper.toDocument("<law>applied-passive-modification</law>"))
+            .build()
+        );
       when(transformLegalDocMlToHtmlUseCase.transformLegalDocMlToHtml(any()))
-          .thenReturn("<html></html>");
+        .thenReturn("<html></html>");
 
       mockMvc
-          .perform(
-              post("/api/v1/renderings")
-                  .queryParam("showMetadata", "true")
-                  .accept(MediaType.TEXT_HTML)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      """
+        .perform(
+          post("/api/v1/renderings")
+            .queryParam("showMetadata", "true")
+            .accept(MediaType.TEXT_HTML)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              """
 
-                                              {
-                          "norm": "<law>original-law</law>"
-                        }
-                        """))
-          .andExpect(status().isOk())
-          .andExpect(content().string("<html></html>"));
+                                    {
+                "norm": "<law>original-law</law>"
+              }
+              """
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(content().string("<html></html>"));
 
       verify(applyPassiveModificationsUseCase, times(1))
-          .applyPassiveModifications(
-              argThat(
-                  query ->
-                      query
-                          .norm()
-                          .getDocument()
-                          .getFirstChild()
-                          .getTextContent()
-                          .equals("original-law")));
+        .applyPassiveModifications(
+          argThat(query ->
+            query.norm().getDocument().getFirstChild().getTextContent().equals("original-law")
+          )
+        );
       verify(transformLegalDocMlToHtmlUseCase, times(1))
-          .transformLegalDocMlToHtml(
-              new TransformLegalDocMlToHtmlUseCase.Query(
-                  "<?xml version=\"1.0\" encoding=\"UTF-8\"?><law>applied-passive-modification</law>",
-                  true,
-                  false));
+        .transformLegalDocMlToHtml(
+          new TransformLegalDocMlToHtmlUseCase.Query(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><law>applied-passive-modification</law>",
+            true,
+            false
+          )
+        );
     }
 
     @Test
     void getHtmlPreviewWithShowMetadataFalse() throws Exception {
       when(applyPassiveModificationsUseCase.applyPassiveModifications(any()))
-          .thenReturn(
-              Norm.builder()
-                  .document(XmlMapper.toDocument("<law>applied-passive-modification</law>"))
-                  .build());
+        .thenReturn(
+          Norm
+            .builder()
+            .document(XmlMapper.toDocument("<law>applied-passive-modification</law>"))
+            .build()
+        );
       when(transformLegalDocMlToHtmlUseCase.transformLegalDocMlToHtml(any()))
-          .thenReturn("<html></html>");
+        .thenReturn("<html></html>");
 
       mockMvc
-          .perform(
-              post("/api/v1/renderings")
-                  .queryParam("showMetadata", "false")
-                  .accept(MediaType.TEXT_HTML)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      """
-                          {
-                            "norm": "<law>original-law</law>"
-                          }
-                          """))
-          .andExpect(status().isOk())
-          .andExpect(content().string("<html></html>"));
+        .perform(
+          post("/api/v1/renderings")
+            .queryParam("showMetadata", "false")
+            .accept(MediaType.TEXT_HTML)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              """
+              {
+                "norm": "<law>original-law</law>"
+              }
+              """
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(content().string("<html></html>"));
 
       verify(applyPassiveModificationsUseCase, times(1))
-          .applyPassiveModifications(
-              argThat(
-                  query ->
-                      query
-                          .norm()
-                          .getDocument()
-                          .getFirstChild()
-                          .getTextContent()
-                          .equals("original-law")));
+        .applyPassiveModifications(
+          argThat(query ->
+            query.norm().getDocument().getFirstChild().getTextContent().equals("original-law")
+          )
+        );
       verify(transformLegalDocMlToHtmlUseCase, times(1))
-          .transformLegalDocMlToHtml(
-              new TransformLegalDocMlToHtmlUseCase.Query(
-                  "<?xml version=\"1.0\" encoding=\"UTF-8\"?><law>applied-passive-modification</law>",
-                  false,
-                  false));
+        .transformLegalDocMlToHtml(
+          new TransformLegalDocMlToHtmlUseCase.Query(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><law>applied-passive-modification</law>",
+            false,
+            false
+          )
+        );
     }
 
     @Test
     void getHtmlPreviewForDate() throws Exception {
       when(applyPassiveModificationsUseCase.applyPassiveModifications(any()))
-          .thenReturn(
-              Norm.builder()
-                  .document(XmlMapper.toDocument("<law>applied-passive-modification</law>"))
-                  .build());
+        .thenReturn(
+          Norm
+            .builder()
+            .document(XmlMapper.toDocument("<law>applied-passive-modification</law>"))
+            .build()
+        );
       when(transformLegalDocMlToHtmlUseCase.transformLegalDocMlToHtml(any()))
-          .thenReturn("<html></html>");
+        .thenReturn("<html></html>");
 
       mockMvc
-          .perform(
-              post("/api/v1/renderings")
-                  .queryParam("showMetadata", "true")
-                  .queryParam("atIsoDate", "2024-01-01T00:00:00.0Z")
-                  .accept(MediaType.TEXT_HTML)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      """
-                          {
-                            "norm": "<law>original-law</law>"
-                          }
-                          """))
-          .andExpect(status().isOk())
-          .andExpect(content().string("<html></html>"));
+        .perform(
+          post("/api/v1/renderings")
+            .queryParam("showMetadata", "true")
+            .queryParam("atIsoDate", "2024-01-01T00:00:00.0Z")
+            .accept(MediaType.TEXT_HTML)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              """
+              {
+                "norm": "<law>original-law</law>"
+              }
+              """
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(content().string("<html></html>"));
 
       verify(transformLegalDocMlToHtmlUseCase, times(1))
-          .transformLegalDocMlToHtml(
-              new TransformLegalDocMlToHtmlUseCase.Query(
-                  "<?xml version=\"1.0\" encoding=\"UTF-8\"?><law>applied-passive-modification</law>",
-                  true,
-                  false));
+        .transformLegalDocMlToHtml(
+          new TransformLegalDocMlToHtmlUseCase.Query(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><law>applied-passive-modification</law>",
+            true,
+            false
+          )
+        );
       verify(applyPassiveModificationsUseCase, times(1))
-          .applyPassiveModifications(
-              AdditionalMatchers.and(
-                  argThat(query -> query.date().equals(Instant.parse("2024-01-01T00:00:00.0Z"))),
-                  AdditionalMatchers.and(
-                      argThat(query -> query.customNorms().isEmpty()),
-                      argThat(
-                          query ->
-                              query
-                                  .norm()
-                                  .getDocument()
-                                  .getFirstChild()
-                                  .getTextContent()
-                                  .equals("original-law")))));
+        .applyPassiveModifications(
+          AdditionalMatchers.and(
+            argThat(query -> query.date().equals(Instant.parse("2024-01-01T00:00:00.0Z"))),
+            AdditionalMatchers.and(
+              argThat(query -> query.customNorms().isEmpty()),
+              argThat(query ->
+                query.norm().getDocument().getFirstChild().getTextContent().equals("original-law")
+              )
+            )
+          )
+        );
     }
 
     @Test
     void getHtmlPreviewForCurrentDate() throws Exception {
       when(applyPassiveModificationsUseCase.applyPassiveModifications(any()))
-          .thenReturn(
-              Norm.builder()
-                  .document(XmlMapper.toDocument("<law>applied-passive-modification</law>"))
-                  .build());
+        .thenReturn(
+          Norm
+            .builder()
+            .document(XmlMapper.toDocument("<law>applied-passive-modification</law>"))
+            .build()
+        );
       when(transformLegalDocMlToHtmlUseCase.transformLegalDocMlToHtml(any()))
-          .thenReturn("<html></html>");
+        .thenReturn("<html></html>");
 
       Instant instantBefore = Instant.now();
 
       mockMvc
-          .perform(
-              post("/api/v1/renderings")
-                  .accept(MediaType.TEXT_HTML)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      """
-                          {
-                            "norm": "<law>original-law</law>"
-                          }
-                          """))
-          .andExpect(status().isOk())
-          .andExpect(content().string("<html></html>"));
+        .perform(
+          post("/api/v1/renderings")
+            .accept(MediaType.TEXT_HTML)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              """
+              {
+                "norm": "<law>original-law</law>"
+              }
+              """
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(content().string("<html></html>"));
 
       verify(applyPassiveModificationsUseCase, times(1))
-          .applyPassiveModifications(
-              argThat(
-                  query ->
-                      query.date().isAfter(instantBefore) && query.date().isBefore(Instant.now())));
+        .applyPassiveModifications(
+          argThat(query ->
+            query.date().isAfter(instantBefore) && query.date().isBefore(Instant.now())
+          )
+        );
     }
 
     @Test
     void getHtmlPreviewForDateWithCustomNorms() throws Exception {
       when(applyPassiveModificationsUseCase.applyPassiveModifications(any()))
-          .thenReturn(
-              Norm.builder()
-                  .document(XmlMapper.toDocument("<law>applied-passive-modification</law>"))
-                  .build());
+        .thenReturn(
+          Norm
+            .builder()
+            .document(XmlMapper.toDocument("<law>applied-passive-modification</law>"))
+            .build()
+        );
       when(transformLegalDocMlToHtmlUseCase.transformLegalDocMlToHtml(any()))
-          .thenReturn("<html></html>");
+        .thenReturn("<html></html>");
 
       mockMvc
-          .perform(
-              post("/api/v1/renderings")
-                  .queryParam("showMetadata", "false")
-                  .queryParam("atIsoDate", "2024-01-01T00:00:00.0Z")
-                  .accept(MediaType.TEXT_HTML)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      """
-                          {
-                            "norm": "<law>original-law</law>",
-                            "customNorms": ["<law>amending-law</law>"]
-                          }
-                          """))
-          .andExpect(status().isOk())
-          .andExpect(content().string("<html></html>"));
+        .perform(
+          post("/api/v1/renderings")
+            .queryParam("showMetadata", "false")
+            .queryParam("atIsoDate", "2024-01-01T00:00:00.0Z")
+            .accept(MediaType.TEXT_HTML)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              """
+              {
+                "norm": "<law>original-law</law>",
+                "customNorms": ["<law>amending-law</law>"]
+              }
+              """
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(content().string("<html></html>"));
 
       verify(applyPassiveModificationsUseCase, times(1))
-          .applyPassiveModifications(
-              argThat(
-                  query ->
-                      query
-                          .customNorms()
-                          .iterator()
-                          .next()
-                          .getDocument()
-                          .getFirstChild()
-                          .getTextContent()
-                          .equals("amending-law")));
+        .applyPassiveModifications(
+          argThat(query ->
+            query
+              .customNorms()
+              .iterator()
+              .next()
+              .getDocument()
+              .getFirstChild()
+              .getTextContent()
+              .equals("amending-law")
+          )
+        );
     }
 
     @Test
     void getHtmlPreviewWithSnippetTrue() throws Exception {
-
       when(transformLegalDocMlToHtmlUseCase.transformLegalDocMlToHtml(any()))
-          .thenReturn("<html></html>");
+        .thenReturn("<html></html>");
       mockMvc
-          .perform(
-              post("/api/v1/renderings")
-                  .queryParam("snippet", "true")
-                  .accept(MediaType.TEXT_HTML)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      """
-                                       {
-                                          "norm": "<law>original-law</law>"
-                                        }
-                                        """))
-          .andExpect(status().isOk())
-          .andExpect(content().string("<html></html>"));
+        .perform(
+          post("/api/v1/renderings")
+            .queryParam("snippet", "true")
+            .accept(MediaType.TEXT_HTML)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              """
+              {
+                 "norm": "<law>original-law</law>"
+               }
+               """
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(content().string("<html></html>"));
 
       verify(applyPassiveModificationsUseCase, times(0)).applyPassiveModifications(any());
       verify(transformLegalDocMlToHtmlUseCase, times(1))
-          .transformLegalDocMlToHtml(
-              new TransformLegalDocMlToHtmlUseCase.Query("<law>original-law</law>", false, true));
+        .transformLegalDocMlToHtml(
+          new TransformLegalDocMlToHtmlUseCase.Query("<law>original-law</law>", false, true)
+        );
     }
   }
 
   @Nested
   class getXmlPreview {
+
     @Test
     void getXmlPreviewForCurrentDate() throws Exception {
       when(applyPassiveModificationsUseCase.applyPassiveModifications(any()))
-          .thenReturn(
-              Norm.builder()
-                  .document(XmlMapper.toDocument("<law>applied-passive-modification</law>"))
-                  .build());
+        .thenReturn(
+          Norm
+            .builder()
+            .document(XmlMapper.toDocument("<law>applied-passive-modification</law>"))
+            .build()
+        );
 
       Instant instantBefore = Instant.now();
 
       mockMvc
-          .perform(
-              post("/api/v1/renderings")
-                  .accept(MediaType.APPLICATION_XML_VALUE)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      """
-                                        {
-                                          "norm": "<law>original-law</law>"
-                                        }
-                                      """))
-          .andExpect(status().isOk())
-          .andExpect(
-              content()
-                  .string(
-                      "<?xml version=\"1.0\" encoding=\"UTF-8\"?><law>applied-passive-modification</law>"));
+        .perform(
+          post("/api/v1/renderings")
+            .accept(MediaType.APPLICATION_XML_VALUE)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              """
+                {
+                  "norm": "<law>original-law</law>"
+                }
+              """
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(
+          content()
+            .string(
+              "<?xml version=\"1.0\" encoding=\"UTF-8\"?><law>applied-passive-modification</law>"
+            )
+        );
 
       verify(applyPassiveModificationsUseCase, times(1))
-          .applyPassiveModifications(
-              AdditionalMatchers.and(
-                  argThat(
-                      query ->
-                          query.date().isAfter(instantBefore)
-                              && query.date().isBefore(Instant.now())),
-                  AdditionalMatchers.and(
-                      argThat(query -> query.customNorms().isEmpty()),
-                      argThat(
-                          query ->
-                              query
-                                  .norm()
-                                  .getDocument()
-                                  .getFirstChild()
-                                  .getTextContent()
-                                  .equals("original-law")))));
+        .applyPassiveModifications(
+          AdditionalMatchers.and(
+            argThat(query ->
+              query.date().isAfter(instantBefore) && query.date().isBefore(Instant.now())
+            ),
+            AdditionalMatchers.and(
+              argThat(query -> query.customNorms().isEmpty()),
+              argThat(query ->
+                query.norm().getDocument().getFirstChild().getTextContent().equals("original-law")
+              )
+            )
+          )
+        );
     }
 
     @Test
     void getXmlPreviewForDate() throws Exception {
       when(applyPassiveModificationsUseCase.applyPassiveModifications(any()))
-          .thenReturn(
-              Norm.builder()
-                  .document(XmlMapper.toDocument("<law>applied-passive-modification</law>"))
-                  .build());
+        .thenReturn(
+          Norm
+            .builder()
+            .document(XmlMapper.toDocument("<law>applied-passive-modification</law>"))
+            .build()
+        );
 
       mockMvc
-          .perform(
-              post("/api/v1/renderings")
-                  .queryParam("atIsoDate", "2024-01-01T00:00:00.0Z")
-                  .accept(MediaType.APPLICATION_XML_VALUE)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      """
-                                        {
-                                          "norm": "<law>original-law</law>"
-                                        }
-                                      """))
-          .andExpect(status().isOk())
-          .andExpect(
-              content()
-                  .string(
-                      "<?xml version=\"1.0\" encoding=\"UTF-8\"?><law>applied-passive-modification</law>"));
+        .perform(
+          post("/api/v1/renderings")
+            .queryParam("atIsoDate", "2024-01-01T00:00:00.0Z")
+            .accept(MediaType.APPLICATION_XML_VALUE)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              """
+                {
+                  "norm": "<law>original-law</law>"
+                }
+              """
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(
+          content()
+            .string(
+              "<?xml version=\"1.0\" encoding=\"UTF-8\"?><law>applied-passive-modification</law>"
+            )
+        );
 
       verify(applyPassiveModificationsUseCase, times(1))
-          .applyPassiveModifications(
-              AdditionalMatchers.and(
-                  argThat(query -> query.date().equals(Instant.parse("2024-01-01T00:00:00.0Z"))),
-                  AdditionalMatchers.and(
-                      argThat(query -> query.customNorms().isEmpty()),
-                      argThat(
-                          query ->
-                              query
-                                  .norm()
-                                  .getDocument()
-                                  .getFirstChild()
-                                  .getTextContent()
-                                  .equals("original-law")))));
+        .applyPassiveModifications(
+          AdditionalMatchers.and(
+            argThat(query -> query.date().equals(Instant.parse("2024-01-01T00:00:00.0Z"))),
+            AdditionalMatchers.and(
+              argThat(query -> query.customNorms().isEmpty()),
+              argThat(query ->
+                query.norm().getDocument().getFirstChild().getTextContent().equals("original-law")
+              )
+            )
+          )
+        );
     }
 
     @Test
     void getXmlPreviewForDateWithCustomNorms() throws Exception {
       when(applyPassiveModificationsUseCase.applyPassiveModifications(any()))
-          .thenReturn(
-              Norm.builder()
-                  .document(XmlMapper.toDocument("<law>applied-passive-modification</law>"))
-                  .build());
+        .thenReturn(
+          Norm
+            .builder()
+            .document(XmlMapper.toDocument("<law>applied-passive-modification</law>"))
+            .build()
+        );
 
       mockMvc
-          .perform(
-              post("/api/v1/renderings")
-                  .queryParam("atIsoDate", "2024-01-01T00:00:00.0Z")
-                  .accept(MediaType.APPLICATION_XML_VALUE)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      """
-                                          {
-                                            "norm": "<law>original-law</law>",
-                                            "customNorms": ["<law>amending-law</law>"]
-                                          }
-                                      """))
-          .andExpect(status().isOk())
-          .andExpect(
-              content()
-                  .string(
-                      "<?xml version=\"1.0\" encoding=\"UTF-8\"?><law>applied-passive-modification</law>"));
+        .perform(
+          post("/api/v1/renderings")
+            .queryParam("atIsoDate", "2024-01-01T00:00:00.0Z")
+            .accept(MediaType.APPLICATION_XML_VALUE)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              """
+                  {
+                    "norm": "<law>original-law</law>",
+                    "customNorms": ["<law>amending-law</law>"]
+                  }
+              """
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(
+          content()
+            .string(
+              "<?xml version=\"1.0\" encoding=\"UTF-8\"?><law>applied-passive-modification</law>"
+            )
+        );
 
       verify(applyPassiveModificationsUseCase, times(1))
-          .applyPassiveModifications(
-              argThat(
-                  query ->
-                      query
-                          .customNorms()
-                          .iterator()
-                          .next()
-                          .getDocument()
-                          .getFirstChild()
-                          .getTextContent()
-                          .equals("amending-law")));
+        .applyPassiveModifications(
+          argThat(query ->
+            query
+              .customNorms()
+              .iterator()
+              .next()
+              .getDocument()
+              .getFirstChild()
+              .getTextContent()
+              .equals("amending-law")
+          )
+        );
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/TimeBoundaryControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/TimeBoundaryControllerTest.java
@@ -44,58 +44,63 @@ import org.springframework.web.method.annotation.HandlerMethodValidationExceptio
 @Import(SecurityConfig.class)
 class TimeBoundaryControllerTest {
 
-  @Autowired private MockMvc mockMvc;
+  @Autowired
+  private MockMvc mockMvc;
 
-  @MockBean private LoadTimeBoundariesUseCase loadTimeBoundariesUseCase;
-  @MockBean private LoadTimeBoundariesAmendedByUseCase loadTimeBoundariesAmendedByUseCase;
-  @MockBean private UpdateTimeBoundariesUseCase updateTimeBoundariesUseCase;
+  @MockBean
+  private LoadTimeBoundariesUseCase loadTimeBoundariesUseCase;
+
+  @MockBean
+  private LoadTimeBoundariesAmendedByUseCase loadTimeBoundariesAmendedByUseCase;
+
+  @MockBean
+  private UpdateTimeBoundariesUseCase updateTimeBoundariesUseCase;
 
   @Nested
   class getTimeBoundaries {
+
     @Test
     void getTimeBoundariesReturnsCorrectData() throws Exception {
       // Given
       final String eli = "eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1";
       final String eventRef =
-          """
-              <akn:eventRef xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2017-03-16" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                      """
-              .strip();
+        """
+        <akn:eventRef xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2017-03-16" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                """.strip();
 
       final String timeInterval =
-          """
-              <akn:timeInterval xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                      """
-              .strip();
+        """
+        <akn:timeInterval xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                """.strip();
 
       final String temporalGroup =
-          """
-              <akn:temporalGroup xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                       </akn:temporalGroup>
-                      """;
+        """
+        <akn:temporalGroup xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                                 </akn:temporalGroup>
+                """;
 
-      List<TimeBoundary> timeBoundaries =
-          List.of(
-              new TimeBoundary(
-                  new TimeInterval(XmlMapper.toNode(timeInterval)),
-                  new EventRef(XmlMapper.toNode(eventRef)),
-                  new TemporalGroup(XmlMapper.toNode(temporalGroup))));
+      List<TimeBoundary> timeBoundaries = List.of(
+        new TimeBoundary(
+          new TimeInterval(XmlMapper.toNode(timeInterval)),
+          new EventRef(XmlMapper.toNode(eventRef)),
+          new TemporalGroup(XmlMapper.toNode(temporalGroup))
+        )
+      );
 
       when(loadTimeBoundariesUseCase.loadTimeBoundariesOfNorm(any())).thenReturn(timeBoundaries);
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/{eli}/timeBoundaries", eli).accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$", hasSize(1)))
-          .andExpect(jsonPath("$[0].date", is("2017-03-16")))
-          .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")))
-          .andExpect(jsonPath("$[0].temporalGroupEid", is("meta-1_geltzeiten-1_geltungszeitgr-1")));
+        .perform(get("/api/v1/norms/{eli}/timeBoundaries", eli).accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0].date", is("2017-03-16")))
+        .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")))
+        .andExpect(jsonPath("$[0].temporalGroupEid", is("meta-1_geltzeiten-1_geltungszeitgr-1")));
 
       verify(loadTimeBoundariesUseCase, times(1))
-          .loadTimeBoundariesOfNorm(any(LoadTimeBoundariesUseCase.Query.class));
+        .loadTimeBoundariesOfNorm(any(LoadTimeBoundariesUseCase.Query.class));
     }
 
     @Test
@@ -105,118 +110,118 @@ class TimeBoundaryControllerTest {
       final String amendedBy = "eli/bund/bgbl-1/2023/412/2024-01-19/1/deu/regelungstext-1";
 
       final String eventRef =
-          """
-              <akn:eventRef xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2017-03-16" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                          """
-              .strip();
+        """
+        <akn:eventRef xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2017-03-16" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                    """.strip();
 
       final String timeInterval =
-          """
-              <akn:timeInterval xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                          """
-              .strip();
+        """
+        <akn:timeInterval xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                    """.strip();
 
       final String temporalGroup =
-          """
-              <akn:temporalGroup xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                              <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                           </akn:temporalGroup>
-                          """
-              .strip();
+        """
+        <akn:temporalGroup xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                                     </akn:temporalGroup>
+                    """.strip();
 
-      List<TimeBoundary> timeBoundaries =
-          List.of(
-              new TimeBoundary(
-                  new TimeInterval(XmlMapper.toNode(timeInterval)),
-                  new EventRef(XmlMapper.toNode(eventRef)),
-                  new TemporalGroup(XmlMapper.toNode(temporalGroup))));
+      List<TimeBoundary> timeBoundaries = List.of(
+        new TimeBoundary(
+          new TimeInterval(XmlMapper.toNode(timeInterval)),
+          new EventRef(XmlMapper.toNode(eventRef)),
+          new TemporalGroup(XmlMapper.toNode(temporalGroup))
+        )
+      );
 
       when(loadTimeBoundariesAmendedByUseCase.loadTimeBoundariesAmendedBy(any()))
-          .thenReturn(timeBoundaries);
+        .thenReturn(timeBoundaries);
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/{eli}/timeBoundaries?amendedBy={amendedBy}", eli, amendedBy)
-                  .accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$", hasSize(1)))
-          .andExpect(jsonPath("$[0].date", is("2017-03-16")))
-          .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")))
-          .andExpect(jsonPath("$[0].temporalGroupEid", is("meta-1_geltzeiten-1_geltungszeitgr-1")));
+        .perform(
+          get("/api/v1/norms/{eli}/timeBoundaries?amendedBy={amendedBy}", eli, amendedBy)
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0].date", is("2017-03-16")))
+        .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")))
+        .andExpect(jsonPath("$[0].temporalGroupEid", is("meta-1_geltzeiten-1_geltungszeitgr-1")));
 
       verify(loadTimeBoundariesAmendedByUseCase, times(1))
-          .loadTimeBoundariesAmendedBy(any(LoadTimeBoundariesAmendedByUseCase.Query.class));
+        .loadTimeBoundariesAmendedBy(any(LoadTimeBoundariesAmendedByUseCase.Query.class));
 
       verify(loadTimeBoundariesAmendedByUseCase, times(1))
-          .loadTimeBoundariesAmendedBy(
-              argThat(
-                  query ->
-                      Objects.equals(query.eli(), eli)
-                          && Objects.equals(query.amendingLawEli(), amendedBy)));
+        .loadTimeBoundariesAmendedBy(
+          argThat(query ->
+            Objects.equals(query.eli(), eli) && Objects.equals(query.amendingLawEli(), amendedBy)
+          )
+        );
     }
   }
 
   @Nested
   class updateTimeBoundaries {
+
     @Test
     void updateTimeBoundariesReturnsSuccess() throws Exception {
       // Given
       final String eli = "eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1";
       final String eventRef1 =
-          """
-              <akn:eventRef xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_lebzykl-1_ereignis-2"
-                                  GUID="7174df87-6418-4d47-ac4e-5fb87c2caa50"
-                                  date="1964-09-21"
-                                  source="attributsemantik-noch-undefiniert"
-                                  type="generation"
-                                  refersTo="inkrafttreten"/>
-                      """
-              .strip();
+        """
+        <akn:eventRef xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_lebzykl-1_ereignis-2"
+                            GUID="7174df87-6418-4d47-ac4e-5fb87c2caa50"
+                            date="1964-09-21"
+                            source="attributsemantik-noch-undefiniert"
+                            type="generation"
+                            refersTo="inkrafttreten"/>
+                """.strip();
 
       final String timeInterval1 =
-          """
-              <akn:timeInterval xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1"
-                                   GUID="6fc42c43-6598-4c95-ac57-da132b047ec1"
-                                   refersTo="geltungszeit"
-                                   start="#meta-1_lebzykl-1_ereignis-2"/>
-                      """
-              .strip();
+        """
+        <akn:timeInterval xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1"
+                             GUID="6fc42c43-6598-4c95-ac57-da132b047ec1"
+                             refersTo="geltungszeit"
+                             start="#meta-1_lebzykl-1_ereignis-2"/>
+                """.strip();
 
       final String temporalGroup =
-          """
-              <akn:temporalGroup xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                       </akn:temporalGroup>
-                      """
-              .strip();
+        """
+        <akn:temporalGroup xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                                 </akn:temporalGroup>
+                """.strip();
 
-      List<TimeBoundary> timeBoundaries =
-          List.of(
-              new TimeBoundary(
-                  new TimeInterval(XmlMapper.toNode(timeInterval1)),
-                  new EventRef(XmlMapper.toNode(eventRef1)),
-                  new TemporalGroup(XmlMapper.toNode(temporalGroup))));
+      List<TimeBoundary> timeBoundaries = List.of(
+        new TimeBoundary(
+          new TimeInterval(XmlMapper.toNode(timeInterval1)),
+          new EventRef(XmlMapper.toNode(eventRef1)),
+          new TemporalGroup(XmlMapper.toNode(temporalGroup))
+        )
+      );
 
       when(updateTimeBoundariesUseCase.updateTimeBoundariesOfNorm(any()))
-          .thenReturn(timeBoundaries);
+        .thenReturn(timeBoundaries);
 
       // When // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/timeBoundaries", eli)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "[{\"date\": \"1964-09-21\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-2\"}]"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$", hasSize(1)))
-          .andExpect(jsonPath("$[0].date", is("1964-09-21")))
-          .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")))
-          .andExpect(jsonPath("$[0].temporalGroupEid", is("meta-1_geltzeiten-1_geltungszeitgr-1")));
+        .perform(
+          put("/api/v1/norms/{eli}/timeBoundaries", eli)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "[{\"date\": \"1964-09-21\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-2\"}]"
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0].date", is("1964-09-21")))
+        .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")))
+        .andExpect(jsonPath("$[0].temporalGroupEid", is("meta-1_geltzeiten-1_geltungszeitgr-1")));
 
       verify(updateTimeBoundariesUseCase, times(1))
-          .updateTimeBoundariesOfNorm(any(UpdateTimeBoundariesUseCase.Query.class));
+        .updateTimeBoundariesOfNorm(any(UpdateTimeBoundariesUseCase.Query.class));
     }
 
     @Test
@@ -234,30 +239,34 @@ class TimeBoundaryControllerTest {
 
       // When // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/timeBoundaries", eli)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "["
-                          + "{\"date\": \"2023-12-30\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-2\"},"
-                          + "{\"date\": \"2024-01-01\", \"eventRefEid\": null},"
-                          + "{\"date\": \"2024-01-01\", \"eventRefEid\": null}"
-                          + "]"))
-          .andExpect(status().isBadRequest())
-          .andExpect(
-              result ->
-                  Assertions.assertInstanceOf(
-                      HandlerMethodValidationException.class, result.getResolvedException()))
-          .andExpect(
-              result ->
-                  assertEquals(
-                      "400 BAD_REQUEST \"Validation failure\"",
-                      Objects.requireNonNull(result.getResolvedException()).getMessage()))
-          .andExpect(
-              result ->
-                  assertThat(memoryAppender.contains("All dates must be unique.", Level.ERROR))
-                      .isTrue());
+        .perform(
+          put("/api/v1/norms/{eli}/timeBoundaries", eli)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "[" +
+              "{\"date\": \"2023-12-30\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-2\"}," +
+              "{\"date\": \"2024-01-01\", \"eventRefEid\": null}," +
+              "{\"date\": \"2024-01-01\", \"eventRefEid\": null}" +
+              "]"
+            )
+        )
+        .andExpect(status().isBadRequest())
+        .andExpect(result ->
+          Assertions.assertInstanceOf(
+            HandlerMethodValidationException.class,
+            result.getResolvedException()
+          )
+        )
+        .andExpect(result ->
+          assertEquals(
+            "400 BAD_REQUEST \"Validation failure\"",
+            Objects.requireNonNull(result.getResolvedException()).getMessage()
+          )
+        )
+        .andExpect(result ->
+          assertThat(memoryAppender.contains("All dates must be unique.", Level.ERROR)).isTrue()
+        );
     }
 
     @Test
@@ -267,12 +276,13 @@ class TimeBoundaryControllerTest {
 
       // When // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/timeBoundaries", eli)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content("[{\"date\": \"THISISNODATE\", \"eventRefEid\": null}]"))
-          .andExpect(status().isBadRequest());
+        .perform(
+          put("/api/v1/norms/{eli}/timeBoundaries", eli)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("[{\"date\": \"THISISNODATE\", \"eventRefEid\": null}]")
+        )
+        .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -290,25 +300,28 @@ class TimeBoundaryControllerTest {
 
       // When // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/timeBoundaries", eli)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content("[]"))
-          .andExpect(status().isBadRequest())
-          .andExpect(
-              result ->
-                  Assertions.assertInstanceOf(
-                      HandlerMethodValidationException.class, result.getResolvedException()))
-          .andExpect(
-              result ->
-                  assertEquals(
-                      "400 BAD_REQUEST \"Validation failure\"",
-                      Objects.requireNonNull(result.getResolvedException()).getMessage()))
-          .andExpect(
-              result ->
-                  assertThat(memoryAppender.contains("Change list must not be empty", Level.ERROR))
-                      .isTrue());
+        .perform(
+          put("/api/v1/norms/{eli}/timeBoundaries", eli)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("[]")
+        )
+        .andExpect(status().isBadRequest())
+        .andExpect(result ->
+          Assertions.assertInstanceOf(
+            HandlerMethodValidationException.class,
+            result.getResolvedException()
+          )
+        )
+        .andExpect(result ->
+          assertEquals(
+            "400 BAD_REQUEST \"Validation failure\"",
+            Objects.requireNonNull(result.getResolvedException()).getMessage()
+          )
+        )
+        .andExpect(result ->
+          assertThat(memoryAppender.contains("Change list must not be empty", Level.ERROR)).isTrue()
+        );
     }
 
     @Test
@@ -326,25 +339,28 @@ class TimeBoundaryControllerTest {
 
       // When // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/timeBoundaries", eli)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content("[{\"date\": null, \"eventRefEid\": null}]"))
-          .andExpect(status().isBadRequest())
-          .andExpect(
-              result ->
-                  Assertions.assertInstanceOf(
-                      HandlerMethodValidationException.class, result.getResolvedException()))
-          .andExpect(
-              result ->
-                  assertEquals(
-                      "400 BAD_REQUEST \"Validation failure\"",
-                      Objects.requireNonNull(result.getResolvedException()).getMessage()))
-          .andExpect(
-              result ->
-                  assertThat(memoryAppender.contains("Date must not be null", Level.ERROR))
-                      .isTrue());
+        .perform(
+          put("/api/v1/norms/{eli}/timeBoundaries", eli)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("[{\"date\": null, \"eventRefEid\": null}]")
+        )
+        .andExpect(status().isBadRequest())
+        .andExpect(result ->
+          Assertions.assertInstanceOf(
+            HandlerMethodValidationException.class,
+            result.getResolvedException()
+          )
+        )
+        .andExpect(result ->
+          assertEquals(
+            "400 BAD_REQUEST \"Validation failure\"",
+            Objects.requireNonNull(result.getResolvedException()).getMessage()
+          )
+        )
+        .andExpect(result ->
+          assertThat(memoryAppender.contains("Date must not be null", Level.ERROR)).isTrue()
+        );
     }
 
     @Test
@@ -354,16 +370,17 @@ class TimeBoundaryControllerTest {
 
       // When
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/timeBoundaries", eli)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content("[{\"date\": null, \"eventRefEid\": null}]"))
-          // Then
-          .andExpect(
-              result ->
-                  assertThat(result.getResponse().getContentAsString())
-                      .contains("400 BAD_REQUEST 'Validation failure'"));
+        .perform(
+          put("/api/v1/norms/{eli}/timeBoundaries", eli)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("[{\"date\": null, \"eventRefEid\": null}]")
+        )
+        // Then
+        .andExpect(result ->
+          assertThat(result.getResponse().getContentAsString())
+            .contains("400 BAD_REQUEST 'Validation failure'")
+        );
     }
 
     @Test
@@ -375,16 +392,18 @@ class TimeBoundaryControllerTest {
 
       // When // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/timeBoundaries", eli)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "[{\"date\": \"1964-09-21\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-2\"}]"))
-          .andExpect(status().isNotFound());
+        .perform(
+          put("/api/v1/norms/{eli}/timeBoundaries", eli)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "[{\"date\": \"1964-09-21\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-2\"}]"
+            )
+        )
+        .andExpect(status().isNotFound());
 
       verify(updateTimeBoundariesUseCase, times(1))
-          .updateTimeBoundariesOfNorm(any(UpdateTimeBoundariesUseCase.Query.class));
+        .updateTimeBoundariesOfNorm(any(UpdateTimeBoundariesUseCase.Query.class));
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ArticleResponseMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ArticleResponseMapperTest.java
@@ -13,81 +13,87 @@ class ArticleResponseMapperTest {
   @Test
   void itMapsNormArticleCorrectly() {
     // Given
-    var article1 =
-        Article.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                            <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                               <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                            <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                            <!-- Absatz (1) -->
-                            <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                               <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                                  <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                               </akn:num>
-                               <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                  <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                     <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                           href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                  </akn:intro>
-                                  <!-- Nummer 1 wurde entfernt -->
-                                  <!-- Nummer 2 -->
-                                  <akn:point eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2" GUID="b5fa1383-f26a-4904-a638-f48711fbcf2d">
-                                     <akn:num eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_bezeichnung-1" GUID="6f0f92b3-1a51-440c-9137-b44ab9d990ac">
-                                        <akn:marker eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_bezeichnung-1_zaehlbez-1" GUID="5d7d54f0-8a4e-4d8f-b5d0-93d0ca393e82" name="2" />2.</akn:num>
-                                     <akn:content eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1" GUID="6cb14ab5-3a7f-45f4-9e85-00ac2fb0fe5e">
-                                        <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1" GUID="db3fbe0f-b758-4cc4-b528-a723cacad94a">
-                                           <akn:mod eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1" GUID="148c2f06-6e33-4af8-9f4a-3da67c888510" refersTo="aenderungsbefehl-ersetzen">In <akn:ref eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1"
-                                                 GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/0-0.xml">§ 20 Absatz 1 Satz 2</akn:ref> wird die Angabe <akn:quotedText
-                                                 eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-1" GUID="694459c4-ef66-4f87-bb78-a332054a2216" startQuote="„" endQuote="“">§ 9 Abs. 1 Satz 2, Abs. 2</akn:quotedText> durch die Wörter <akn:quotedText
-                                                 eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2" GUID="dd25bdb6-4ef4-4ef5-808c-27579b6ae196" startQuote="„" endQuote="“">§ 9 Absatz 1 Satz 2, Absatz 2 oder 3</akn:quotedText> ersetzt.</akn:mod>
-                                        </akn:p>
-                                     </akn:content>
-                                  </akn:point>
-                               </akn:list>
-                            </akn:paragraph>
-                         </akn:article>
-                         """))
-            .build();
-    var nextVersionNorm =
-        Norm.builder()
-            .document(
-                XmlMapper.toDocument(
-                    """
-                          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                             <akn:act name="regelungstext">
-                                <!-- Metadaten -->
-                                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2024-01-01/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01" />
-                                      </akn:FRBRExpression>
-                                  </akn:identification>
-                                </akn:meta>
-                             </akn:act>
-                          </akn:akomaNtoso>
-                        """))
-            .build();
+    var article1 = Article
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+              <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                 <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+              <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+              <!-- Absatz (1) -->
+              <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                 <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                    <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                 </akn:num>
+                 <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                    <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                       <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                             href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                    </akn:intro>
+                    <!-- Nummer 1 wurde entfernt -->
+                    <!-- Nummer 2 -->
+                    <akn:point eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2" GUID="b5fa1383-f26a-4904-a638-f48711fbcf2d">
+                       <akn:num eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_bezeichnung-1" GUID="6f0f92b3-1a51-440c-9137-b44ab9d990ac">
+                          <akn:marker eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_bezeichnung-1_zaehlbez-1" GUID="5d7d54f0-8a4e-4d8f-b5d0-93d0ca393e82" name="2" />2.</akn:num>
+                       <akn:content eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1" GUID="6cb14ab5-3a7f-45f4-9e85-00ac2fb0fe5e">
+                          <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1" GUID="db3fbe0f-b758-4cc4-b528-a723cacad94a">
+                             <akn:mod eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1" GUID="148c2f06-6e33-4af8-9f4a-3da67c888510" refersTo="aenderungsbefehl-ersetzen">In <akn:ref eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1"
+                                   GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/0-0.xml">§ 20 Absatz 1 Satz 2</akn:ref> wird die Angabe <akn:quotedText
+                                   eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-1" GUID="694459c4-ef66-4f87-bb78-a332054a2216" startQuote="„" endQuote="“">§ 9 Abs. 1 Satz 2, Abs. 2</akn:quotedText> durch die Wörter <akn:quotedText
+                                   eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2" GUID="dd25bdb6-4ef4-4ef5-808c-27579b6ae196" startQuote="„" endQuote="“">§ 9 Absatz 1 Satz 2, Absatz 2 oder 3</akn:quotedText> ersetzt.</akn:mod>
+                          </akn:p>
+                       </akn:content>
+                    </akn:point>
+                 </akn:list>
+              </akn:paragraph>
+           </akn:article>
+           """
+        )
+      )
+      .build();
+    var nextVersionNorm = Norm
+      .builder()
+      .document(
+        XmlMapper.toDocument(
+          """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+               <akn:act name="regelungstext">
+                  <!-- Metadaten -->
+                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2024-01-01/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01" />
+                        </akn:FRBRExpression>
+                    </akn:identification>
+                  </akn:meta>
+               </akn:act>
+            </akn:akomaNtoso>
+          """
+        )
+      )
+      .build();
 
     // When
-    final ArticleResponseSchema resultArticle =
-        ArticleResponseMapper.fromNormArticle(article1, nextVersionNorm);
+    final ArticleResponseSchema resultArticle = ArticleResponseMapper.fromNormArticle(
+      article1,
+      nextVersionNorm
+    );
 
     // Then
     assertThat(resultArticle.getEid()).isEqualTo("hauptteil-1_art-1");
     assertThat(resultArticle.getEnumeration()).isEqualTo("1");
     assertThat(resultArticle.getTitle()).isEqualTo("Änderung des Vereinsgesetzes");
     assertThat(resultArticle.getAffectedDocumentEli())
-        .isEqualTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1");
+      .isEqualTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1");
     assertThat(resultArticle.getAffectedDocumentZf0Eli())
-        .isEqualTo("eli/bund/bgbl-1/1964/s593/2024-01-01/1/deu/regelungstext-1");
+      .isEqualTo("eli/bund/bgbl-1/1964/s593/2024-01-01/1/deu/regelungstext-1");
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ElementResponseMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ElementResponseMapperTest.java
@@ -8,23 +8,24 @@ import java.util.NoSuchElementException;
 import org.junit.jupiter.api.Test;
 
 class ElementResponseMapperTest {
+
   @Test
   void convertsAnArticleNode() {
     // Given
-    var node =
-        XmlMapper.toNode(
-            """
-            <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="000" eId="hauptteil-1_para-1" refersTo="stammform">
-              <akn:num GUID="000" eId="hauptteil-1_bezeichnung-1">
-                <akn:marker GUID="000" eId="hauptteil-1_bezeichnung-1_zaehlbez-1" name="1"/>
-                § 1
-              </akn:num>
-              <akn:heading GUID="000" eId="hauptteil-1_überschrift-1">
-                Überschrift des Artikels
-              </akn:heading>
-              <akn:paragraph GUID="000" eId="hauptteil-1_abs-1"></akn:paragraph>
-            </akn:article>
-            """);
+    var node = XmlMapper.toNode(
+      """
+      <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="000" eId="hauptteil-1_para-1" refersTo="stammform">
+        <akn:num GUID="000" eId="hauptteil-1_bezeichnung-1">
+          <akn:marker GUID="000" eId="hauptteil-1_bezeichnung-1_zaehlbez-1" name="1"/>
+          § 1
+        </akn:num>
+        <akn:heading GUID="000" eId="hauptteil-1_überschrift-1">
+          Überschrift des Artikels
+        </akn:heading>
+        <akn:paragraph GUID="000" eId="hauptteil-1_abs-1"></akn:paragraph>
+      </akn:article>
+      """
+    );
 
     // When
     var output = ElementResponseMapper.fromElementNode(node);
@@ -38,16 +39,16 @@ class ElementResponseMapperTest {
   @Test
   void convertsAnArticleWithMissingMarkerToNode() {
     // Given
-    var node =
-        XmlMapper.toNode(
-            """
-            <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="000" eId="hauptteil-1_para-1" refersTo="stammform">
-              <akn:heading GUID="000" eId="hauptteil-1_überschrift-1">
-                Überschrift des Artikels
-              </akn:heading>
-              <akn:paragraph GUID="000" eId="hauptteil-1_abs-1"></akn:paragraph>
-            </akn:article>
-            """);
+    var node = XmlMapper.toNode(
+      """
+      <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="000" eId="hauptteil-1_para-1" refersTo="stammform">
+        <akn:heading GUID="000" eId="hauptteil-1_überschrift-1">
+          Überschrift des Artikels
+        </akn:heading>
+        <akn:paragraph GUID="000" eId="hauptteil-1_abs-1"></akn:paragraph>
+      </akn:article>
+      """
+    );
 
     // When
     var output = ElementResponseMapper.fromElementNode(node);
@@ -61,17 +62,17 @@ class ElementResponseMapperTest {
   @Test
   void convertsAnArticleWithMissingHeadingToNode() {
     // Given
-    var node =
-        XmlMapper.toNode(
-            """
-            <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="000" eId="hauptteil-1_para-1" refersTo="stammform">
-              <akn:num GUID="000" eId="hauptteil-1_bezeichnung-1">
-                <akn:marker GUID="000" eId="hauptteil-1_bezeichnung-1_zaehlbez-1" name="1"/>
-                § 1
-              </akn:num>
-              <akn:paragraph GUID="000" eId="hauptteil-1_abs-1"></akn:paragraph>
-            </akn:article>
-            """);
+    var node = XmlMapper.toNode(
+      """
+      <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="000" eId="hauptteil-1_para-1" refersTo="stammform">
+        <akn:num GUID="000" eId="hauptteil-1_bezeichnung-1">
+          <akn:marker GUID="000" eId="hauptteil-1_bezeichnung-1_zaehlbez-1" name="1"/>
+          § 1
+        </akn:num>
+        <akn:paragraph GUID="000" eId="hauptteil-1_abs-1"></akn:paragraph>
+      </akn:article>
+      """
+    );
 
     // When
     var output = ElementResponseMapper.fromElementNode(node);
@@ -85,13 +86,13 @@ class ElementResponseMapperTest {
   @Test
   void convertsAnArticleWithoutTitleToNode() {
     // Given
-    var node =
-        XmlMapper.toNode(
-            """
-            <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="000" eId="hauptteil-1_para-1" refersTo="stammform">
-              <akn:paragraph GUID="000" eId="hauptteil-1_abs-1"></akn:paragraph>
-            </akn:article>
-            """);
+    var node = XmlMapper.toNode(
+      """
+      <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="000" eId="hauptteil-1_para-1" refersTo="stammform">
+        <akn:paragraph GUID="000" eId="hauptteil-1_abs-1"></akn:paragraph>
+      </akn:article>
+      """
+    );
 
     // When
     var output = ElementResponseMapper.fromElementNode(node);
@@ -105,27 +106,27 @@ class ElementResponseMapperTest {
   @Test
   void convertsABookToNode() {
     // Given
-    var node =
-        XmlMapper.toNode(
-            """
-            <akn:book eId="hauptteil-1_buch-1" GUID="3c36aeed-d116-47c1-b475-a5e8bdfefe63">
-              <akn:num
-                eId="hauptteil-1_buch-1_bezeichnung-1"
-                GUID="5b8320d2-2ed9-4652-aa5a-147da381f87c"
-              >
-                <akn:marker
-                  eId="hauptteil-1_buch-1_bezeichnung-1_zaehlbez-1"
-                  GUID="9b24f762-a99d-48c6-9dd7-d1cb9bbd758f"
-                  name="1"
-                />Buch 1</akn:num
-              >
-              <akn:heading
-                eId="hauptteil-1_buch-1_überschrift-1"
-                GUID="20bf09db-2a0b-4cc6-ac38-9d485062c187"
-                >Überschrift Buch</akn:heading
-              >
-            </akn:book>
-            """);
+    var node = XmlMapper.toNode(
+      """
+      <akn:book eId="hauptteil-1_buch-1" GUID="3c36aeed-d116-47c1-b475-a5e8bdfefe63">
+        <akn:num
+          eId="hauptteil-1_buch-1_bezeichnung-1"
+          GUID="5b8320d2-2ed9-4652-aa5a-147da381f87c"
+        >
+          <akn:marker
+            eId="hauptteil-1_buch-1_bezeichnung-1_zaehlbez-1"
+            GUID="9b24f762-a99d-48c6-9dd7-d1cb9bbd758f"
+            name="1"
+          />Buch 1</akn:num
+        >
+        <akn:heading
+          eId="hauptteil-1_buch-1_überschrift-1"
+          GUID="20bf09db-2a0b-4cc6-ac38-9d485062c187"
+          >Überschrift Buch</akn:heading
+        >
+      </akn:book>
+      """
+    );
 
     // When
     var output = ElementResponseMapper.fromElementNode(node);
@@ -139,30 +140,30 @@ class ElementResponseMapperTest {
   @Test
   void convertsAPartToNode() {
     // Given
-    var node =
-        XmlMapper.toNode(
-            """
-            <akn:part
-              eId="hauptteil-1_buch-1_teil-1"
-              GUID="8afdae9b-dcf4-48c8-ba38-31f24526bcf0"
-            >
-              <akn:num
-                eId="hauptteil-1_buch-1_teil-1_bezeichnung-1"
-                GUID="30151b69-5d3a-4fc6-b46a-86b0de37fb15"
-              >
-                <akn:marker
-                  eId="hauptteil-1_buch-1_teil-1_bezeichnung-1_zaehlbez-1"
-                  GUID="6c5d6dc7-f14b-4e1d-8f8b-570a13aeff9c"
-                  name="1"
-                />Teil 1</akn:num
-              >
-              <akn:heading
-                eId="hauptteil-1_buch-1_teil-1_überschrift-1"
-                GUID="344fa409-e0ba-4f53-beae-a61abf138efb"
-                >Überschrift Teil</akn:heading
-              ></akn:part
-            >
-            """);
+    var node = XmlMapper.toNode(
+      """
+      <akn:part
+        eId="hauptteil-1_buch-1_teil-1"
+        GUID="8afdae9b-dcf4-48c8-ba38-31f24526bcf0"
+      >
+        <akn:num
+          eId="hauptteil-1_buch-1_teil-1_bezeichnung-1"
+          GUID="30151b69-5d3a-4fc6-b46a-86b0de37fb15"
+        >
+          <akn:marker
+            eId="hauptteil-1_buch-1_teil-1_bezeichnung-1_zaehlbez-1"
+            GUID="6c5d6dc7-f14b-4e1d-8f8b-570a13aeff9c"
+            name="1"
+          />Teil 1</akn:num
+        >
+        <akn:heading
+          eId="hauptteil-1_buch-1_teil-1_überschrift-1"
+          GUID="344fa409-e0ba-4f53-beae-a61abf138efb"
+          >Überschrift Teil</akn:heading
+        ></akn:part
+      >
+      """
+    );
 
     // When
     var output = ElementResponseMapper.fromElementNode(node);
@@ -176,30 +177,30 @@ class ElementResponseMapperTest {
   @Test
   void convertsAChapterToNode() {
     // Given
-    var node =
-        XmlMapper.toNode(
-            """
-            <akn:chapter
-              eId="hauptteil-1_buch-1_teil-1_kapitel-1"
-              GUID="d4b23c42-acab-4220-af45-faa22820d588"
-            >
-              <akn:num
-                eId="hauptteil-1_buch-1_teil-1_kapitel-1_bezeichnung-1"
-                GUID="dcca1b77-1a1d-4c67-9cb1-b6687fae065e"
-              >
-                <akn:marker
-                  eId="hauptteil-1_buch-1_teil-1_kapitel-1_bezeichnung-1_zaehlbez-1"
-                  GUID="1543b5cf-b6a2-47a0-99a7-172299fdb9f7"
-                  name="1"
-                />Kapitel 1</akn:num
-              >
-              <akn:heading
-                eId="hauptteil-1_buch-1_teil-1_kapitel-1_überschrift-1"
-                GUID="32cd7607-c65e-44ef-bbbb-d0163a122583"
-                >Überschrift Kapitel</akn:heading
-              ></akn:chapter
-            >
-            """);
+    var node = XmlMapper.toNode(
+      """
+      <akn:chapter
+        eId="hauptteil-1_buch-1_teil-1_kapitel-1"
+        GUID="d4b23c42-acab-4220-af45-faa22820d588"
+      >
+        <akn:num
+          eId="hauptteil-1_buch-1_teil-1_kapitel-1_bezeichnung-1"
+          GUID="dcca1b77-1a1d-4c67-9cb1-b6687fae065e"
+        >
+          <akn:marker
+            eId="hauptteil-1_buch-1_teil-1_kapitel-1_bezeichnung-1_zaehlbez-1"
+            GUID="1543b5cf-b6a2-47a0-99a7-172299fdb9f7"
+            name="1"
+          />Kapitel 1</akn:num
+        >
+        <akn:heading
+          eId="hauptteil-1_buch-1_teil-1_kapitel-1_überschrift-1"
+          GUID="32cd7607-c65e-44ef-bbbb-d0163a122583"
+          >Überschrift Kapitel</akn:heading
+        ></akn:chapter
+      >
+      """
+    );
 
     // When
     var output = ElementResponseMapper.fromElementNode(node);
@@ -213,30 +214,30 @@ class ElementResponseMapperTest {
   @Test
   void convertsASectionToNode() {
     // Given
-    var node =
-        XmlMapper.toNode(
-            """
-            <akn:section
-              eId="hauptteil-1_abschnitt-1"
-              GUID="f1474e45-57fe-4ba4-983e-efef589d31f3"
-            >
-              <akn:num
-                eId="hauptteil-1_abschnitt-1_bezeichnung-1"
-                GUID="28b0d5bc-1bb2-4c2f-8766-ba8df3d05441"
-              >
-                <akn:marker
-                  eId="hauptteil-1_abschnitt-1_bezeichnung-1_zaehlbez-1"
-                  GUID="d1af8069-6f00-442c-841c-6c4183a49a84"
-                  name="1"
-                />Abschnitt 1</akn:num
-              >
-              <akn:heading
-                eId="hauptteil-1_abschnitt-1_überschrift-1"
-                GUID="d241c159-828c-4b06-8aa2-90b14ade12cb"
-                >Allgemeines</akn:heading
-              ></akn:section
-            >
-            """);
+    var node = XmlMapper.toNode(
+      """
+      <akn:section
+        eId="hauptteil-1_abschnitt-1"
+        GUID="f1474e45-57fe-4ba4-983e-efef589d31f3"
+      >
+        <akn:num
+          eId="hauptteil-1_abschnitt-1_bezeichnung-1"
+          GUID="28b0d5bc-1bb2-4c2f-8766-ba8df3d05441"
+        >
+          <akn:marker
+            eId="hauptteil-1_abschnitt-1_bezeichnung-1_zaehlbez-1"
+            GUID="d1af8069-6f00-442c-841c-6c4183a49a84"
+            name="1"
+          />Abschnitt 1</akn:num
+        >
+        <akn:heading
+          eId="hauptteil-1_abschnitt-1_überschrift-1"
+          GUID="d241c159-828c-4b06-8aa2-90b14ade12cb"
+          >Allgemeines</akn:heading
+        ></akn:section
+      >
+      """
+    );
 
     // When
     var output = ElementResponseMapper.fromElementNode(node);
@@ -250,30 +251,30 @@ class ElementResponseMapperTest {
   @Test
   void convertsASubsectionToNode() {
     // Given
-    var node =
-        XmlMapper.toNode(
-            """
-            <akn:subsection
-              eId="hauptteil-1_abschnitt-1_uabschnitt-1"
-              GUID="18F63BE0-B9AB-4464-92A0-8469EE5CE8A0"
-            >
-              <akn:num
-                eId="hauptteil-1_abschnitt-1_uabschnitt-1_bezeichnung-1"
-                GUID="335ed7f7-c7fb-442b-bb6f-9986d3defcfe"
-              >
-                <akn:marker
-                  eId="hauptteil-1_abschnitt-1_uabschnitt-1_bezeichnung-1_zaehlbez-1"
-                  GUID="a953c37a-7cec-4876-826e-fb9e2193603a"
-                  name="1"
-                />
-              </akn:num>
-              <akn:heading
-                eId="hauptteil-1_abschnitt-1_uabschnitt-1*überschrift-1"
-                GUID="7cabc2bc-f00c-4435-9c3a-1bc84111cf2e"
-                >Art 1 bis 6</akn:heading
-              >
-            </akn:subsection>
-            """);
+    var node = XmlMapper.toNode(
+      """
+      <akn:subsection
+        eId="hauptteil-1_abschnitt-1_uabschnitt-1"
+        GUID="18F63BE0-B9AB-4464-92A0-8469EE5CE8A0"
+      >
+        <akn:num
+          eId="hauptteil-1_abschnitt-1_uabschnitt-1_bezeichnung-1"
+          GUID="335ed7f7-c7fb-442b-bb6f-9986d3defcfe"
+        >
+          <akn:marker
+            eId="hauptteil-1_abschnitt-1_uabschnitt-1_bezeichnung-1_zaehlbez-1"
+            GUID="a953c37a-7cec-4876-826e-fb9e2193603a"
+            name="1"
+          />
+        </akn:num>
+        <akn:heading
+          eId="hauptteil-1_abschnitt-1_uabschnitt-1*überschrift-1"
+          GUID="7cabc2bc-f00c-4435-9c3a-1bc84111cf2e"
+          >Art 1 bis 6</akn:heading
+        >
+      </akn:subsection>
+      """
+    );
 
     // When
     var output = ElementResponseMapper.fromElementNode(node);
@@ -287,23 +288,23 @@ class ElementResponseMapperTest {
   @Test
   void convertsATitleToNode() {
     // Given
-    var node =
-        XmlMapper.toNode(
-            """
-          <akn:title
-            eId="hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1"
-            GUID="564b7bae-affe-42db-a82a-957727e75da3"
-          >
-            <akn:num
-            eId="hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1_bezeichnung-1"
-            GUID="496212de-91d3-4a5b-8ef4-c2c8aeb28a00"> <akn:marker
-            eId="hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1_bezeichnung-1_zaehlbez-1"
-            GUID="c9c285df-aa3a-4aa7-b9a3-d4e85987375e" name="1"/>Titel 1</akn:num>
-            <akn:heading
-            eId="hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1_überschrift-1"
-            GUID="0e672fb2-d15a-4339-a6bd-0e019fc3cc04">Überschrift Titel</akn:heading>
-          </akn:title>
-          """);
+    var node = XmlMapper.toNode(
+      """
+      <akn:title
+        eId="hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1"
+        GUID="564b7bae-affe-42db-a82a-957727e75da3"
+      >
+        <akn:num
+        eId="hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1_bezeichnung-1"
+        GUID="496212de-91d3-4a5b-8ef4-c2c8aeb28a00"> <akn:marker
+        eId="hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1_bezeichnung-1_zaehlbez-1"
+        GUID="c9c285df-aa3a-4aa7-b9a3-d4e85987375e" name="1"/>Titel 1</akn:num>
+        <akn:heading
+        eId="hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1_überschrift-1"
+        GUID="0e672fb2-d15a-4339-a6bd-0e019fc3cc04">Überschrift Titel</akn:heading>
+      </akn:title>
+      """
+    );
 
     // When
     var output = ElementResponseMapper.fromElementNode(node);
@@ -311,37 +312,37 @@ class ElementResponseMapperTest {
     // Then
     assertThat(output.getTitle()).isEqualTo("Titel 1 Überschrift Titel");
     assertThat(output.getEid())
-        .isEqualTo("hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1");
+      .isEqualTo("hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1");
     assertThat(output.getType()).isEqualTo("title");
   }
 
   @Test
   void convertsASubtitleToNode() {
     // Given
-    var node =
-        XmlMapper.toNode(
-            """
-            <akn:subtitle
-              eId="hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1_utitel-1"
-              GUID="bdcbfaa4-faa7-48e1-89e1-951fe3181c05"
-            >
-              <akn:num
-                eId="hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1_utitel-1_bezeichnung-1"
-                GUID="c4f689b2-0090-4898-b59c-3d2f3d6bdec2"
-              >
-                <akn:marker
-                  eId="hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1_utitel-1_bezeichnung-1_zaehlbez-1"
-                  GUID="0ac85cd0-d9c7-43c0-8374-946fbf2dd4f6"
-                  name="1"
-                />Untertitel 1</akn:num
-              >
-              <akn:heading
-                eId="hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1_utitel-1_überschrift-1"
-                GUID="597d4424-edac-46de-8732-5bb39b13479a"
-                >Überschrift Untertitel</akn:heading
-              ></akn:subtitle
-            >
-            """);
+    var node = XmlMapper.toNode(
+      """
+      <akn:subtitle
+        eId="hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1_utitel-1"
+        GUID="bdcbfaa4-faa7-48e1-89e1-951fe3181c05"
+      >
+        <akn:num
+          eId="hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1_utitel-1_bezeichnung-1"
+          GUID="c4f689b2-0090-4898-b59c-3d2f3d6bdec2"
+        >
+          <akn:marker
+            eId="hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1_utitel-1_bezeichnung-1_zaehlbez-1"
+            GUID="0ac85cd0-d9c7-43c0-8374-946fbf2dd4f6"
+            name="1"
+          />Untertitel 1</akn:num
+        >
+        <akn:heading
+          eId="hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1_utitel-1_überschrift-1"
+          GUID="597d4424-edac-46de-8732-5bb39b13479a"
+          >Überschrift Untertitel</akn:heading
+        ></akn:subtitle
+      >
+      """
+    );
 
     // When
     var output = ElementResponseMapper.fromElementNode(node);
@@ -349,21 +350,21 @@ class ElementResponseMapperTest {
     // Then
     assertThat(output.getTitle()).isEqualTo("Untertitel 1 Überschrift Untertitel");
     assertThat(output.getEid())
-        .isEqualTo("hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1_utitel-1");
+      .isEqualTo("hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1_utitel-1");
     assertThat(output.getType()).isEqualTo("subtitle");
   }
 
   @Test
   void convertsAPrefaceNode() {
     // Given
-    var node =
-        XmlMapper.toNode(
-            """
-            <akn:preface xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="einleitung-1" GUID="000">
-              <akn:longTitle></akn:longTitle>
-              <akn:block></akn:block>
-            </akn:preface>
-            """);
+    var node = XmlMapper.toNode(
+      """
+      <akn:preface xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="einleitung-1" GUID="000">
+        <akn:longTitle></akn:longTitle>
+        <akn:block></akn:block>
+      </akn:preface>
+      """
+    );
 
     // When
     var output = ElementResponseMapper.fromElementNode(node);
@@ -377,13 +378,13 @@ class ElementResponseMapperTest {
   @Test
   void convertsAPreambleNode() {
     // Given
-    var node =
-        XmlMapper.toNode(
-            """
-            <akn:preamble xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="preambel-1" GUID="000">
-              <akn:formula></akn:formula>
-            </akn:preamble>
-            """);
+    var node = XmlMapper.toNode(
+      """
+      <akn:preamble xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="preambel-1" GUID="000">
+        <akn:formula></akn:formula>
+      </akn:preamble>
+      """
+    );
 
     // When
     var output = ElementResponseMapper.fromElementNode(node);
@@ -397,14 +398,14 @@ class ElementResponseMapperTest {
   @Test
   void convertsAConclusionsNode() {
     // Given
-    var node =
-        XmlMapper.toNode(
-            """
-            <akn:conclusions eId="schluss-1" GUID="000">
-              <akn:formula></akn:formula>
-              <akn:blockContainer></akn:blockContainer>
-            </akn:conclusions>
-            """);
+    var node = XmlMapper.toNode(
+      """
+      <akn:conclusions eId="schluss-1" GUID="000">
+        <akn:formula></akn:formula>
+        <akn:blockContainer></akn:blockContainer>
+      </akn:conclusions>
+      """
+    );
 
     // When
     var output = ElementResponseMapper.fromElementNode(node);
@@ -418,12 +419,12 @@ class ElementResponseMapperTest {
   @Test
   void convertsAnArbitraryNode() {
     // Given
-    var node =
-        XmlMapper.toNode(
-            """
-            <akn:someRandomNode xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="random-1" GUID="000">
-            </akn:someRandomNode>
-            """);
+    var node = XmlMapper.toNode(
+      """
+      <akn:someRandomNode xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="random-1" GUID="000">
+      </akn:someRandomNode>
+      """
+    );
 
     // When
     var output = ElementResponseMapper.fromElementNode(node);
@@ -437,17 +438,17 @@ class ElementResponseMapperTest {
   @Test
   void throwsWhenConvertingANodeWithoutEid() {
     // Given
-    var node =
-        XmlMapper.toNode(
-            """
-            <akn:preface xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="000">
-              <akn:longTitle></akn:longTitle>
-              <akn:block></akn:block>
-            </akn:preface>
-            """);
+    var node = XmlMapper.toNode(
+      """
+      <akn:preface xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="000">
+        <akn:longTitle></akn:longTitle>
+        <akn:block></akn:block>
+      </akn:preface>
+      """
+    );
 
     // When
     assertThatThrownBy(() -> ElementResponseMapper.fromElementNode(node))
-        .isInstanceOf(NoSuchElementException.class);
+      .isInstanceOf(NoSuchElementException.class);
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/NormResponseMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/NormResponseMapperTest.java
@@ -12,78 +12,80 @@ class NormResponseMapperTest {
   @Test
   void canMapPrintAnnouncedNorm() {
     // Given
-    var norm =
-        Norm.builder()
-            .document(
-                XmlMapper.toDocument(
-                    """
-        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-           <akn:act name="regelungstext">
-              <!-- Metadaten -->
-              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                    <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                       <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
-                       <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
-                       <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
-                    </akn:FRBRWork>
-                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                       <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                    </akn:FRBRExpression>
-                </akn:identification>
-                                <akn:proprietary eId="meta-1_proprietary-1" GUID="cbeef40f-ddc7-4ea5-9d4d-c0077844b58f" source="attributsemantik-noch-undefiniert">
-                                  <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
-                                    <meta:typ>gesetz</meta:typ>
-                                    <meta:form>stammform</meta:form>
-                                    <meta:fassung>verkuendungsfassung</meta:fassung>
-                                    <meta:art>regelungstext</meta:art>
-                                    <meta:initiant>nicht-vorhanden</meta:initiant>
-                                    <meta:bearbeitendeInstitution>nicht-vorhanden</meta:bearbeitendeInstitution>
-                                    <!-- Die vorliegende Angabe von meta:fna stellt einen beliebigen, exemplarischen Fundstellennachweis dar und besitzt keine fachliche Korrektheit. -->
-                                    <meta:fna>754-28-1</meta:fna>
-                                    <!-- Die vorliegende Angabe von meta:gesta besitzt keine fachliche Korrektheit. -->
-                                    <meta:gesta>nicht-vorhanden</meta:gesta>
-                                    <!-- Die vorliegenden Angaben von meta:federfuehrung besitzen keine fachliche Korrektheit. -->
-                                    <meta:federfuehrung>
-                                      <meta:federfuehrend ab="2002-12-01" bis="unbestimmt">Bundesministerium des Innern und für Heimat</meta:federfuehrend>
-                                      <meta:federfuehrend ab="2002-10-01" bis="2002-12-01">Bundesministerium der Justiz</meta:federfuehrend>
-                                    </meta:federfuehrung>
-                                  </meta:legalDocML.de_metadaten>
-                                </akn:proprietary>
-              </akn:meta>
+    var norm = Norm
+      .builder()
+      .document(
+        XmlMapper.toDocument(
+          """
+          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+             <akn:act name="regelungstext">
+                <!-- Metadaten -->
+                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                      <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                         <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                         <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                         <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                      </akn:FRBRWork>
+                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                         <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                      </akn:FRBRExpression>
+                  </akn:identification>
+                                  <akn:proprietary eId="meta-1_proprietary-1" GUID="cbeef40f-ddc7-4ea5-9d4d-c0077844b58f" source="attributsemantik-noch-undefiniert">
+                                    <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+                                      <meta:typ>gesetz</meta:typ>
+                                      <meta:form>stammform</meta:form>
+                                      <meta:fassung>verkuendungsfassung</meta:fassung>
+                                      <meta:art>regelungstext</meta:art>
+                                      <meta:initiant>nicht-vorhanden</meta:initiant>
+                                      <meta:bearbeitendeInstitution>nicht-vorhanden</meta:bearbeitendeInstitution>
+                                      <!-- Die vorliegende Angabe von meta:fna stellt einen beliebigen, exemplarischen Fundstellennachweis dar und besitzt keine fachliche Korrektheit. -->
+                                      <meta:fna>754-28-1</meta:fna>
+                                      <!-- Die vorliegende Angabe von meta:gesta besitzt keine fachliche Korrektheit. -->
+                                      <meta:gesta>nicht-vorhanden</meta:gesta>
+                                      <!-- Die vorliegenden Angaben von meta:federfuehrung besitzen keine fachliche Korrektheit. -->
+                                      <meta:federfuehrung>
+                                        <meta:federfuehrend ab="2002-12-01" bis="unbestimmt">Bundesministerium des Innern und für Heimat</meta:federfuehrend>
+                                        <meta:federfuehrend ab="2002-10-01" bis="2002-12-01">Bundesministerium der Justiz</meta:federfuehrend>
+                                      </meta:federfuehrung>
+                                    </meta:legalDocML.de_metadaten>
+                                  </akn:proprietary>
+                </akn:meta>
 
-              <akn:preface eId="einleitung-1" GUID="fc10e89f-fde4-44bf-aa98-b6bdea01f0ea">
-               <akn:longTitle eId="einleitung-1_doktitel-1" GUID="abbb08de-e7e2-40ab-aba0-079ce786e6d6">
-                  <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="3e7c2134-d82c-44ba-b50d-bad9790375a0">
-                     <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="3b355cab-ce10-45b5-9cde-cc618fbf491f" />
-                     <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="c83abe1e-5fde-4e4e-a9b5-7293505ffeff" />
-                     <akn:docTitle
-                        eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="8c4eabab-9893-455e-b83b-c46f2453f2fb">Gesetz zur Regelung des öffentlichen Vereinsrechts</akn:docTitle>
-                     <akn:shortTitle eId="einleitung-1_doktitel-1_text-1_kurztitel-1" GUID="fdb8ed28-2e1f-4d81-b780-846fd9ecb716">( <akn:inline
-                           eId="einleitung-1_doktitel-1_text-1_kurztitel-1_inline-1" GUID="bdff7240-266e-4ff3-b311-60342bd1afa2" refersTo="amtliche-abkuerzung" name="attributsemantik-noch-undefiniert">Vereinsgesetz</akn:inline>)</akn:shortTitle>
-                  </akn:p>
-               </akn:longTitle>
-               <akn:block eId="einleitung-1_block-1" GUID="010d9df0-817a-49b6-a121-d0a1d412a3e3" name="attributsemantik-noch-undefiniert">
-                  <akn:date eId="einleitung-1_block-1_datum-1" GUID="28fafbe4-403d-4436-8d0d-7241cbbdade0" refersTo="ausfertigung-datum" date="1964-08-05">Vom 5. August 1964 </akn:date>
-               </akn:block>
-            </akn:preface>
-           </akn:act>
-        </akn:akomaNtoso>
-        """))
-            .build();
+                <akn:preface eId="einleitung-1" GUID="fc10e89f-fde4-44bf-aa98-b6bdea01f0ea">
+                 <akn:longTitle eId="einleitung-1_doktitel-1" GUID="abbb08de-e7e2-40ab-aba0-079ce786e6d6">
+                    <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="3e7c2134-d82c-44ba-b50d-bad9790375a0">
+                       <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="3b355cab-ce10-45b5-9cde-cc618fbf491f" />
+                       <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="c83abe1e-5fde-4e4e-a9b5-7293505ffeff" />
+                       <akn:docTitle
+                          eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="8c4eabab-9893-455e-b83b-c46f2453f2fb">Gesetz zur Regelung des öffentlichen Vereinsrechts</akn:docTitle>
+                       <akn:shortTitle eId="einleitung-1_doktitel-1_text-1_kurztitel-1" GUID="fdb8ed28-2e1f-4d81-b780-846fd9ecb716">( <akn:inline
+                             eId="einleitung-1_doktitel-1_text-1_kurztitel-1_inline-1" GUID="bdff7240-266e-4ff3-b311-60342bd1afa2" refersTo="amtliche-abkuerzung" name="attributsemantik-noch-undefiniert">Vereinsgesetz</akn:inline>)</akn:shortTitle>
+                    </akn:p>
+                 </akn:longTitle>
+                 <akn:block eId="einleitung-1_block-1" GUID="010d9df0-817a-49b6-a121-d0a1d412a3e3" name="attributsemantik-noch-undefiniert">
+                    <akn:date eId="einleitung-1_block-1_datum-1" GUID="28fafbe4-403d-4436-8d0d-7241cbbdade0" refersTo="ausfertigung-datum" date="1964-08-05">Vom 5. August 1964 </akn:date>
+                 </akn:block>
+              </akn:preface>
+             </akn:act>
+          </akn:akomaNtoso>
+          """
+        )
+      )
+      .build();
 
     // When
     final NormResponseSchema result = NormResponseMapper.fromUseCaseData(norm);
 
     // Then
     assertThat(result.getEli())
-        .isEqualTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1");
+      .isEqualTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1");
     assertThat(result.getTitle()).isEqualTo("Gesetz zur Regelung des öffentlichen Vereinsrechts");
     assertThat(result.getShortTitle()).isEqualTo("Vereinsgesetz");
     assertThat(result.getFrbrName()).isEqualTo("BGBl. I");
@@ -95,64 +97,66 @@ class NormResponseMapperTest {
   @Test
   void canMapDigitallyAnnouncedNorm() {
     // Given
-    var norm =
-        Norm.builder()
-            .document(
-                XmlMapper.toDocument(
-                    """
-        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-           <akn:act name="regelungstext">
-              <!-- Metadaten -->
-              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                    <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="d4f77434-7c1f-4496-917a-262a82a7070c">
-                       <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="ad47b5be-0012-447a-90db-71438b38650e" value="eli/bund/bgbl-1/2023/413/regelungstext-1" />
-                       <akn:FRBRuri eId="meta-1_ident-1_frbrwork-1_frbruri-1" GUID="a739e012-fe1d-4411-91b8-58e0de76fc28" value="eli/bund/bgbl-1/2023/413" />
-                       <akn:FRBRalias eId="meta-1_ident-1_frbrwork-1_frbralias-1" GUID="42ae272d-4b4a-4d25-9965-79e76c741b5b" name="übergreifende-id" value="c53036e4-14ac-420f-b01a-bae05a0a9756" />
-                       <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="525ff48c-a66e-45f6-b036-884935f7ba7d" date="2023-12-29" name="verkuendungsfassung" />
-                       <akn:FRBRauthor eId="meta-1_ident-1_frbrwork-1_frbrauthor-1" GUID="27fa3047-26e1-4c59-8701-76dd34043d71" href="recht.bund.de/institution/bundesregierung" />
-                       <akn:FRBRcountry eId="meta-1_ident-1_frbrwork-1_frbrcountry-1" GUID="fa3d22d4-4f01-4486-9d45-c1edcf50729e" value="de" />
-                       <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="565c2f06-c2c9-4a27-aeb3-ca34199ce08c" value="413" />
-                       <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="7219aecc-e1eb-49a1-abf5-bba8a8be721c" value="bgbl-1" />
-                       <akn:FRBRsubtype eId="meta-1_ident-1_frbrwork-1_frbrsubtype-1" GUID="c5bc9d46-575f-4808-90e8-a354a227d701" value="regelungstext-1" />
-                    </akn:FRBRWork>
-                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1"/>
-                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                       <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                    </akn:FRBRExpression>
-                </akn:identification>
-              </akn:meta>
+    var norm = Norm
+      .builder()
+      .document(
+        XmlMapper.toDocument(
+          """
+          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+             <akn:act name="regelungstext">
+                <!-- Metadaten -->
+                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                      <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="d4f77434-7c1f-4496-917a-262a82a7070c">
+                         <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="ad47b5be-0012-447a-90db-71438b38650e" value="eli/bund/bgbl-1/2023/413/regelungstext-1" />
+                         <akn:FRBRuri eId="meta-1_ident-1_frbrwork-1_frbruri-1" GUID="a739e012-fe1d-4411-91b8-58e0de76fc28" value="eli/bund/bgbl-1/2023/413" />
+                         <akn:FRBRalias eId="meta-1_ident-1_frbrwork-1_frbralias-1" GUID="42ae272d-4b4a-4d25-9965-79e76c741b5b" name="übergreifende-id" value="c53036e4-14ac-420f-b01a-bae05a0a9756" />
+                         <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="525ff48c-a66e-45f6-b036-884935f7ba7d" date="2023-12-29" name="verkuendungsfassung" />
+                         <akn:FRBRauthor eId="meta-1_ident-1_frbrwork-1_frbrauthor-1" GUID="27fa3047-26e1-4c59-8701-76dd34043d71" href="recht.bund.de/institution/bundesregierung" />
+                         <akn:FRBRcountry eId="meta-1_ident-1_frbrwork-1_frbrcountry-1" GUID="fa3d22d4-4f01-4486-9d45-c1edcf50729e" value="de" />
+                         <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="565c2f06-c2c9-4a27-aeb3-ca34199ce08c" value="413" />
+                         <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="7219aecc-e1eb-49a1-abf5-bba8a8be721c" value="bgbl-1" />
+                         <akn:FRBRsubtype eId="meta-1_ident-1_frbrwork-1_frbrsubtype-1" GUID="c5bc9d46-575f-4808-90e8-a354a227d701" value="regelungstext-1" />
+                      </akn:FRBRWork>
+                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1"/>
+                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                         <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                      </akn:FRBRExpression>
+                  </akn:identification>
+                </akn:meta>
 
-              <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
-                 <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
-                    <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
-                       <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Verkündungsfassung</akn:docStage>
-                       <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Gesetz zum ersten Teil der Reform des Nachrichtendienstrechts</akn:docTitle>
-                    </akn:p>
-                 </akn:longTitle>
-                 <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
-                    <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="2023-12-29">Vom
-                       29.12.2023</akn:date>
-                 </akn:block>
-              </akn:preface>
-           </akn:act>
-        </akn:akomaNtoso>
-        """))
-            .build();
+                <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                   <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                      <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                         <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Verkündungsfassung</akn:docStage>
+                         <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Gesetz zum ersten Teil der Reform des Nachrichtendienstrechts</akn:docTitle>
+                      </akn:p>
+                   </akn:longTitle>
+                   <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                      <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="2023-12-29">Vom
+                         29.12.2023</akn:date>
+                   </akn:block>
+                </akn:preface>
+             </akn:act>
+          </akn:akomaNtoso>
+          """
+        )
+      )
+      .build();
 
     // When
     final NormResponseSchema result = NormResponseMapper.fromUseCaseData(norm);
 
     // Then
     assertThat(result.getEli())
-        .isEqualTo("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1");
+      .isEqualTo("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1");
     assertThat(result.getTitle())
-        .isEqualTo("Gesetz zum ersten Teil der Reform des Nachrichtendienstrechts");
+      .isEqualTo("Gesetz zum ersten Teil der Reform des Nachrichtendienstrechts");
     assertThat(result.getFrbrName()).isEqualTo("BGBl. I");
     assertThat(result.getFrbrNumber()).isEqualTo("413");
     assertThat(result.getFrbrDateVerkuendung()).isEqualTo("2023-12-29");

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ProprietaryResponseMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ProprietaryResponseMapperTest.java
@@ -8,31 +8,36 @@ import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 
 class ProprietaryResponseMapperTest {
+
   @Test
   void convertsProprietaryToResponseSchema() {
-    final Proprietary proprietary =
-        Proprietary.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                                          <akn:proprietary eId="meta-1_proprietary-1" GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c" source="attributsemantik-noch-undefiniert">
-                                              <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
-                                                  <meta:typ>gesetz</meta:typ>
-                                                  <meta:fna>000-00-0</meta:fna>
-                                                  <meta:fassung>verkuendungsfassung</meta:fassung>
-                                              </meta:legalDocML.de_metadaten>
-                                              <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                                  <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
-                                                  <meta:fna start="1995-01-01" end="2000-12-31">222-22-2</meta:fna>
-                                                  <meta:fna start="2001-01-01">333-33-3</meta:fna>
-                                              </meta:legalDocML.de_metadaten_ds>
-                                          </akn:proprietary>
-                                          """))
-            .build();
+    final Proprietary proprietary = Proprietary
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:proprietary eId="meta-1_proprietary-1" GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c" source="attributsemantik-noch-undefiniert">
+              <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+                  <meta:typ>gesetz</meta:typ>
+                  <meta:fna>000-00-0</meta:fna>
+                  <meta:fassung>verkuendungsfassung</meta:fassung>
+              </meta:legalDocML.de_metadaten>
+              <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                  <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
+                  <meta:fna start="1995-01-01" end="2000-12-31">222-22-2</meta:fna>
+                  <meta:fna start="2001-01-01">333-33-3</meta:fna>
+              </meta:legalDocML.de_metadaten_ds>
+          </akn:proprietary>
+          """
+        )
+      )
+      .build();
 
     // When
-    var responseSchema =
-        ProprietaryResponseMapper.fromProprietary(proprietary, LocalDate.parse("1999-09-09"));
+    var responseSchema = ProprietaryResponseMapper.fromProprietary(
+      proprietary,
+      LocalDate.parse("1999-09-09")
+    );
 
     // Then
     assertThat(responseSchema.getFna()).isEqualTo("222-22-2");
@@ -40,27 +45,31 @@ class ProprietaryResponseMapperTest {
 
   @Test
   void convertsProprietaryEinzelelementToResponseSchema() {
-    final Proprietary proprietary =
-        Proprietary.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                                          <akn:proprietary eId="meta-1_proprietary-1" GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c" source="attributsemantik-noch-undefiniert">
-                                              <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                                  <meta:einzelelement href="#hauptteil-1_abschnitt-0_para-1">
-                                                      <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN</meta:artDerNorm>
-                                                      <meta:artDerNorm start="1995-01-01" end="2000-12-31">ÄN</meta:artDerNorm>
-                                                      <meta:artDerNorm start="2001-01-01">ÜN</meta:artDerNorm>
-                                                  </meta:einzelelement>
-                                              </meta:legalDocML.de_metadaten_ds>
-                                          </akn:proprietary>
-                                          """))
-            .build();
+    final Proprietary proprietary = Proprietary
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:proprietary eId="meta-1_proprietary-1" GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c" source="attributsemantik-noch-undefiniert">
+              <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                  <meta:einzelelement href="#hauptteil-1_abschnitt-0_para-1">
+                      <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN</meta:artDerNorm>
+                      <meta:artDerNorm start="1995-01-01" end="2000-12-31">ÄN</meta:artDerNorm>
+                      <meta:artDerNorm start="2001-01-01">ÜN</meta:artDerNorm>
+                  </meta:einzelelement>
+              </meta:legalDocML.de_metadaten_ds>
+          </akn:proprietary>
+          """
+        )
+      )
+      .build();
 
     // When
-    var responseSchema =
-        ProprietaryResponseMapper.fromProprietarySingleElement(
-            proprietary, "hauptteil-1_abschnitt-0_para-1", LocalDate.parse("1999-09-09"));
+    var responseSchema = ProprietaryResponseMapper.fromProprietarySingleElement(
+      proprietary,
+      "hauptteil-1_abschnitt-0_para-1",
+      LocalDate.parse("1999-09-09")
+    );
 
     // Then
     assertThat(responseSchema.getArtDerNorm()).isEqualTo("ÄN");

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ReleaseResponseMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ReleaseResponseMapperTest.java
@@ -15,107 +15,113 @@ class ReleaseResponseMapperTest {
   @Test
   void canMapAnnouncementAndEffectedNorms() {
     // Given
-    var amendingNorm =
-        Norm.builder()
-            .document(
-                XmlMapper.toDocument(
-                    """
-                             <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                           <akn:act name="regelungstext">
+    var amendingNorm = Norm
+      .builder()
+      .document(
+        XmlMapper.toDocument(
+          """
+               <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+             <akn:act name="regelungstext">
 
-                              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
-                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                    </akn:FRBRExpression>
-                                 </akn:identification>
-                              </akn:meta>
-                              <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                 <!-- Artikel 1 : Hauptänderung -->
-                                 <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                    <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                       <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                                    <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                                    <!-- Absatz (1) -->
-                                    <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                                       <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                                          <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                                       </akn:num>
-                                       <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                          <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                             <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                                   href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                          </akn:intro>
-                                       </akn:list>
-                                    </akn:paragraph>
-                                 </akn:article>
-                                  <!-- Artikel 3: Geltungszeitregel-->
-                                  <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                     <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                        <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
-                                     <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                                     <!-- Absatz (1) -->
-                                     <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                        <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-                                           <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
-                                        </akn:num>
-                                        <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                           <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                              nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                        </akn:content>
-                                     </akn:paragraph>
-                                  </akn:article>
-                              </akn:body>
-                           </akn:act>
-                        </akn:akomaNtoso>
-                        """))
-            .build();
-    var affectedNormZf0 =
-        Norm.builder()
-            .document(
-                XmlMapper.toDocument(
-                    """
-                          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                             <akn:act name="regelungstext">
-                                <!-- Metadaten -->
-                                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
-                                      </akn:FRBRExpression>
-                                  </akn:identification>
-                                </akn:meta>
-                             </akn:act>
-                          </akn:akomaNtoso>
-                        """))
-            .build();
-    var announcement =
-        Announcement.builder()
-            .norm(amendingNorm)
-            .releasedByDocumentalistAt(Instant.parse("2024-01-02T10:20:30.0Z"))
-            .build();
+                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
+                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                      </akn:FRBRExpression>
+                   </akn:identification>
+                </akn:meta>
+                <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                   <!-- Artikel 1 : Hauptänderung -->
+                   <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                      <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                         <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                      <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                      <!-- Absatz (1) -->
+                      <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                         <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                            <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                         </akn:num>
+                         <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                            <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                               <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                     href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                            </akn:intro>
+                         </akn:list>
+                      </akn:paragraph>
+                   </akn:article>
+                    <!-- Artikel 3: Geltungszeitregel-->
+                    <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                       <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
+                          <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
+                       <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+                       <!-- Absatz (1) -->
+                       <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
+                          <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
+                             <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
+                          </akn:num>
+                          <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
+                             <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
+                                nach der Verkündung</akn:date> in Kraft. </akn:p>
+                          </akn:content>
+                       </akn:paragraph>
+                    </akn:article>
+                </akn:body>
+             </akn:act>
+          </akn:akomaNtoso>
+          """
+        )
+      )
+      .build();
+    var affectedNormZf0 = Norm
+      .builder()
+      .document(
+        XmlMapper.toDocument(
+          """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+               <akn:act name="regelungstext">
+                  <!-- Metadaten -->
+                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
+                        </akn:FRBRExpression>
+                    </akn:identification>
+                  </akn:meta>
+               </akn:act>
+            </akn:akomaNtoso>
+          """
+        )
+      )
+      .build();
+    var announcement = Announcement
+      .builder()
+      .norm(amendingNorm)
+      .releasedByDocumentalistAt(Instant.parse("2024-01-02T10:20:30.0Z"))
+      .build();
 
     // When
-    final ReleaseResponseSchema result =
-        ReleaseResponseMapper.fromAnnouncement(announcement, List.of(affectedNormZf0));
+    final ReleaseResponseSchema result = ReleaseResponseMapper.fromAnnouncement(
+      announcement,
+      List.of(affectedNormZf0)
+    );
 
     // Then
     assertThat(result.getReleaseAt()).isEqualTo(Instant.parse("2024-01-02T10:20:30.0Z"));
     assertThat(result.getAmendingLawEli())
-        .isEqualTo("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1");
+      .isEqualTo("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1");
     assertThat(result.getZf0Elis())
-        .hasSize(1)
-        .containsExactly("eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1");
+      .hasSize(1)
+      .containsExactly("eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1");
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/TimeBoundaryMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/TimeBoundaryMapperTest.java
@@ -18,30 +18,29 @@ import org.junit.jupiter.api.Test;
 class TimeBoundaryMapperTest {
 
   String xml =
-      """
-                            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                               <akn:act name="regelungstext">
-                                  <!-- Metadaten -->
-                                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                     <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                        <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                            source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                        <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                                            source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                     </akn:lifecycle>
-                                     <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                                 <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                                 </akn:temporalGroup>
-                                     </akn:temporalData>
-                                  </akn:meta>
-                               </akn:act>
-                            </akn:akomaNtoso>
-                          """
-          .strip();
+    """
+      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+         <akn:act name="regelungstext">
+            <!-- Metadaten -->
+            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+               <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+               </akn:lifecycle>
+               <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                           <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                              <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                           </akn:temporalGroup>
+               </akn:temporalData>
+            </akn:meta>
+         </akn:act>
+      </akn:akomaNtoso>
+    """.strip();
 
   @Test
   void canMapFromUseCaseData() {
@@ -62,14 +61,16 @@ class TimeBoundaryMapperTest {
 
   @Nested
   class fromResponseSchema {
+
     @Test
     void canMapFromResponseSchemaEmpty() {
       // Given
       List<TimeBoundarySchema> timeBoundaries = List.of();
 
       // When
-      List<TimeBoundaryChangeData> timeBoundaryChangeData =
-          TimeBoundaryMapper.fromResponseSchema(timeBoundaries);
+      List<TimeBoundaryChangeData> timeBoundaryChangeData = TimeBoundaryMapper.fromResponseSchema(
+        timeBoundaries
+      );
 
       // Then
       assertThat(timeBoundaryChangeData).isEmpty();
@@ -78,16 +79,18 @@ class TimeBoundaryMapperTest {
     @Test
     void canMapFromResponseSchemaOne() {
       // Given
-      List<TimeBoundarySchema> timeBoundaries =
-          List.of(
-              new TimeBoundarySchema(
-                  LocalDate.parse("2023-12-30"),
-                  "meta-1_lebzykl-1_ereignis-2",
-                  "meta-1_geltzeiten-1_geltungszeitgr-1"));
+      List<TimeBoundarySchema> timeBoundaries = List.of(
+        new TimeBoundarySchema(
+          LocalDate.parse("2023-12-30"),
+          "meta-1_lebzykl-1_ereignis-2",
+          "meta-1_geltzeiten-1_geltungszeitgr-1"
+        )
+      );
 
       // When
-      List<TimeBoundaryChangeData> timeBoundaryChangeData =
-          TimeBoundaryMapper.fromResponseSchema(timeBoundaries);
+      List<TimeBoundaryChangeData> timeBoundaryChangeData = TimeBoundaryMapper.fromResponseSchema(
+        timeBoundaries
+      );
 
       // Then
       assertThat(timeBoundaryChangeData).isNotEmpty();
@@ -98,20 +101,23 @@ class TimeBoundaryMapperTest {
     @Test
     void canMapFromResponseSchemaTwo() {
       // Given
-      List<TimeBoundarySchema> timeBoundaries =
-          List.of(
-              new TimeBoundarySchema(
-                  LocalDate.parse("2023-12-30"),
-                  "meta-1_lebzykl-1_ereignis-2",
-                  "meta-1_geltzeiten-1_geltungszeitgr-1"),
-              new TimeBoundarySchema(
-                  LocalDate.parse("2016-01-28"),
-                  "meta-1_lebzykl-1_ereignis-1",
-                  "meta-1_geltzeiten-1_geltungszeitgr-1"));
+      List<TimeBoundarySchema> timeBoundaries = List.of(
+        new TimeBoundarySchema(
+          LocalDate.parse("2023-12-30"),
+          "meta-1_lebzykl-1_ereignis-2",
+          "meta-1_geltzeiten-1_geltungszeitgr-1"
+        ),
+        new TimeBoundarySchema(
+          LocalDate.parse("2016-01-28"),
+          "meta-1_lebzykl-1_ereignis-1",
+          "meta-1_geltzeiten-1_geltungszeitgr-1"
+        )
+      );
 
       // When
-      List<TimeBoundaryChangeData> timeBoundaryChangeData =
-          TimeBoundaryMapper.fromResponseSchema(timeBoundaries);
+      List<TimeBoundaryChangeData> timeBoundaryChangeData = TimeBoundaryMapper.fromResponseSchema(
+        timeBoundaries
+      );
 
       // Then
       assertThat(timeBoundaryChangeData).isNotEmpty();

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/NormDtoTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/NormDtoTest.java
@@ -27,23 +27,23 @@ class NormDtoTest {
   void testAllConstraintsAreMet() {
     // Given
     var xml =
-        """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                          </akn:FRBRExpression>
-                      </akn:identification>
-                    </akn:meta>
-                 </akn:act>
-              </akn:akomaNtoso>
-            """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                    </akn:FRBRExpression>
+                </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
     var guid = UUID.fromString("c01334e2-f12b-4055-ac82-15ac03c74c78");
     var eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
 
@@ -65,10 +65,13 @@ class NormDtoTest {
 
     // Then
     assertThat(violations)
-        .hasSize(3)
-        .extracting(
-            violation -> violation.getPropertyPath().toString() + " " + violation.getMessage())
-        .containsExactlyInAnyOrder(
-            "eli must not be null", "guid must not be null", "xml must not be null");
+      .hasSize(3)
+      .extracting(violation -> violation.getPropertyPath().toString() + " " + violation.getMessage()
+      )
+      .containsExactlyInAnyOrder(
+        "eli must not be null",
+        "guid must not be null",
+        "xml must not be null"
+      );
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/AnnouncementMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/AnnouncementMapperTest.java
@@ -17,34 +17,37 @@ class AnnouncementMapperTest {
   void itShouldMapToDomain() {
     // Given
     var xml =
-        """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                          </akn:FRBRExpression>
-                       </akn:identification>
-                    </akn:meta>
-                 </akn:act>
-              </akn:akomaNtoso>
-            """;
-    var normDto =
-        NormDto.builder()
-            .xml(xml)
-            .eli("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
-            .guid(UUID.fromString("ba44d2ae-0e73-44ba-850a-932ab2fa553f"))
-            .build();
-    var announcementDto =
-        AnnouncementDto.builder().releasedByDocumentalistAt(Instant.now()).normDto(normDto).build();
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                    </akn:FRBRExpression>
+                 </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
+    var normDto = NormDto
+      .builder()
+      .xml(xml)
+      .eli("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+      .guid(UUID.fromString("ba44d2ae-0e73-44ba-850a-932ab2fa553f"))
+      .build();
+    var announcementDto = AnnouncementDto
+      .builder()
+      .releasedByDocumentalistAt(Instant.now())
+      .normDto(normDto)
+      .build();
 
     // When
     final Announcement announcement = AnnouncementMapper.mapToDomain(announcementDto);
@@ -53,38 +56,38 @@ class AnnouncementMapperTest {
     assertThat(announcement).isNotNull();
     assertThat(announcement.getNorm().getEli()).contains(announcementDto.getNormDto().getEli());
     assertThat(announcement.getReleasedByDocumentalistAt())
-        .isEqualTo(announcementDto.getReleasedByDocumentalistAt());
+      .isEqualTo(announcementDto.getReleasedByDocumentalistAt());
   }
 
   @Test
   void itShouldMapToDto() {
     // Given
     var xml =
-        """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                          </akn:FRBRExpression>
-                       </akn:identification>
-                    </akn:meta>
-                 </akn:act>
-              </akn:akomaNtoso>
-            """;
-    var announcement =
-        Announcement.builder()
-            .norm(Norm.builder().document(XmlMapper.toDocument(xml)).build())
-            .releasedByDocumentalistAt(Instant.now())
-            .build();
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                    </akn:FRBRExpression>
+                 </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
+    var announcement = Announcement
+      .builder()
+      .norm(Norm.builder().document(XmlMapper.toDocument(xml)).build())
+      .releasedByDocumentalistAt(Instant.now())
+      .build();
 
     // When
     final AnnouncementDto announcementDto = AnnouncementMapper.mapToDto(announcement);
@@ -93,6 +96,6 @@ class AnnouncementMapperTest {
     assertThat(announcementDto).isNotNull();
     assertThat(announcementDto.getNormDto().getEli()).isEqualTo(announcement.getNorm().getEli());
     assertThat(announcementDto.getReleasedByDocumentalistAt())
-        .isEqualTo(announcement.getReleasedByDocumentalistAt());
+      .isEqualTo(announcement.getReleasedByDocumentalistAt());
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/NormMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/NormMapperTest.java
@@ -14,32 +14,32 @@ class NormMapperTest {
   void itShouldMapToDomain() {
     // Given
     var xml =
-        """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                          </akn:FRBRExpression>
-                       </akn:identification>
-                    </akn:meta>
-                 </akn:act>
-              </akn:akomaNtoso>
-            """;
-    var normDto =
-        NormDto.builder()
-            .xml(xml)
-            .eli("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
-            .guid(UUID.fromString("c01334e2-f12b-4055-ac82-15ac03c74c78"))
-            .build();
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                    </akn:FRBRExpression>
+                 </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
+    var normDto = NormDto
+      .builder()
+      .xml(xml)
+      .eli("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+      .guid(UUID.fromString("c01334e2-f12b-4055-ac82-15ac03c74c78"))
+      .build();
 
     // When
     final Norm norm = NormMapper.mapToDomain(normDto);
@@ -53,26 +53,26 @@ class NormMapperTest {
   void itShouldMapToDto() {
     // Given
     var xml =
-        """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                          </akn:FRBRExpression>
-                       </akn:identification>
-                    </akn:meta>
-                 </akn:act>
-              </akn:akomaNtoso>
-            """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                    </akn:FRBRExpression>
+                 </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
     var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
 
     // When

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/XmlMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/XmlMapperTest.java
@@ -12,59 +12,60 @@ class XmlMapperTest {
   void itCanConvertTextToXmlDocument() {
     // Given
     var text =
-        """
-                          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                             <akn:act name="regelungstext">
-                                <!-- Metadaten -->
-                                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                      </akn:FRBRExpression>
-                                  </akn:identification>
-                                </akn:meta>
-                             </akn:act>
-                          </akn:akomaNtoso>
-                        """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                    </akn:FRBRExpression>
+                </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
 
     // When
     final Document document = XmlMapper.toDocument(text);
 
     // Then
     assertThat(
-            document
-                .getElementsByTagName("akn:act")
-                .item(0)
-                .getAttributes()
-                .getNamedItem("name")
-                .getNodeValue())
-        .isEqualTo("regelungstext");
+      document
+        .getElementsByTagName("akn:act")
+        .item(0)
+        .getAttributes()
+        .getNamedItem("name")
+        .getNodeValue()
+    )
+      .isEqualTo("regelungstext");
   }
 
   @Test
   void itCanConvertTextToXmlDocumentAndBack() {
     // Given
     var text =
-        """
-                        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                           <akn:act name="regelungstext">
-                              <!-- Metadaten -->
-                              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                    </akn:FRBRExpression>
-                                </akn:identification>
-                              </akn:meta>
-                           </akn:act>
-                        </akn:akomaNtoso>
-                        """;
+      """
+      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+         <akn:act name="regelungstext">
+            <!-- Metadaten -->
+            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                  <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                     <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                  </akn:FRBRExpression>
+              </akn:identification>
+            </akn:meta>
+         </akn:act>
+      </akn:akomaNtoso>
+      """;
 
     // When
     final Document document = XmlMapper.toDocument(text);

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/AmendingLawValidatorTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/AmendingLawValidatorTest.java
@@ -22,44 +22,50 @@ class AmendingLawValidatorTest {
   private final LoadZf0Service loadZf0Service = mock(LoadZf0Service.class);
   private final SingleModValidator singleModValidator = mock(SingleModValidator.class);
 
-  private final AmendingLawValidator underTest =
-      new AmendingLawValidator(loadNormPort, loadZf0Service, singleModValidator);
+  private final AmendingLawValidator underTest = new AmendingLawValidator(
+    loadNormPort,
+    loadZf0Service,
+    singleModValidator
+  );
 
   @Test
   void emptyActiveModificationDestinationHref() {
     // given
     final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithMods.xml");
     amendingNorm
-        .getNodeByEId("hauptteil-1_art-1")
-        .get()
-        .getAttributes()
-        .getNamedItem("refersTo")
-        .setTextContent("");
+      .getNodeByEId("hauptteil-1_art-1")
+      .get()
+      .getAttributes()
+      .getNamedItem("refersTo")
+      .setTextContent("");
 
     // when
     Throwable thrown = catchThrowable(() -> underTest.destinationIsSet(amendingNorm));
 
     // then
     assertThat(thrown)
-        .isInstanceOf(ValidationException.class)
-        .hasMessageContaining(
-            "For norm with Eli (eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1): RefersTo is empty in article with eId hauptteil-1_art-1");
+      .isInstanceOf(ValidationException.class)
+      .hasMessageContaining(
+        "For norm with Eli (eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1): RefersTo is empty in article with eId hauptteil-1_art-1"
+      );
   }
 
   @Test
   void emptyArticleRefersTo() {
     // given
-    final Norm amendingNorm =
-        NormFixtures.loadFromDisk("NormWithEmptyActiveModificationDestinationHref.xml");
+    final Norm amendingNorm = NormFixtures.loadFromDisk(
+      "NormWithEmptyActiveModificationDestinationHref.xml"
+    );
 
     // when
     Throwable thrown = catchThrowable(() -> underTest.destinationIsSet(amendingNorm));
 
     // then
     assertThat(thrown)
-        .isInstanceOf(ValidationException.class)
-        .hasMessageContaining(
-            "For norm with Eli (eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1): ActiveModification Destination Href is empty where textualMod eId is meta-1_analysis-1_activemod-1_textualmod-1");
+      .isInstanceOf(ValidationException.class)
+      .hasMessageContaining(
+        "For norm with Eli (eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1): ActiveModification Destination Href is empty where textualMod eId is meta-1_analysis-1_activemod-1_textualmod-1"
+      );
   }
 
   @Test
@@ -67,21 +73,22 @@ class AmendingLawValidatorTest {
     // given
     final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithMods.xml");
     amendingNorm
-        .getMeta()
-        .getAnalysis()
-        .map(Analysis::getActiveModifications)
-        .orElse(Collections.emptyList())
-        .getFirst()
-        .setDestinationHref("#THIS_IS_NOT_OK_A_HREF_IS_NEVER_RELATIVE");
+      .getMeta()
+      .getAnalysis()
+      .map(Analysis::getActiveModifications)
+      .orElse(Collections.emptyList())
+      .getFirst()
+      .setDestinationHref("#THIS_IS_NOT_OK_A_HREF_IS_NEVER_RELATIVE");
 
     // when
     Throwable thrown = catchThrowable(() -> underTest.destinationIsSet(amendingNorm));
 
     // then
     assertThat(thrown)
-        .isInstanceOf(ValidationException.class)
-        .hasMessageContaining(
-            "For norm with Eli (eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1): ActiveModification Destination Href holds an empty (more general: invalid) Eli where textualMod eId is meta-1_analysis-1_activemod-1_textualmod-1");
+      .isInstanceOf(ValidationException.class)
+      .hasMessageContaining(
+        "For norm with Eli (eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1): ActiveModification Destination Href holds an empty (more general: invalid) Eli where textualMod eId is meta-1_analysis-1_activemod-1_textualmod-1"
+      );
   }
 
   @Test
@@ -89,59 +96,59 @@ class AmendingLawValidatorTest {
     // given
     final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithMods.xml");
     amendingNorm
-        .getMeta()
-        .getAnalysis()
-        .map(Analysis::getActiveModifications)
-        .orElse(Collections.emptyList())
-        .getFirst()
-        .setDestinationHref("");
+      .getMeta()
+      .getAnalysis()
+      .map(Analysis::getActiveModifications)
+      .orElse(Collections.emptyList())
+      .getFirst()
+      .setDestinationHref("");
 
     amendingNorm
-        .getMeta()
-        .getAnalysis()
-        .map(Analysis::getActiveModifications)
-        .orElse(Collections.emptyList())
-        .getFirst()
-        .getNode()
-        .getAttributes()
-        .getNamedItem("eId")
-        .setTextContent("");
+      .getMeta()
+      .getAnalysis()
+      .map(Analysis::getActiveModifications)
+      .orElse(Collections.emptyList())
+      .getFirst()
+      .getNode()
+      .getAttributes()
+      .getNamedItem("eId")
+      .setTextContent("");
 
     // when
     Throwable thrown = catchThrowable(() -> underTest.destinationIsSet(amendingNorm));
 
     // then
     assertThat(thrown)
-        .isInstanceOf(ValidationException.class)
-        .hasMessageContaining(
-            "For norm with Eli (eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1): TextualMod eId empty.");
+      .isInstanceOf(ValidationException.class)
+      .hasMessageContaining(
+        "For norm with Eli (eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1): TextualMod eId empty."
+      );
   }
 
   @Test
   void emptyAknModHrefEli() {
-
     // given
     final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithMods.xml");
     amendingNorm
-        .getArticles()
-        .getFirst()
-        .getMods()
-        .getFirst()
-        .setTargetRefHref("#THIS_IS_NOT_OK_A_HREF_IS_NEVER_RELATIVE");
+      .getArticles()
+      .getFirst()
+      .getMods()
+      .getFirst()
+      .setTargetRefHref("#THIS_IS_NOT_OK_A_HREF_IS_NEVER_RELATIVE");
 
     // when
     Throwable thrown = catchThrowable(() -> underTest.destinationIsSet(amendingNorm));
 
     // then
     assertThat(thrown)
-        .isInstanceOf(ValidationException.class)
-        .hasMessageContaining(
-            "For norm with Eli (eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1): The Eli in aknMod href is empty in article with eId hauptteil-1_art-1");
+      .isInstanceOf(ValidationException.class)
+      .hasMessageContaining(
+        "For norm with Eli (eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1): The Eli in aknMod href is empty in article with eId hauptteil-1_art-1"
+      );
   }
 
   @Test
   void emptyAffectedDocumentHref() {
-
     // given
     final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithMods.xml");
     amendingNorm.getArticles().getFirst().setAffectedDocumentEli("");
@@ -151,9 +158,10 @@ class AmendingLawValidatorTest {
 
     // then
     assertThat(thrown)
-        .isInstanceOf(ValidationException.class)
-        .hasMessageContaining(
-            "For norm with Eli (eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1): AffectedDocument href is empty in article with eId hauptteil-1_art-1");
+      .isInstanceOf(ValidationException.class)
+      .hasMessageContaining(
+        "For norm with Eli (eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1): AffectedDocument href is empty in article with eId hauptteil-1_art-1"
+      );
   }
 
   @Test
@@ -175,9 +183,10 @@ class AmendingLawValidatorTest {
 
     // then
     assertThat(thrown)
-        .isInstanceOf(ValidationException.class)
-        .hasMessageContaining(
-            "For norm with Eli (eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1): Elis are not consistent");
+      .isInstanceOf(ValidationException.class)
+      .hasMessageContaining(
+        "For norm with Eli (eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1): Elis are not consistent"
+      );
   }
 
   @Test
@@ -199,9 +208,10 @@ class AmendingLawValidatorTest {
 
     // then
     assertThat(thrown)
-        .isInstanceOf(ValidationException.class)
-        .hasMessageContaining(
-            "For norm with Eli (eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1): Eids are not consistent");
+      .isInstanceOf(ValidationException.class)
+      .hasMessageContaining(
+        "For norm with Eli (eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1): Eids are not consistent"
+      );
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/AnnouncementServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/AnnouncementServiceTest.java
@@ -25,14 +25,18 @@ import org.junit.jupiter.api.Test;
 class AnnouncementServiceTest {
 
   final LoadAllAnnouncementsPort loadAllAnnouncementsPort = mock(LoadAllAnnouncementsPort.class);
-  final LoadAnnouncementByNormEliPort loadAnnouncementByNormEliPort =
-      mock(LoadAnnouncementByNormEliPort.class);
+  final LoadAnnouncementByNormEliPort loadAnnouncementByNormEliPort = mock(
+    LoadAnnouncementByNormEliPort.class
+  );
   final LoadNormPort loadNormPort = mock(LoadNormPort.class);
   final LoadZf0Service loadZf0Service = mock(LoadZf0Service.class);
 
-  final AnnouncementService announcementService =
-      new AnnouncementService(
-          loadAllAnnouncementsPort, loadAnnouncementByNormEliPort, loadNormPort, loadZf0Service);
+  final AnnouncementService announcementService = new AnnouncementService(
+    loadAllAnnouncementsPort,
+    loadAnnouncementByNormEliPort,
+    loadNormPort,
+    loadZf0Service
+  );
 
   @Nested
   class loadAllAnnouncements {
@@ -40,32 +44,36 @@ class AnnouncementServiceTest {
     @Test
     void itReturnsAnnouncements() {
       // Given
-      var announcement =
-          Announcement.builder()
-              .norm(
-                  Norm.builder()
-                      .document(
-                          XmlMapper.toDocument(
-                              """
-                                    <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                                    <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                       xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                           http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                                       <akn:act name="regelungstext">
-                                          <!-- Metadaten -->
-                                          <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                             <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                                <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                                   <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                                </akn:FRBRExpression>
-                                            </akn:identification>
-                                          </akn:meta>
-                                       </akn:act>
-                                    </akn:akomaNtoso>
-                                  """))
-                      .build())
-              .releasedByDocumentalistAt(Instant.now())
-              .build();
+      var announcement = Announcement
+        .builder()
+        .norm(
+          Norm
+            .builder()
+            .document(
+              XmlMapper.toDocument(
+                """
+                  <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+                  <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                         http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                     <akn:act name="regelungstext">
+                        <!-- Metadaten -->
+                        <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                           <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                              <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                                 <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                              </akn:FRBRExpression>
+                          </akn:identification>
+                        </akn:meta>
+                     </akn:act>
+                  </akn:akomaNtoso>
+                """
+              )
+            )
+            .build()
+        )
+        .releasedByDocumentalistAt(Instant.now())
+        .build();
       when(loadAllAnnouncementsPort.loadAllAnnouncements()).thenReturn(List.of(announcement));
 
       // When
@@ -83,56 +91,61 @@ class AnnouncementServiceTest {
     @Test
     void itThrowsAnnouncementNotFoundException() {
       // given
-      final var query =
-          new LoadAnnouncementByNormEliUseCase.Query(
-              "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1");
+      final var query = new LoadAnnouncementByNormEliUseCase.Query(
+        "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"
+      );
 
       when(loadAnnouncementByNormEliPort.loadAnnouncementByNormEli(any()))
-          .thenReturn(Optional.empty());
+        .thenReturn(Optional.empty());
 
       // when
       assertThatThrownBy(() -> announcementService.loadAnnouncementByNormEli(query))
-          // then
-          .isInstanceOf(AnnouncementNotFoundException.class);
+        // then
+        .isInstanceOf(AnnouncementNotFoundException.class);
     }
 
     @Test
     void itReturnsAnnouncement() {
       // Given
-      var announcement =
-          Announcement.builder()
-              .norm(
-                  Norm.builder()
-                      .document(
-                          XmlMapper.toDocument(
-                              """
-                                    <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                                    <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                       xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                           http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                                       <akn:act name="regelungstext">
-                                          <!-- Metadaten -->
-                                          <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                             <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                                <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                                   <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                                </akn:FRBRExpression>
-                                            </akn:identification>
-                                          </akn:meta>
-                                       </akn:act>
-                                    </akn:akomaNtoso>
-                                  """))
-                      .build())
-              .releasedByDocumentalistAt(Instant.now())
-              .build();
+      var announcement = Announcement
+        .builder()
+        .norm(
+          Norm
+            .builder()
+            .document(
+              XmlMapper.toDocument(
+                """
+                  <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+                  <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                         http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                     <akn:act name="regelungstext">
+                        <!-- Metadaten -->
+                        <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                           <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                              <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                                 <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                              </akn:FRBRExpression>
+                          </akn:identification>
+                        </akn:meta>
+                     </akn:act>
+                  </akn:akomaNtoso>
+                """
+              )
+            )
+            .build()
+        )
+        .releasedByDocumentalistAt(Instant.now())
+        .build();
       when(loadAnnouncementByNormEliPort.loadAnnouncementByNormEli(any()))
-          .thenReturn(Optional.of(announcement));
+        .thenReturn(Optional.of(announcement));
 
       // When
-      var loadedAnnouncement =
-          announcementService.loadAnnouncementByNormEli(
-              new LoadAnnouncementByNormEliUseCase.Query(
-                  "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"));
+      var loadedAnnouncement = announcementService.loadAnnouncementByNormEli(
+        new LoadAnnouncementByNormEliUseCase.Query(
+          "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"
+        )
+      );
 
       // Then
       verify(loadAnnouncementByNormEliPort, times(1)).loadAnnouncementByNormEli(any());
@@ -146,110 +159,118 @@ class AnnouncementServiceTest {
     @Test
     void itReturnsNorms() {
       // Given
-      var amendingNorm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                               <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                             <akn:act name="regelungstext">
+      var amendingNorm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+                 <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+               <akn:act name="regelungstext">
 
-                                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                      </akn:FRBRExpression>
-                                   </akn:identification>
-                                </akn:meta>
-                                <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                   <!-- Artikel 1 : Hauptänderung -->
-                                   <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                      <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                         <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                                      <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                                      <!-- Absatz (1) -->
-                                      <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                                         <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                                            <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                                         </akn:num>
-                                         <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                            <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                               <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                                     href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                            </akn:intro>
-                                         </akn:list>
-                                      </akn:paragraph>
-                                   </akn:article>
-                                    <!-- Artikel 3: Geltungszeitregel-->
-                                    <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                       <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                          <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
-                                       <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                                       <!-- Absatz (1) -->
-                                       <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                          <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-                                             <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
-                                          </akn:num>
-                                          <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                             <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                                nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                          </akn:content>
-                                       </akn:paragraph>
-                                    </akn:article>
-                                </akn:body>
-                             </akn:act>
-                          </akn:akomaNtoso>
-                          """))
-              .build();
-      var affectedNormZf0 =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                               <akn:act name="regelungstext">
-                                  <!-- Metadaten -->
-                                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
-                                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
-                                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
-                                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
-                                        </akn:FRBRExpression>
-                                    </akn:identification>
-                                  </akn:meta>
-                               </akn:act>
-                            </akn:akomaNtoso>
-                          """))
-              .build();
+                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                        </akn:FRBRExpression>
+                     </akn:identification>
+                  </akn:meta>
+                  <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                     <!-- Artikel 1 : Hauptänderung -->
+                     <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                        <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                           <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                        <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                        <!-- Absatz (1) -->
+                        <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                           <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                              <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                           </akn:num>
+                           <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                              <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                                 <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                       href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                              </akn:intro>
+                           </akn:list>
+                        </akn:paragraph>
+                     </akn:article>
+                      <!-- Artikel 3: Geltungszeitregel-->
+                      <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                         <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
+                            <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
+                         <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+                         <!-- Absatz (1) -->
+                         <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
+                            <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
+                               <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
+                            </akn:num>
+                            <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
+                               <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
+                                  nach der Verkündung</akn:date> in Kraft. </akn:p>
+                            </akn:content>
+                         </akn:paragraph>
+                      </akn:article>
+                  </akn:body>
+               </akn:act>
+            </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
+      var affectedNormZf0 = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
-      var announcement =
-          Announcement.builder()
-              .norm(amendingNorm)
-              .releasedByDocumentalistAt(Instant.now())
-              .build();
+      var announcement = Announcement
+        .builder()
+        .norm(amendingNorm)
+        .releasedByDocumentalistAt(Instant.now())
+        .build();
       when(loadAnnouncementByNormEliPort.loadAnnouncementByNormEli(any()))
-          .thenReturn(Optional.of(announcement));
+        .thenReturn(Optional.of(announcement));
       // Should return target law but we dont care what is returned, since we also mock the loadZf0
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(amendingNorm));
-      when(loadZf0Service.loadOrCreateZf0(
-              argThat(argument -> argument.amendingLaw().equals(amendingNorm))))
-          .thenReturn(affectedNormZf0);
+      when(
+        loadZf0Service.loadOrCreateZf0(
+          argThat(argument -> argument.amendingLaw().equals(amendingNorm))
+        )
+      )
+        .thenReturn(affectedNormZf0);
 
       // When
-      var norms =
-          announcementService.loadTargetNormsAffectedByAnnouncement(
-              new LoadTargetNormsAffectedByAnnouncementUseCase.Query(
-                  "eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1"));
+      var norms = announcementService.loadTargetNormsAffectedByAnnouncement(
+        new LoadTargetNormsAffectedByAnnouncementUseCase.Query(
+          "eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1"
+        )
+      );
 
       // Then
       verify(loadAnnouncementByNormEliPort, times(1)).loadAnnouncementByNormEli(any());

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/ArticleServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/ArticleServiceTest.java
@@ -26,8 +26,11 @@ class ArticleServiceTest {
   final LoadNormPort loadNormPort = mock(LoadNormPort.class);
   final TimeMachineService timeMachineService = mock(TimeMachineService.class);
   final XsltTransformationService xsltTransformationService = mock(XsltTransformationService.class);
-  final ArticleService articleService =
-      new ArticleService(loadNormPort, timeMachineService, xsltTransformationService);
+  final ArticleService articleService = new ArticleService(
+    loadNormPort,
+    timeMachineService,
+    xsltTransformationService
+  );
 
   @Nested
   class loadArticleHtml {
@@ -59,9 +62,8 @@ class ArticleServiceTest {
 
       // when
       assertThatThrownBy(() -> articleService.loadArticleHtml(query))
-
-          // then
-          .isInstanceOf(NormNotFoundException.class);
+        // then
+        .isInstanceOf(NormNotFoundException.class);
     }
 
     @Test
@@ -76,14 +78,14 @@ class ArticleServiceTest {
 
       // when
       assertThatThrownBy(() -> articleService.loadArticleHtml(query))
-
-          // then
-          .isInstanceOf(ArticleNotFoundException.class);
+        // then
+        .isInstanceOf(ArticleNotFoundException.class);
     }
   }
 
   @Nested
   class loadArticlesFromNorm {
+
     @Test
     void itReturnsArticlesFromNorm() {
       // Given
@@ -108,8 +110,9 @@ class ArticleServiceTest {
       final var eli = "eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1";
       final var amendedBy = "eli/bund/bgbl-1/2017/s815/1995-03-15/1/deu/regelungstext-1";
       final String amendedAt = null;
-      final var norm =
-          NormFixtures.loadFromDisk("NormWithPassiveModificationsInDifferentArticles.xml");
+      final var norm = NormFixtures.loadFromDisk(
+        "NormWithPassiveModificationsInDifferentArticles.xml"
+      );
       final var query = new LoadArticlesFromNormUseCase.Query(eli, amendedBy, amendedAt);
 
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(norm));
@@ -170,7 +173,7 @@ class ArticleServiceTest {
 
       // When / Then
       assertThatThrownBy(() -> articleService.loadArticlesFromNorm(query))
-          .isInstanceOf(NormNotFoundException.class);
+        .isInstanceOf(NormNotFoundException.class);
     }
 
     @Test
@@ -252,41 +255,43 @@ class ArticleServiceTest {
       // Given
       var eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
 
-      var norm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                           <akn:act name="regelungstext">
-                              <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                       <!-- Artikel 1 : Hauptänderung -->
-                                       <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                          Some Text
-                                       </akn:article>
+      var norm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                             <!-- Artikel 1 : Hauptänderung -->
+                             <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                                Some Text
+                             </akn:article>
 
-                                       <!-- Artikel 3: Geltungszeitregel-->
-                                       <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                          More Text
-                                       </akn:article>
-                                    </akn:body>
-                           </akn:act>
-                        </akn:akomaNtoso>
-                      """))
-              .build();
+                             <!-- Artikel 3: Geltungszeitregel-->
+                             <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                                More Text
+                             </akn:article>
+                          </akn:body>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(norm));
 
       // When
-      var xmls =
-          articleService.loadSpecificArticlesXmlFromNorm(
-              new LoadSpecificArticlesXmlFromNormUseCase.Query(eli, null));
+      var xmls = articleService.loadSpecificArticlesXmlFromNorm(
+        new LoadSpecificArticlesXmlFromNormUseCase.Query(eli, null)
+      );
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
       assertThat(xmls).isNotEmpty();
       assertThat(xmls.getFirst()).contains("hauptteil-1_art-1");
       assertThat(xmls.get(1)).contains("hauptteil-1_art-3");
@@ -301,12 +306,11 @@ class ArticleServiceTest {
 
       // When
       assertThatThrownBy(() -> articleService.loadSpecificArticlesXmlFromNorm(query))
-
-          // Then
-          .isInstanceOf(NormNotFoundException.class);
+        // Then
+        .isInstanceOf(NormNotFoundException.class);
 
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
     }
 
     @Test
@@ -314,41 +318,43 @@ class ArticleServiceTest {
       // Given
       var eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
 
-      var norm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                           <akn:act name="regelungstext">
-                              <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                       <!-- Artikel 1 : Hauptänderung -->
-                                       <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                          Some Text
-                                       </akn:article>
+      var norm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                             <!-- Artikel 1 : Hauptänderung -->
+                             <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                                Some Text
+                             </akn:article>
 
-                                       <!-- Artikel 3: Geltungszeitregel-->
-                                       <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                          More Text
-                                       </akn:article>
-                                    </akn:body>
-                           </akn:act>
-                        </akn:akomaNtoso>
-                      """))
-              .build();
+                             <!-- Artikel 3: Geltungszeitregel-->
+                             <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                                More Text
+                             </akn:article>
+                          </akn:body>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(norm));
 
       // When
-      var xmls =
-          articleService.loadSpecificArticlesXmlFromNorm(
-              new LoadSpecificArticlesXmlFromNormUseCase.Query(eli, "geltungszeitregel"));
+      var xmls = articleService.loadSpecificArticlesXmlFromNorm(
+        new LoadSpecificArticlesXmlFromNormUseCase.Query(eli, "geltungszeitregel")
+      );
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
       assertThat(xmls).isNotEmpty();
       assertThat(xmls.getFirst()).contains("hauptteil-1_art-3");
     }
@@ -359,37 +365,37 @@ class ArticleServiceTest {
       var eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
       var query = new LoadSpecificArticlesXmlFromNormUseCase.Query(eli, "geltungszeitregel");
 
-      var norm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                           <akn:act name="regelungstext">
-                              <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                       <!-- Artikel 1 : Hauptänderung -->
-                                       <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                          Some Text
-                                       </akn:article>
-                                    </akn:body>
-                           </akn:act>
-                        </akn:akomaNtoso>
-                      """))
-              .build();
+      var norm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                             <!-- Artikel 1 : Hauptänderung -->
+                             <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                                Some Text
+                             </akn:article>
+                          </akn:body>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(norm));
 
       // When
       assertThatThrownBy(() -> articleService.loadSpecificArticlesXmlFromNorm(query))
-
-          // Then
-          .isInstanceOf(
-              LoadSpecificArticlesXmlFromNormUseCase.ArticleOfTypeNotFoundException.class);
+        // Then
+        .isInstanceOf(LoadSpecificArticlesXmlFromNormUseCase.ArticleOfTypeNotFoundException.class);
 
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
     }
 
     @Test
@@ -398,33 +404,33 @@ class ArticleServiceTest {
       var eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
       var query = new LoadSpecificArticlesXmlFromNormUseCase.Query(eli, "geltungszeitregel");
 
-      var norm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                           <akn:act name="regelungstext">
-                              <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                              </akn:body>
-                           </akn:act>
-                        </akn:akomaNtoso>
-                      """))
-              .build();
+      var norm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                    </akn:body>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(norm));
 
       // When
       assertThatThrownBy(() -> articleService.loadSpecificArticlesXmlFromNorm(query))
-
-          // Then
-          .isInstanceOf(
-              LoadSpecificArticlesXmlFromNormUseCase.ArticleOfTypeNotFoundException.class);
+        // Then
+        .isInstanceOf(LoadSpecificArticlesXmlFromNormUseCase.ArticleOfTypeNotFoundException.class);
 
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/ElementServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/ElementServiceTest.java
@@ -19,15 +19,20 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class ElementServiceTest {
+
   final LoadNormPort loadNormPort = mock(LoadNormPort.class);
   final XsltTransformationService xsltTransformationService = mock(XsltTransformationService.class);
   final TimeMachineService timeMachineService = mock(TimeMachineService.class);
 
-  final ElementService service =
-      new ElementService(loadNormPort, xsltTransformationService, timeMachineService);
+  final ElementService service = new ElementService(
+    loadNormPort,
+    xsltTransformationService,
+    timeMachineService
+  );
 
   @Nested
   class loadElementFromNorm {
+
     @Test
     void itLoadsAnElementFromANorm() {
       // Given
@@ -35,28 +40,28 @@ class ElementServiceTest {
       var eid = "meta-1";
 
       var normXml =
-          """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso
-                xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd">
-                <akn:act name="regelungstext">
-                  <!-- Metadaten -->
-                  <akn:meta eId="meta-1" GUID="000">
-                    <akn:identification eId="meta-1_ident-1" GUID="000" source="attributsemantik-noch-undefiniert">
-                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="000">
-                        <akn:FRBRthis
-                          eId="meta-1_ident-1_frbrexpression-1_frbrthis-1"
-                          GUID="000"
-                          value="eli/bund/bgbl-1/2000/s1/1970-01-01/1/deu/regelungstext-1"
-                        />
-                      </akn:FRBRExpression>
-                    </akn:identification>
-                  </akn:meta>
-                </akn:act>
-              </akn:akomaNtoso>
-              """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso
+          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd">
+          <akn:act name="regelungstext">
+            <!-- Metadaten -->
+            <akn:meta eId="meta-1" GUID="000">
+              <akn:identification eId="meta-1_ident-1" GUID="000" source="attributsemantik-noch-undefiniert">
+                <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="000">
+                  <akn:FRBRthis
+                    eId="meta-1_ident-1_frbrexpression-1_frbrthis-1"
+                    GUID="000"
+                    value="eli/bund/bgbl-1/2000/s1/1970-01-01/1/deu/regelungstext-1"
+                  />
+                </akn:FRBRExpression>
+              </akn:identification>
+            </akn:meta>
+          </akn:act>
+        </akn:akomaNtoso>
+        """;
 
       var norm = new Norm(XmlMapper.toDocument(normXml));
       when(loadNormPort.loadNorm(new LoadNormPort.Command(eli))).thenReturn(Optional.of(norm));
@@ -95,28 +100,28 @@ class ElementServiceTest {
       var eid = "meta-1000";
 
       var normXml =
-          """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso
-                xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd">
-                <akn:act name="regelungstext">
-                  <!-- Metadaten -->
-                  <akn:meta eId="meta-1" GUID="000">
-                    <akn:identification eId="meta-1_ident-1" GUID="000" source="attributsemantik-noch-undefiniert">
-                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="000">
-                        <akn:FRBRthis
-                          eId="meta-1_ident-1_frbrexpression-1_frbrthis-1"
-                          GUID="000"
-                          value="eli/bund/bgbl-1/2000/s1/1970-01-01/1/deu/regelungstext-1"
-                        />
-                      </akn:FRBRExpression>
-                    </akn:identification>
-                  </akn:meta>
-                </akn:act>
-              </akn:akomaNtoso>
-              """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso
+          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd">
+          <akn:act name="regelungstext">
+            <!-- Metadaten -->
+            <akn:meta eId="meta-1" GUID="000">
+              <akn:identification eId="meta-1_ident-1" GUID="000" source="attributsemantik-noch-undefiniert">
+                <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="000">
+                  <akn:FRBRthis
+                    eId="meta-1_ident-1_frbrexpression-1_frbrthis-1"
+                    GUID="000"
+                    value="eli/bund/bgbl-1/2000/s1/1970-01-01/1/deu/regelungstext-1"
+                  />
+                </akn:FRBRExpression>
+              </akn:identification>
+            </akn:meta>
+          </akn:act>
+        </akn:akomaNtoso>
+        """;
 
       var norm = new Norm(XmlMapper.toDocument(normXml));
       when(loadNormPort.loadNorm(new LoadNormPort.Command(eli))).thenReturn(Optional.of(norm));
@@ -133,6 +138,7 @@ class ElementServiceTest {
 
   @Nested
   class loadElementHtmlFromNorm {
+
     @Test
     void itLoadsTheElementHtmlFromANorm() {
       // Given
@@ -140,36 +146,37 @@ class ElementServiceTest {
       var eid = "meta-1";
 
       var normXml =
-          """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso
-                xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd">
-                <akn:act name="regelungstext">
-                  <!-- Metadaten -->
-                  <akn:meta eId="meta-1" GUID="000">
-                    <akn:identification eId="meta-1_ident-1" GUID="000" source="attributsemantik-noch-undefiniert">
-                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="000">
-                        <akn:FRBRthis
-                          eId="meta-1_ident-1_frbrexpression-1_frbrthis-1"
-                          GUID="000"
-                          value="eli/bund/bgbl-1/2000/s1/1970-01-01/1/deu/regelungstext-1"
-                        />
-                      </akn:FRBRExpression>
-                    </akn:identification>
-                  </akn:meta>
-                </akn:act>
-              </akn:akomaNtoso>
-              """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso
+          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd">
+          <akn:act name="regelungstext">
+            <!-- Metadaten -->
+            <akn:meta eId="meta-1" GUID="000">
+              <akn:identification eId="meta-1_ident-1" GUID="000" source="attributsemantik-noch-undefiniert">
+                <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="000">
+                  <akn:FRBRthis
+                    eId="meta-1_ident-1_frbrexpression-1_frbrthis-1"
+                    GUID="000"
+                    value="eli/bund/bgbl-1/2000/s1/1970-01-01/1/deu/regelungstext-1"
+                  />
+                </akn:FRBRExpression>
+              </akn:identification>
+            </akn:meta>
+          </akn:act>
+        </akn:akomaNtoso>
+        """;
 
       var norm = new Norm(XmlMapper.toDocument(normXml));
       when(loadNormPort.loadNorm(new LoadNormPort.Command(eli))).thenReturn(Optional.of(norm));
       when(xsltTransformationService.transformLegalDocMlToHtml(any())).thenReturn("<div></div>");
 
       // When
-      var html =
-          service.loadElementHtmlFromNorm(new LoadElementHtmlFromNormUseCase.Query(eli, eid));
+      var html = service.loadElementHtmlFromNorm(
+        new LoadElementHtmlFromNormUseCase.Query(eli, eid)
+      );
 
       // Then
       assertThat(html).contains("<div></div>");
@@ -187,8 +194,9 @@ class ElementServiceTest {
       when(loadNormPort.loadNorm(new LoadNormPort.Command(eli))).thenReturn(Optional.empty());
 
       // When
-      var element =
-          service.loadElementHtmlFromNorm(new LoadElementHtmlFromNormUseCase.Query(eli, eid));
+      var element = service.loadElementHtmlFromNorm(
+        new LoadElementHtmlFromNormUseCase.Query(eli, eid)
+      );
 
       // Then
       assertThat(element).isEmpty();
@@ -203,36 +211,37 @@ class ElementServiceTest {
       var eid = "meta-1000";
 
       var normXml =
-          """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso
-                xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd">
-                <akn:act name="regelungstext">
-                  <!-- Metadaten -->
-                  <akn:meta eId="meta-1" GUID="000">
-                    <akn:identification eId="meta-1_ident-1" GUID="000" source="attributsemantik-noch-undefiniert">
-                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="000">
-                        <akn:FRBRthis
-                          eId="meta-1_ident-1_frbrexpression-1_frbrthis-1"
-                          GUID="000"
-                          value="eli/bund/bgbl-1/2000/s1/1970-01-01/1/deu/regelungstext-1"
-                        />
-                      </akn:FRBRExpression>
-                    </akn:identification>
-                  </akn:meta>
-                </akn:act>
-              </akn:akomaNtoso>
-              """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso
+          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd">
+          <akn:act name="regelungstext">
+            <!-- Metadaten -->
+            <akn:meta eId="meta-1" GUID="000">
+              <akn:identification eId="meta-1_ident-1" GUID="000" source="attributsemantik-noch-undefiniert">
+                <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="000">
+                  <akn:FRBRthis
+                    eId="meta-1_ident-1_frbrexpression-1_frbrthis-1"
+                    GUID="000"
+                    value="eli/bund/bgbl-1/2000/s1/1970-01-01/1/deu/regelungstext-1"
+                  />
+                </akn:FRBRExpression>
+              </akn:identification>
+            </akn:meta>
+          </akn:act>
+        </akn:akomaNtoso>
+        """;
 
       var norm = new Norm(XmlMapper.toDocument(normXml));
       when(loadNormPort.loadNorm(new LoadNormPort.Command(eli))).thenReturn(Optional.of(norm));
       when(xsltTransformationService.transformLegalDocMlToHtml(any())).thenReturn("<div></div>");
 
       // When
-      var html =
-          service.loadElementHtmlFromNorm(new LoadElementHtmlFromNormUseCase.Query(eli, eid));
+      var html = service.loadElementHtmlFromNorm(
+        new LoadElementHtmlFromNormUseCase.Query(eli, eid)
+      );
 
       // Then
       assertThat(html).isEmpty();
@@ -243,6 +252,7 @@ class ElementServiceTest {
 
   @Nested
   class loadElementHtmlAtDateFromNorm {
+
     @Test
     void itLoadsTheElementHtmlAtTheDateFromTheNorm() {
       // Given
@@ -251,46 +261,49 @@ class ElementServiceTest {
       var date = Instant.parse("2099-12-31T00:00:00.00Z");
 
       var normXml =
-          """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso
-                xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd">
-                <akn:act name="regelungstext">
-                  <!-- Metadaten -->
-                  <akn:meta eId="meta-1" GUID="000">
-                    <akn:identification eId="meta-1_ident-1" GUID="000" source="attributsemantik-noch-undefiniert">
-                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="000">
-                        <akn:FRBRthis
-                          eId="meta-1_ident-1_frbrexpression-1_frbrthis-1"
-                          GUID="000"
-                          value="eli/bund/bgbl-1/2000/s1/1970-01-01/1/deu/regelungstext-1"
-                        />
-                      </akn:FRBRExpression>
-                    </akn:identification>
-                  </akn:meta>
-                </akn:act>
-              </akn:akomaNtoso>
-              """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso
+          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd">
+          <akn:act name="regelungstext">
+            <!-- Metadaten -->
+            <akn:meta eId="meta-1" GUID="000">
+              <akn:identification eId="meta-1_ident-1" GUID="000" source="attributsemantik-noch-undefiniert">
+                <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="000">
+                  <akn:FRBRthis
+                    eId="meta-1_ident-1_frbrexpression-1_frbrthis-1"
+                    GUID="000"
+                    value="eli/bund/bgbl-1/2000/s1/1970-01-01/1/deu/regelungstext-1"
+                  />
+                </akn:FRBRExpression>
+              </akn:identification>
+            </akn:meta>
+          </akn:act>
+        </akn:akomaNtoso>
+        """;
 
       var norm = new Norm(XmlMapper.toDocument(normXml));
       when(loadNormPort.loadNorm(new LoadNormPort.Command(eli))).thenReturn(Optional.of(norm));
-      when(timeMachineService.applyPassiveModifications(
-              new ApplyPassiveModificationsUseCase.Query(norm, date)))
-          .thenReturn(norm);
+      when(
+        timeMachineService.applyPassiveModifications(
+          new ApplyPassiveModificationsUseCase.Query(norm, date)
+        )
+      )
+        .thenReturn(norm);
       when(xsltTransformationService.transformLegalDocMlToHtml(any())).thenReturn("<div></div>");
 
       // When
-      var html =
-          service.loadElementHtmlAtDateFromNorm(
-              new LoadElementHtmlAtDateFromNormUseCase.Query(eli, eid, date));
+      var html = service.loadElementHtmlAtDateFromNorm(
+        new LoadElementHtmlAtDateFromNormUseCase.Query(eli, eid, date)
+      );
 
       // Then
       assertThat(html).contains("<div></div>");
       verify(loadNormPort).loadNorm(new LoadNormPort.Command(eli));
       verify(timeMachineService)
-          .applyPassiveModifications(new ApplyPassiveModificationsUseCase.Query(norm, date));
+        .applyPassiveModifications(new ApplyPassiveModificationsUseCase.Query(norm, date));
       verify(xsltTransformationService, times(1)).transformLegalDocMlToHtml(any());
     }
 
@@ -304,9 +317,9 @@ class ElementServiceTest {
       when(loadNormPort.loadNorm(new LoadNormPort.Command(eli))).thenReturn(Optional.empty());
 
       // When
-      var html =
-          service.loadElementHtmlAtDateFromNorm(
-              new LoadElementHtmlAtDateFromNormUseCase.Query(eli, eid, date));
+      var html = service.loadElementHtmlAtDateFromNorm(
+        new LoadElementHtmlAtDateFromNormUseCase.Query(eli, eid, date)
+      );
 
       // Then
       assertThat(html).isEmpty();
@@ -321,51 +334,55 @@ class ElementServiceTest {
       var date = Instant.parse("2099-12-31T00:00:00.00Z");
 
       var normXml =
-          """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso
-                xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd">
-                <akn:act name="regelungstext">
-                  <!-- Metadaten -->
-                  <akn:meta eId="meta-1" GUID="000">
-                    <akn:identification eId="meta-1_ident-1" GUID="000" source="attributsemantik-noch-undefiniert">
-                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="000">
-                        <akn:FRBRthis
-                          eId="meta-1_ident-1_frbrexpression-1_frbrthis-1"
-                          GUID="000"
-                          value="eli/bund/bgbl-1/2000/s1/1970-01-01/1/deu/regelungstext-1"
-                        />
-                      </akn:FRBRExpression>
-                    </akn:identification>
-                  </akn:meta>
-                </akn:act>
-              </akn:akomaNtoso>
-              """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso
+          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd">
+          <akn:act name="regelungstext">
+            <!-- Metadaten -->
+            <akn:meta eId="meta-1" GUID="000">
+              <akn:identification eId="meta-1_ident-1" GUID="000" source="attributsemantik-noch-undefiniert">
+                <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="000">
+                  <akn:FRBRthis
+                    eId="meta-1_ident-1_frbrexpression-1_frbrthis-1"
+                    GUID="000"
+                    value="eli/bund/bgbl-1/2000/s1/1970-01-01/1/deu/regelungstext-1"
+                  />
+                </akn:FRBRExpression>
+              </akn:identification>
+            </akn:meta>
+          </akn:act>
+        </akn:akomaNtoso>
+        """;
 
       var norm = new Norm(XmlMapper.toDocument(normXml));
       when(loadNormPort.loadNorm(new LoadNormPort.Command(eli))).thenReturn(Optional.of(norm));
-      when(timeMachineService.applyPassiveModifications(
-              new ApplyPassiveModificationsUseCase.Query(norm, date)))
-          .thenReturn(norm);
+      when(
+        timeMachineService.applyPassiveModifications(
+          new ApplyPassiveModificationsUseCase.Query(norm, date)
+        )
+      )
+        .thenReturn(norm);
       when(xsltTransformationService.transformLegalDocMlToHtml(any())).thenReturn("<div></div>");
 
       // When
-      var html =
-          service.loadElementHtmlAtDateFromNorm(
-              new LoadElementHtmlAtDateFromNormUseCase.Query(eli, eid, date));
+      var html = service.loadElementHtmlAtDateFromNorm(
+        new LoadElementHtmlAtDateFromNormUseCase.Query(eli, eid, date)
+      );
 
       // Then
       assertThat(html).isEmpty();
       verify(loadNormPort).loadNorm(new LoadNormPort.Command(eli));
       verify(timeMachineService)
-          .applyPassiveModifications(new ApplyPassiveModificationsUseCase.Query(norm, date));
+        .applyPassiveModifications(new ApplyPassiveModificationsUseCase.Query(norm, date));
     }
   }
 
   @Nested
   class loadElementsByTypeFromNorm {
+
     @Test
     void returnsAllSupportedTypesFromANorm() {
       // Given
@@ -373,10 +390,12 @@ class ElementServiceTest {
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(norm));
 
       // When
-      var elements =
-          service.loadElementsByTypeFromNorm(
-              new LoadElementsByTypeFromNormUseCase.Query(
-                  "fake/eli", List.of("preface", "preamble", "article", "conclusions")));
+      var elements = service.loadElementsByTypeFromNorm(
+        new LoadElementsByTypeFromNormUseCase.Query(
+          "fake/eli",
+          List.of("preface", "preamble", "article", "conclusions")
+        )
+      );
 
       // Then
       assertThat(elements).hasSize(5);
@@ -396,9 +415,9 @@ class ElementServiceTest {
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(norm));
 
       // When
-      var elements =
-          service.loadElementsByTypeFromNorm(
-              new LoadElementsByTypeFromNormUseCase.Query("fake/eli", List.of("article")));
+      var elements = service.loadElementsByTypeFromNorm(
+        new LoadElementsByTypeFromNormUseCase.Query("fake/eli", List.of("article"))
+      );
 
       // Then
       assertThat(elements).hasSize(2);
@@ -413,9 +432,9 @@ class ElementServiceTest {
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(norm));
 
       // When
-      var elements =
-          service.loadElementsByTypeFromNorm(
-              new LoadElementsByTypeFromNormUseCase.Query("fake/eli", List.of("preface")));
+      var elements = service.loadElementsByTypeFromNorm(
+        new LoadElementsByTypeFromNormUseCase.Query("fake/eli", List.of("preface"))
+      );
 
       // Then
       assertThat(elements).isEmpty();
@@ -428,9 +447,9 @@ class ElementServiceTest {
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(norm));
 
       // When
-      var elements =
-          service.loadElementsByTypeFromNorm(
-              new LoadElementsByTypeFromNormUseCase.Query("fake/eli", List.of()));
+      var elements = service.loadElementsByTypeFromNorm(
+        new LoadElementsByTypeFromNormUseCase.Query("fake/eli", List.of())
+      );
 
       // Then
       assertThat(elements).isEmpty();
@@ -443,12 +462,12 @@ class ElementServiceTest {
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(norm));
 
       // When / Then
-      assertThatThrownBy(
-              () ->
-                  service.loadElementsByTypeFromNorm(
-                      new LoadElementsByTypeFromNormUseCase.Query(
-                          "fake/eli", List.of("invalid_type"))))
-          .isInstanceOf(LoadElementsByTypeFromNormUseCase.UnsupportedElementTypeException.class);
+      assertThatThrownBy(() ->
+          service.loadElementsByTypeFromNorm(
+            new LoadElementsByTypeFromNormUseCase.Query("fake/eli", List.of("invalid_type"))
+          )
+        )
+        .isInstanceOf(LoadElementsByTypeFromNormUseCase.UnsupportedElementTypeException.class);
     }
 
     @Test
@@ -456,30 +475,34 @@ class ElementServiceTest {
       // Given
       // Nothing given -> Loading should fail
 
-      LoadElementsByTypeFromNormUseCase.Query query =
-          new LoadElementsByTypeFromNormUseCase.Query("fake/eli", List.of("article"));
+      LoadElementsByTypeFromNormUseCase.Query query = new LoadElementsByTypeFromNormUseCase.Query(
+        "fake/eli",
+        List.of("article")
+      );
 
       // When / Then
       assertThatThrownBy(() -> service.loadElementsByTypeFromNorm(query))
-          .isInstanceOf(NormNotFoundException.class);
+        .isInstanceOf(NormNotFoundException.class);
     }
 
     @Test
     void filtersReturnedElementsByAmendingNorm() {
       // Given
-      var targetNorm =
-          NormFixtures.loadFromDisk("NormWithPassiveModificationsInDifferentArticles.xml");
+      var targetNorm = NormFixtures.loadFromDisk(
+        "NormWithPassiveModificationsInDifferentArticles.xml"
+      );
       var targetNormEli = targetNorm.getEli();
       when(loadNormPort.loadNorm(new LoadNormPort.Command(targetNormEli)))
-          .thenReturn(Optional.of(targetNorm));
+        .thenReturn(Optional.of(targetNorm));
 
       // When
-      var elements =
-          service.loadElementsByTypeFromNorm(
-              new LoadElementsByTypeFromNormUseCase.Query(
-                  targetNormEli,
-                  List.of("preface", "preamble", "article", "conclusions"),
-                  "eli/bund/bgbl-1/2017/s815/1995-03-15/1/deu/regelungstext-1"));
+      var elements = service.loadElementsByTypeFromNorm(
+        new LoadElementsByTypeFromNormUseCase.Query(
+          targetNormEli,
+          List.of("preface", "preamble", "article", "conclusions"),
+          "eli/bund/bgbl-1/2017/s815/1995-03-15/1/deu/regelungstext-1"
+        )
+      );
 
       // Then
       assertThat(elements).hasSize(1);
@@ -491,18 +514,21 @@ class ElementServiceTest {
       // Given
       var targetNorm = NormFixtures.loadFromDisk("NormWithMultiplePassiveModifications.xml");
       var targetNormEli = targetNorm.getEli();
-      when(loadNormPort.loadNorm(
-              new LoadNormPort.Command(
-                  "eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1")))
-          .thenReturn(Optional.of(targetNorm));
+      when(
+        loadNormPort.loadNorm(
+          new LoadNormPort.Command("eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1")
+        )
+      )
+        .thenReturn(Optional.of(targetNorm));
 
       // When
-      var elements =
-          service.loadElementsByTypeFromNorm(
-              new LoadElementsByTypeFromNormUseCase.Query(
-                  targetNormEli,
-                  List.of("preface", "preamble", "article", "conclusions"),
-                  "fake/eli"));
+      var elements = service.loadElementsByTypeFromNorm(
+        new LoadElementsByTypeFromNormUseCase.Query(
+          targetNormEli,
+          List.of("preface", "preamble", "article", "conclusions"),
+          "fake/eli"
+        )
+      );
 
       // Then
       assertThat(elements).isEmpty();
@@ -511,6 +537,7 @@ class ElementServiceTest {
 
   @Nested
   class elementType {
+
     @Test
     void returnsTheEnumValueForSupportedTypes() {
       // When
@@ -524,7 +551,7 @@ class ElementServiceTest {
     void throwsWhenAttemptingToGetTheValueForAnUnsupportedType() {
       // When / Then
       assertThatThrownBy(() -> ElementService.ElementType.fromLabel("invalid_type"))
-          .isInstanceOf(LoadElementsByTypeFromNormUseCase.UnsupportedElementTypeException.class);
+        .isInstanceOf(LoadElementsByTypeFromNormUseCase.UnsupportedElementTypeException.class);
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/LoadZf0ServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/LoadZf0ServiceTest.java
@@ -22,12 +22,15 @@ class LoadZf0ServiceTest {
   final LoadNormByGuidPort loadNormByGuidPort = mock(LoadNormByGuidPort.class);
   final UpdateOrSaveNormPort updateOrSaveNormPort = mock(UpdateOrSaveNormPort.class);
   final LoadNormPort loadNormPort = mock(LoadNormPort.class);
-  final LoadZf0Service loadZf0Service =
-      new LoadZf0Service(updateNormService, loadNormByGuidPort, updateOrSaveNormPort, loadNormPort);
+  final LoadZf0Service loadZf0Service = new LoadZf0Service(
+    updateNormService,
+    loadNormByGuidPort,
+    updateOrSaveNormPort,
+    loadNormPort
+  );
 
   @Test
   void itLoadsZf0FromDB() {
-
     // Given
     final Norm amendingLaw = NormFixtures.loadFromDisk("NormWithMods.xml");
     final Norm targetLaw = NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml");
@@ -35,8 +38,9 @@ class LoadZf0ServiceTest {
     when(loadNormByGuidPort.loadNormByGuid(any())).thenReturn(Optional.of(zf0Law));
 
     // When
-    final Norm zf0NormLoaded =
-        loadZf0Service.loadOrCreateZf0(new LoadZf0UseCase.Query(amendingLaw, targetLaw));
+    final Norm zf0NormLoaded = loadZf0Service.loadOrCreateZf0(
+      new LoadZf0UseCase.Query(amendingLaw, targetLaw)
+    );
 
     // Then
     assertThat(zf0Law).isEqualTo(zf0NormLoaded);
@@ -44,173 +48,171 @@ class LoadZf0ServiceTest {
 
   @Test
   void itSuccessfullyCreatesZf0OutOfTargetLaw() {
-
     // Given
     final Norm amendingLaw = NormFixtures.loadFromDisk("NormWithMods.xml");
     final Norm targetLaw = NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml");
 
     // When
-    final Norm zf0Norm =
-        loadZf0Service.loadOrCreateZf0(new LoadZf0UseCase.Query(amendingLaw, targetLaw));
+    final Norm zf0Norm = loadZf0Service.loadOrCreateZf0(
+      new LoadZf0UseCase.Query(amendingLaw, targetLaw)
+    );
 
     // Then
     final FRBRExpression frbrExpressionTargetLaw = targetLaw.getMeta().getFRBRExpression();
     final FRBRExpression frbrExpressionZf0Law = zf0Norm.getMeta().getFRBRExpression();
     assertThat(frbrExpressionZf0Law.getFRBRaliasPreviousVersionId())
-        .isNotEmpty()
-        .contains(frbrExpressionTargetLaw.getFRBRaliasCurrentVersionId());
+      .isNotEmpty()
+      .contains(frbrExpressionTargetLaw.getFRBRaliasCurrentVersionId());
     assertThat(frbrExpressionZf0Law.getFRBRaliasCurrentVersionId())
-        .isEqualTo(frbrExpressionTargetLaw.getFRBRaliasNextVersionId());
+      .isEqualTo(frbrExpressionTargetLaw.getFRBRaliasNextVersionId());
     assertThat(frbrExpressionZf0Law.getFRBRaliasNextVersionId()).isNotNull();
     assertThat(frbrExpressionZf0Law.getEli())
-        .contains(amendingLaw.getMeta().getFRBRWork().getFBRDate());
+      .contains(amendingLaw.getMeta().getFRBRWork().getFBRDate());
     assertThat(frbrExpressionZf0Law.getFBRDate())
-        .isEqualTo(amendingLaw.getMeta().getFRBRWork().getFBRDate());
+      .isEqualTo(amendingLaw.getMeta().getFRBRWork().getFBRDate());
 
     final FRBRManifestation frbrManifestationZf0Law = zf0Norm.getMeta().getFRBRManifestation();
     assertThat(frbrManifestationZf0Law.getEli()).contains(frbrExpressionZf0Law.getEli());
     assertThat(frbrManifestationZf0Law.getFBRDate()).isEqualTo(LocalDate.now().toString());
 
     assertThat(
-            targetLaw
-                .getMeta()
-                .getAnalysis()
-                .map(analysis -> analysis.getPassiveModifications().stream())
-                .orElse(Stream.empty()))
-        .isEmpty();
+      targetLaw
+        .getMeta()
+        .getAnalysis()
+        .map(analysis -> analysis.getPassiveModifications().stream())
+        .orElse(Stream.empty())
+    )
+      .isEmpty();
     assertThat(
-            zf0Norm
-                .getMeta()
-                .getAnalysis()
-                .map(analysis -> analysis.getPassiveModifications().stream())
-                .orElse(Stream.empty()))
-        .hasSize(1);
-    final TextualMod activeMod =
-        amendingLaw
-            .getMeta()
-            .getAnalysis()
-            .map(analysis -> analysis.getActiveModifications().stream())
-            .orElse(Stream.empty())
-            .toList()
-            .getFirst();
-    final TextualMod passiveMod =
-        zf0Norm
-            .getMeta()
-            .getAnalysis()
-            .map(analysis -> analysis.getPassiveModifications().stream())
-            .orElse(Stream.empty())
-            .toList()
-            .getFirst();
+      zf0Norm
+        .getMeta()
+        .getAnalysis()
+        .map(analysis -> analysis.getPassiveModifications().stream())
+        .orElse(Stream.empty())
+    )
+      .hasSize(1);
+    final TextualMod activeMod = amendingLaw
+      .getMeta()
+      .getAnalysis()
+      .map(analysis -> analysis.getActiveModifications().stream())
+      .orElse(Stream.empty())
+      .toList()
+      .getFirst();
+    final TextualMod passiveMod = zf0Norm
+      .getMeta()
+      .getAnalysis()
+      .map(analysis -> analysis.getPassiveModifications().stream())
+      .orElse(Stream.empty())
+      .toList()
+      .getFirst();
     assertThat(passiveMod.getType()).isEqualTo(activeMod.getType());
     assertThat(passiveMod.getSourceHref().orElseThrow().getEli().orElseThrow())
-        .isEqualTo(amendingLaw.getEli());
+      .isEqualTo(amendingLaw.getEli());
     assertThat(passiveMod.getDestinationHref().orElseThrow().getEId())
-        .isEqualTo(activeMod.getDestinationHref().orElseThrow().getEId());
+      .isEqualTo(activeMod.getDestinationHref().orElseThrow().getEId());
     assertThat(passiveMod.getForcePeriodEid()).isNotEmpty();
   }
 
   @Test
   void itSuccessfullyCreatesZf0OutOfQuotedStructureWithUpToMods() {
-
     // Given
     final Norm amendingLaw = NormFixtures.loadFromDisk("NormWithQuotedStructureModsAndUpTo.xml");
-    final Norm targetLaw =
-        NormFixtures.loadFromDisk("NormWithoutPassiveModsQuotedStructureAndUpTo.xml");
+    final Norm targetLaw = NormFixtures.loadFromDisk(
+      "NormWithoutPassiveModsQuotedStructureAndUpTo.xml"
+    );
 
     // When
-    final Norm zf0Norm =
-        loadZf0Service.loadOrCreateZf0(new LoadZf0UseCase.Query(amendingLaw, targetLaw));
+    final Norm zf0Norm = loadZf0Service.loadOrCreateZf0(
+      new LoadZf0UseCase.Query(amendingLaw, targetLaw)
+    );
 
     // Then
     final FRBRExpression frbrExpressionTargetLaw = targetLaw.getMeta().getFRBRExpression();
     final FRBRExpression frbrExpressionZf0Law = zf0Norm.getMeta().getFRBRExpression();
     assertThat(frbrExpressionZf0Law.getFRBRaliasPreviousVersionId())
-        .isNotEmpty()
-        .contains(frbrExpressionTargetLaw.getFRBRaliasCurrentVersionId());
+      .isNotEmpty()
+      .contains(frbrExpressionTargetLaw.getFRBRaliasCurrentVersionId());
     assertThat(frbrExpressionZf0Law.getFRBRaliasCurrentVersionId())
-        .isEqualTo(frbrExpressionTargetLaw.getFRBRaliasNextVersionId());
+      .isEqualTo(frbrExpressionTargetLaw.getFRBRaliasNextVersionId());
     assertThat(frbrExpressionZf0Law.getFRBRaliasNextVersionId()).isNotNull();
     assertThat(frbrExpressionZf0Law.getEli())
-        .contains(amendingLaw.getMeta().getFRBRWork().getFBRDate());
+      .contains(amendingLaw.getMeta().getFRBRWork().getFBRDate());
     assertThat(frbrExpressionZf0Law.getFBRDate())
-        .isEqualTo(amendingLaw.getMeta().getFRBRWork().getFBRDate());
+      .isEqualTo(amendingLaw.getMeta().getFRBRWork().getFBRDate());
 
     final FRBRManifestation frbrManifestationZf0Law = zf0Norm.getMeta().getFRBRManifestation();
     assertThat(frbrManifestationZf0Law.getEli()).contains(frbrExpressionZf0Law.getEli());
     assertThat(frbrManifestationZf0Law.getFBRDate()).isEqualTo(LocalDate.now().toString());
 
     assertThat(
-            targetLaw
-                .getMeta()
-                .getAnalysis()
-                .map(analysis -> analysis.getPassiveModifications().stream())
-                .orElse(Stream.empty()))
-        .isEmpty();
+      targetLaw
+        .getMeta()
+        .getAnalysis()
+        .map(analysis -> analysis.getPassiveModifications().stream())
+        .orElse(Stream.empty())
+    )
+      .isEmpty();
     assertThat(
-            zf0Norm
-                .getMeta()
-                .getAnalysis()
-                .map(analysis -> analysis.getPassiveModifications().stream())
-                .orElse(Stream.empty()))
-        .hasSize(2);
-    final TextualMod firstActiveMod =
-        amendingLaw
-            .getMeta()
-            .getAnalysis()
-            .map(analysis -> analysis.getActiveModifications().stream())
-            .orElse(Stream.empty())
-            .toList()
-            .getFirst();
-    final TextualMod firstPassiveMod =
-        zf0Norm
-            .getMeta()
-            .getAnalysis()
-            .map(analysis -> analysis.getPassiveModifications().stream())
-            .orElse(Stream.empty())
-            .toList()
-            .getFirst();
+      zf0Norm
+        .getMeta()
+        .getAnalysis()
+        .map(analysis -> analysis.getPassiveModifications().stream())
+        .orElse(Stream.empty())
+    )
+      .hasSize(2);
+    final TextualMod firstActiveMod = amendingLaw
+      .getMeta()
+      .getAnalysis()
+      .map(analysis -> analysis.getActiveModifications().stream())
+      .orElse(Stream.empty())
+      .toList()
+      .getFirst();
+    final TextualMod firstPassiveMod = zf0Norm
+      .getMeta()
+      .getAnalysis()
+      .map(analysis -> analysis.getPassiveModifications().stream())
+      .orElse(Stream.empty())
+      .toList()
+      .getFirst();
     assertThat(firstPassiveMod.getType()).isEqualTo(firstActiveMod.getType());
     assertThat(firstPassiveMod.getSourceHref().orElseThrow().getEli().orElseThrow())
-        .isEqualTo(amendingLaw.getEli());
+      .isEqualTo(amendingLaw.getEli());
     assertThat(firstPassiveMod.getDestinationHref().orElseThrow().getEId())
-        .isEqualTo(firstActiveMod.getDestinationHref().orElseThrow().getEId());
+      .isEqualTo(firstActiveMod.getDestinationHref().orElseThrow().getEId());
     assertThat(firstPassiveMod.getForcePeriodEid()).isNotEmpty();
     assertThat(firstActiveMod.getDestinationHref().orElseThrow().getEId().orElseThrow())
-        .isEqualTo(firstPassiveMod.getDestinationHref().orElseThrow().toString().replace("#", ""));
+      .isEqualTo(firstPassiveMod.getDestinationHref().orElseThrow().toString().replace("#", ""));
     assertThat(firstActiveMod.getDestinationUpTo().orElseThrow().getEId().orElseThrow())
-        .isEqualTo(firstPassiveMod.getDestinationUpTo().orElseThrow().toString().replace("#", ""));
+      .isEqualTo(firstPassiveMod.getDestinationUpTo().orElseThrow().toString().replace("#", ""));
 
-    final TextualMod secondActiveMod =
-        amendingLaw
-            .getMeta()
-            .getAnalysis()
-            .map(analysis -> analysis.getActiveModifications().stream())
-            .orElse(Stream.empty())
-            .toList()
-            .getLast();
-    final TextualMod secondPassiveMod =
-        zf0Norm
-            .getMeta()
-            .getAnalysis()
-            .map(analysis -> analysis.getPassiveModifications().stream())
-            .orElse(Stream.empty())
-            .toList()
-            .getLast();
+    final TextualMod secondActiveMod = amendingLaw
+      .getMeta()
+      .getAnalysis()
+      .map(analysis -> analysis.getActiveModifications().stream())
+      .orElse(Stream.empty())
+      .toList()
+      .getLast();
+    final TextualMod secondPassiveMod = zf0Norm
+      .getMeta()
+      .getAnalysis()
+      .map(analysis -> analysis.getPassiveModifications().stream())
+      .orElse(Stream.empty())
+      .toList()
+      .getLast();
     assertThat(secondPassiveMod.getType()).isEqualTo(secondActiveMod.getType());
     assertThat(secondPassiveMod.getSourceHref().orElseThrow().getEli().orElseThrow())
-        .isEqualTo(amendingLaw.getEli());
+      .isEqualTo(amendingLaw.getEli());
     assertThat(secondPassiveMod.getDestinationHref().orElseThrow().getEId())
-        .isEqualTo(secondActiveMod.getDestinationHref().orElseThrow().getEId());
+      .isEqualTo(secondActiveMod.getDestinationHref().orElseThrow().getEId());
     assertThat(secondPassiveMod.getForcePeriodEid()).isNotEmpty();
     assertThat(secondActiveMod.getDestinationHref().orElseThrow().getEId().orElseThrow())
-        .isEqualTo(secondPassiveMod.getDestinationHref().orElseThrow().toString().replace("#", ""));
+      .isEqualTo(secondPassiveMod.getDestinationHref().orElseThrow().toString().replace("#", ""));
     assertThat(secondPassiveMod.getDestinationUpTo().orElseThrow().getEId().orElseThrow())
-        .isEqualTo(secondPassiveMod.getDestinationUpTo().orElseThrow().toString().replace("#", ""));
+      .isEqualTo(secondPassiveMod.getDestinationUpTo().orElseThrow().toString().replace("#", ""));
   }
 
   @Test
   void itLoadsTargetLawFromDB() {
-
     // Given
     final Norm amendingLaw = NormFixtures.loadFromDisk("NormWithMods.xml");
     final Norm targetLaw = NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml");
@@ -229,7 +231,6 @@ class LoadZf0ServiceTest {
 
   @Test
   void throwExceptionWhenEliIsEmpty() {
-
     // Given
     final Norm amendingLaw = NormFixtures.loadFromDisk("NormWithMods.xml");
     final Norm targetLaw = NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml");
@@ -244,8 +245,9 @@ class LoadZf0ServiceTest {
 
     // then
     assertThat(thrown)
-        .isInstanceOf(ValidationException.class)
-        .hasMessageContaining(
-            "Cannot read target norm eli from mod Optional[hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1]");
+      .isInstanceOf(ValidationException.class)
+      .hasMessageContaining(
+        "Cannot read target norm eli from mod Optional[hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1]"
+      );
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/NormServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/NormServiceTest.java
@@ -31,14 +31,14 @@ class NormServiceTest {
   final LoadZf0Service loadZf0Service = mock(LoadZf0Service.class);
   final UpdateOrSaveNormPort updateOrSaveNormPort = mock(UpdateOrSaveNormPort.class);
 
-  final NormService service =
-      new NormService(
-          loadNormPort,
-          updateNormPort,
-          singleModValidator,
-          updateNormService,
-          loadZf0Service,
-          updateOrSaveNormPort);
+  final NormService service = new NormService(
+    loadNormPort,
+    updateNormPort,
+    singleModValidator,
+    updateNormService,
+    loadZf0Service,
+    updateOrSaveNormPort
+  );
 
   @Nested
   class loadNorm {
@@ -48,28 +48,30 @@ class NormServiceTest {
       // Given
       var eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
 
-      var norm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                               <akn:act name="regelungstext">
-                                  <!-- Metadaten -->
-                                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                        </akn:FRBRExpression>
-                                    </akn:identification>
-                                  </akn:meta>
-                               </akn:act>
-                            </akn:akomaNtoso>
-                          """))
-              .build();
+      var norm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(norm));
 
       // When
@@ -77,7 +79,7 @@ class NormServiceTest {
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
       assertThat(returnedNorm).isEqualTo(norm);
     }
 
@@ -90,12 +92,11 @@ class NormServiceTest {
 
       // When
       assertThatThrownBy(() -> service.loadNorm(query))
-
-          // Then
-          .isInstanceOf(NormNotFoundException.class);
+        // Then
+        .isInstanceOf(NormNotFoundException.class);
 
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
     }
   }
 
@@ -107,28 +108,30 @@ class NormServiceTest {
       // Given
       var eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
 
-      var norm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-               <akn:act name="regelungstext">
-                  <!-- Metadaten -->
-                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                        </akn:FRBRExpression>
-                    </akn:identification>
-                  </akn:meta>
-               </akn:act>
-            </akn:akomaNtoso>
-          """))
-              .build();
+      var norm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(norm));
 
       // When
@@ -136,7 +139,7 @@ class NormServiceTest {
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
       assertThat(xml).isPresent();
       assertThat(xml.get()).contains("eId=\"meta-1_ident-1_frbrexpression-1_frbrthis-1\"");
     }
@@ -152,7 +155,7 @@ class NormServiceTest {
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
       assertThat(xml).isEmpty();
     }
   }
@@ -166,73 +169,73 @@ class NormServiceTest {
       var eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
 
       var oldXml =
-          """
-          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-             <akn:act name="regelungstext">
-                <!-- Metadaten -->
-                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                         <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                      </akn:FRBRExpression>
-                  </akn:identification>
-                </akn:meta>
-                <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
-                    <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
-                       <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
-                          <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
-                          <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
-                          Innern</akn:docProponent>
-                          <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
-                       </akn:p>
-                    </akn:longTitle>
-                    <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
-                       <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
-                    </akn:block>
-                 </akn:preface>
-             </akn:act>
-          </akn:akomaNtoso>
-          """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                       <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                    </akn:FRBRExpression>
+                </akn:identification>
+              </akn:meta>
+              <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                  <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                     <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                        <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
+                        <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
+                        Innern</akn:docProponent>
+                        <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
+                     </akn:p>
+                  </akn:longTitle>
+                  <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                     <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
+                  </akn:block>
+               </akn:preface>
+           </akn:act>
+        </akn:akomaNtoso>
+        """;
       var newXml =
-          """
-          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-             <akn:act name="regelungstext">
-                <!-- Metadaten -->
-                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                         <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                      </akn:FRBRExpression>
-                  </akn:identification>
-                </akn:meta>
-                <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
-                    <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
-                       <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
-                          <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
-                          <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
-                          Innern</akn:docProponent>
-                          <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Dritten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
-                       </akn:p>
-                    </akn:longTitle>
-                    <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
-                       <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
-                    </akn:block>
-                 </akn:preface>
-             </akn:act>
-          </akn:akomaNtoso>
-          """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                       <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                    </akn:FRBRExpression>
+                </akn:identification>
+              </akn:meta>
+              <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                  <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                     <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                        <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
+                        <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
+                        Innern</akn:docProponent>
+                        <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Dritten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
+                     </akn:p>
+                  </akn:longTitle>
+                  <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                     <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
+                  </akn:block>
+               </akn:preface>
+           </akn:act>
+        </akn:akomaNtoso>
+        """;
       var oldNorm = Norm.builder().document(XmlMapper.toDocument(oldXml)).build();
       var newNorm = Norm.builder().document(XmlMapper.toDocument(newXml)).build();
 
@@ -244,12 +247,12 @@ class NormServiceTest {
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
       verify(updateNormPort, times(1))
-          .updateNorm(argThat(argument -> Objects.equals(argument.norm(), newNorm)));
+        .updateNorm(argThat(argument -> Objects.equals(argument.norm(), newNorm)));
       assertThat(result).isPresent();
       assertThat(result.get())
-          .contains("Entwurf eines Dritten Gesetzes zur Änderung des Vereinsgesetzes");
+        .contains("Entwurf eines Dritten Gesetzes zur Änderung des Vereinsgesetzes");
     }
 
     @Test
@@ -258,39 +261,39 @@ class NormServiceTest {
       var eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
 
       var newXml =
-          """
-          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-             <akn:act name="regelungstext">
-                <!-- Metadaten -->
-                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                         <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                      </akn:FRBRExpression>
-                  </akn:identification>
-                </akn:meta>
-                <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
-                    <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
-                       <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
-                          <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
-                          <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
-                          Innern</akn:docProponent>
-                          <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Dritten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
-                       </akn:p>
-                    </akn:longTitle>
-                    <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
-                       <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
-                    </akn:block>
-                 </akn:preface>
-             </akn:act>
-          </akn:akomaNtoso>
-          """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                       <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                    </akn:FRBRExpression>
+                </akn:identification>
+              </akn:meta>
+              <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                  <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                     <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                        <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
+                        <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
+                        Innern</akn:docProponent>
+                        <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Dritten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
+                     </akn:p>
+                  </akn:longTitle>
+                  <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                     <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
+                  </akn:block>
+               </akn:preface>
+           </akn:act>
+        </akn:akomaNtoso>
+        """;
 
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.empty());
 
@@ -299,7 +302,7 @@ class NormServiceTest {
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
       verify(updateNormPort, times(0)).updateNorm(any());
       assertThat(result).isEmpty();
     }
@@ -310,84 +313,85 @@ class NormServiceTest {
       var eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
 
       var oldXml =
-          """
-          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-             <akn:act name="regelungstext">
-                <!-- Metadaten -->
-                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                         <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                      </akn:FRBRExpression>
-                  </akn:identification>
-                </akn:meta>
-                <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
-                    <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
-                       <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
-                          <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
-                          <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
-                          Innern</akn:docProponent>
-                          <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
-                       </akn:p>
-                    </akn:longTitle>
-                    <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
-                       <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
-                    </akn:block>
-                 </akn:preface>
-             </akn:act>
-          </akn:akomaNtoso>
-          """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                       <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                    </akn:FRBRExpression>
+                </akn:identification>
+              </akn:meta>
+              <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                  <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                     <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                        <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
+                        <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
+                        Innern</akn:docProponent>
+                        <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
+                     </akn:p>
+                  </akn:longTitle>
+                  <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                     <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
+                  </akn:block>
+               </akn:preface>
+           </akn:act>
+        </akn:akomaNtoso>
+        """;
       var newXml =
-          """
-          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-             <akn:act name="regelungstext">
-                <!-- Metadaten -->
-                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2000-01-01/1/deu/regelungstext-1" />
-                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                         <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                      </akn:FRBRExpression>
-                  </akn:identification>
-                </akn:meta>
-                <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
-                    <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
-                       <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
-                          <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
-                          <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
-                          Innern</akn:docProponent>
-                          <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Dritten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
-                       </akn:p>
-                    </akn:longTitle>
-                    <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
-                       <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
-                    </akn:block>
-                 </akn:preface>
-             </akn:act>
-          </akn:akomaNtoso>
-          """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2000-01-01/1/deu/regelungstext-1" />
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                       <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                    </akn:FRBRExpression>
+                </akn:identification>
+              </akn:meta>
+              <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                  <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                     <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                        <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
+                        <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
+                        Innern</akn:docProponent>
+                        <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Dritten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
+                     </akn:p>
+                  </akn:longTitle>
+                  <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                     <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
+                  </akn:block>
+               </akn:preface>
+           </akn:act>
+        </akn:akomaNtoso>
+        """;
       var oldNorm = Norm.builder().document(XmlMapper.toDocument(oldXml)).build();
 
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(oldNorm));
 
       // When
-      var thrown =
-          catchThrowable(() -> service.updateNormXml(new UpdateNormXmlUseCase.Query(eli, newXml)));
+      var thrown = catchThrowable(() ->
+        service.updateNormXml(new UpdateNormXmlUseCase.Query(eli, newXml))
+      );
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
       verify(updateNormPort, times(0)).updateNorm(any());
       assertThat(thrown).isInstanceOf(UpdateNormXmlUseCase.InvalidUpdateException.class);
     }
@@ -398,84 +402,85 @@ class NormServiceTest {
       var eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
 
       var oldXml =
-          """
-          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-             <akn:act name="regelungstext">
-                <!-- Metadaten -->
-                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                         <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                      </akn:FRBRExpression>
-                  </akn:identification>
-                </akn:meta>
-                <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
-                    <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
-                       <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
-                          <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
-                          <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
-                          Innern</akn:docProponent>
-                          <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
-                       </akn:p>
-                    </akn:longTitle>
-                    <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
-                       <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
-                    </akn:block>
-                 </akn:preface>
-             </akn:act>
-          </akn:akomaNtoso>
-          """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                       <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                    </akn:FRBRExpression>
+                </akn:identification>
+              </akn:meta>
+              <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                  <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                     <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                        <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
+                        <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
+                        Innern</akn:docProponent>
+                        <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
+                     </akn:p>
+                  </akn:longTitle>
+                  <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                     <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
+                  </akn:block>
+               </akn:preface>
+           </akn:act>
+        </akn:akomaNtoso>
+        """;
       var newXml =
-          """
-          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-             <akn:act name="regelungstext">
-                <!-- Metadaten -->
-                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                         <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                      </akn:FRBRExpression>
-                  </akn:identification>
-                </akn:meta>
-                <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
-                    <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
-                       <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
-                          <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
-                          <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
-                          Innern</akn:docProponent>
-                          <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Dritten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
-                       </akn:p>
-                    </akn:longTitle>
-                    <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
-                       <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
-                    </akn:block>
-                 </akn:preface>
-             </akn:act>
-          </akn:akomaNtoso>
-          """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                       <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                    </akn:FRBRExpression>
+                </akn:identification>
+              </akn:meta>
+              <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                  <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                     <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                        <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
+                        <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
+                        Innern</akn:docProponent>
+                        <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Dritten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
+                     </akn:p>
+                  </akn:longTitle>
+                  <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                     <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
+                  </akn:block>
+               </akn:preface>
+           </akn:act>
+        </akn:akomaNtoso>
+        """;
       var oldNorm = Norm.builder().document(XmlMapper.toDocument(oldXml)).build();
 
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(oldNorm));
 
       // When
-      var thrown =
-          catchThrowable(() -> service.updateNormXml(new UpdateNormXmlUseCase.Query(eli, newXml)));
+      var thrown = catchThrowable(() ->
+        service.updateNormXml(new UpdateNormXmlUseCase.Query(eli, newXml))
+      );
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
       verify(updateNormPort, times(0)).updateNorm(any());
       assertThat(thrown).isInstanceOf(UpdateNormXmlUseCase.InvalidUpdateException.class);
     }
@@ -491,23 +496,24 @@ class NormServiceTest {
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.empty());
 
       // when/than
-      var throwable =
-          AssertionsForClassTypes.catchThrowable(
-              () ->
-                  service.updateMod(
-                      new UpdateModUseCase.Query(
-                          eli,
-                          "eid",
-                          "refersTo",
-                          "time-boundary-eid",
-                          "destinanation-href",
-                          null,
-                          "new text")));
+      var throwable = AssertionsForClassTypes.catchThrowable(() ->
+        service.updateMod(
+          new UpdateModUseCase.Query(
+            eli,
+            "eid",
+            "refersTo",
+            "time-boundary-eid",
+            "destinanation-href",
+            null,
+            "new text"
+          )
+        )
+      );
 
       assertThat(throwable).isInstanceOf(NormNotFoundException.class);
 
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
       verify(updateNormPort, times(0)).updateNorm(any());
     }
 
@@ -519,20 +525,21 @@ class NormServiceTest {
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(amendingLaw));
 
       // When
-      var xml =
-          service.updateMod(
-              new UpdateModUseCase.Query(
-                  eli,
-                  "eid",
-                  "refersTo",
-                  "time-boundary-eid",
-                  "#THIS_IS_NOT_OK_A_HREF_IS_NEVER_RELATIVE",
-                  null,
-                  "new text"));
+      var xml = service.updateMod(
+        new UpdateModUseCase.Query(
+          eli,
+          "eid",
+          "refersTo",
+          "time-boundary-eid",
+          "#THIS_IS_NOT_OK_A_HREF_IS_NEVER_RELATIVE",
+          null,
+          "new text"
+        )
+      );
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
       verify(updateNormPort, times(0)).updateNorm(any());
       assertThat(xml).isEmpty();
     }
@@ -542,31 +549,32 @@ class NormServiceTest {
       // Given
       Norm amendingNorm = NormFixtures.loadFromDisk("NormWithMods.xml");
       String amendingNormEli = amendingNorm.getEli();
-      Mod mod =
-          amendingNorm.getMods().stream()
-              .filter(
-                  m ->
-                      m.getEid().isPresent()
-                          && m.getEid()
-                              .get()
-                              .equals(
-                                  "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"))
-              .findFirst()
-              .orElseThrow();
+      Mod mod = amendingNorm
+        .getMods()
+        .stream()
+        .filter(m ->
+          m.getEid().isPresent() &&
+          m
+            .getEid()
+            .get()
+            .equals("hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1")
+        )
+        .findFirst()
+        .orElseThrow();
       Norm targetNorm = NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml");
       String targetNormEli = targetNorm.getEli();
       Norm zf0Norm = NormFixtures.loadFromDisk("NormWithPassiveModifications.xml");
       String newCharacterRange = "20-25";
       String newTimeBoundaryEid = "#time-boundary-eid";
       String newDestinationHref =
-          targetNormEli
-              + "/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/"
-              + newCharacterRange
-              + ".xml";
+        targetNormEli +
+        "/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/" +
+        newCharacterRange +
+        ".xml";
       String newContent = "new text";
       when(loadNormPort.loadNorm(any()))
-          .thenReturn(Optional.of(amendingNorm))
-          .thenReturn(Optional.of(targetNorm));
+        .thenReturn(Optional.of(amendingNorm))
+        .thenReturn(Optional.of(targetNorm));
       when(loadZf0Service.loadOrCreateZf0(any())).thenReturn(zf0Norm);
       when(updateNormService.updateActiveModifications(any())).thenReturn(amendingNorm);
       when(updateNormService.updatePassiveModifications(any())).thenReturn(zf0Norm);
@@ -575,21 +583,23 @@ class NormServiceTest {
 
       // When
       service.updateMod(
-          new UpdateModUseCase.Query(
-              amendingNormEli,
-              "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1", // <-
-              // this
-              // matters now
-              "refersTo",
-              newTimeBoundaryEid, // <- this will be set
-              newDestinationHref, // <- this will be set in ActivMods AND mod
-              null,
-              newContent,
-              false));
+        new UpdateModUseCase.Query(
+          amendingNormEli,
+          "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1", // <-
+          // this
+          // matters now
+          "refersTo",
+          newTimeBoundaryEid, // <- this will be set
+          newDestinationHref, // <- this will be set in ActivMods AND mod
+          null,
+          newContent,
+          false
+        )
+      );
 
       // Then
       verify(singleModValidator, times(1))
-          .validate(argThat(zf0NormArg -> zf0NormArg.equals(zf0Norm)), argThat(m -> m.equals(mod)));
+        .validate(argThat(zf0NormArg -> zf0NormArg.equals(zf0Norm)), argThat(m -> m.equals(mod)));
     }
 
     @Test
@@ -604,14 +614,14 @@ class NormServiceTest {
       String newCharacterRange = "9-34";
       String newTimeBoundaryEid = "#time-boundary-eid";
       String newDestinationHref =
-          targetNormEli
-              + "/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/"
-              + newCharacterRange
-              + ".xml";
+        targetNormEli +
+        "/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/" +
+        newCharacterRange +
+        ".xml";
       String newContent = "§ 9 Absatz 1 Satz 2, Absatz 2 oder 3";
       when(loadNormPort.loadNorm(any()))
-          .thenReturn(Optional.of(amendingNorm))
-          .thenReturn(Optional.of(targetNorm));
+        .thenReturn(Optional.of(amendingNorm))
+        .thenReturn(Optional.of(targetNorm));
       when(loadZf0Service.loadOrCreateZf0(any())).thenReturn(zf0Norm);
       when(updateNormService.updateActiveModifications(any())).thenReturn(amendingNorm);
       when(updateNormService.updatePassiveModifications(any())).thenReturn(zf0Norm);
@@ -619,46 +629,50 @@ class NormServiceTest {
       when(updateOrSaveNormPort.updateOrSave(any())).thenReturn(zf0Norm);
 
       // When
-      var returnedXml =
-          service.updateMod(
-              new UpdateModUseCase.Query(
-                  amendingNormEli,
-                  eId,
-                  "refersTo",
-                  newTimeBoundaryEid, // <- this will be set
-                  newDestinationHref, // <- this will be set in ActivMods AND mod
-                  null,
-                  newContent,
-                  false));
+      var returnedXml = service.updateMod(
+        new UpdateModUseCase.Query(
+          amendingNormEli,
+          eId,
+          "refersTo",
+          newTimeBoundaryEid, // <- this will be set
+          newDestinationHref, // <- this will be set in ActivMods AND mod
+          null,
+          newContent,
+          false
+        )
+      );
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), amendingNormEli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), amendingNormEli)));
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), targetNormEli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), targetNormEli)));
       verify(loadZf0Service, times(1)).loadOrCreateZf0(any());
       verify(updateNormService, times(1))
-          .updateActiveModifications(
-              argThat(
-                  argument ->
-                      Objects.equals(argument.amendingNorm(), amendingNorm)
-                          && Objects.equals(argument.eId(), eId)
-                          && Objects.equals(argument.timeBoundaryEid(), newTimeBoundaryEid)
-                          && Objects.equals(argument.destinationHref(), newDestinationHref)));
+        .updateActiveModifications(
+          argThat(argument ->
+            Objects.equals(argument.amendingNorm(), amendingNorm) &&
+            Objects.equals(argument.eId(), eId) &&
+            Objects.equals(argument.timeBoundaryEid(), newTimeBoundaryEid) &&
+            Objects.equals(argument.destinationHref(), newDestinationHref)
+          )
+        );
       verify(updateNormService, times(1))
-          .updatePassiveModifications(
-              argThat(
-                  argument ->
-                      Objects.equals(argument.zf0Norm(), zf0Norm)
-                          && Objects.equals(argument.amendingNorm(), amendingNorm)));
+        .updatePassiveModifications(
+          argThat(argument ->
+            Objects.equals(argument.zf0Norm(), zf0Norm) &&
+            Objects.equals(argument.amendingNorm(), amendingNorm)
+          )
+        );
       verify(updateNormPort, times(1))
-          .updateNorm(argThat(argument -> Objects.equals(argument.norm(), amendingNorm)));
+        .updateNorm(argThat(argument -> Objects.equals(argument.norm(), amendingNorm)));
       verify(updateOrSaveNormPort, times(1))
-          .updateOrSave(argThat(argument -> Objects.equals(argument.norm(), zf0Norm)));
+        .updateOrSave(argThat(argument -> Objects.equals(argument.norm(), zf0Norm)));
 
       assertThat(returnedXml).isPresent();
-      final Document amendingXmlDocument =
-          XmlMapper.toDocument(returnedXml.get().amendingNormXml());
+      final Document amendingXmlDocument = XmlMapper.toDocument(
+        returnedXml.get().amendingNormXml()
+      );
       final Norm resultAmendingNorm = Norm.builder().document(amendingXmlDocument).build();
 
       final Mod mod = resultAmendingNorm.getMods().getFirst();
@@ -666,12 +680,13 @@ class NormServiceTest {
       assertThat(mod.getTargetRefHref().get().value()).contains(newDestinationHref);
       assertThat(mod.getNewText()).contains(newContent);
       assertThat(returnedXml.get().targetNormZf0Xml())
-          .isEqualTo(XmlMapper.toString(zf0Norm.getDocument()));
+        .isEqualTo(XmlMapper.toString(zf0Norm.getDocument()));
     }
   }
 
   @Nested
   class updateMods {
+
     @Test
     void itCallsLoadNormAndReturnsEmptyBecauseEliNotFound() {
       // Given
@@ -679,14 +694,16 @@ class NormServiceTest {
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.empty());
 
       // When
-      var result =
-          service.updateMods(
-              new UpdateModsUseCase.Query(
-                  eli, List.of(new UpdateModsUseCase.NewModData("eid", "time-boundary-eid"))));
+      var result = service.updateMods(
+        new UpdateModsUseCase.Query(
+          eli,
+          List.of(new UpdateModsUseCase.NewModData("eid", "time-boundary-eid"))
+        )
+      );
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
       verify(updateNormPort, times(0)).updateNorm(any());
       assertThat(result).isEmpty();
     }
@@ -696,23 +713,24 @@ class NormServiceTest {
       // Given
       Norm amendingNorm = NormFixtures.loadFromDisk("NormWithMods.xml");
       String amendingNormEli = amendingNorm.getEli();
-      Mod mod =
-          amendingNorm.getMods().stream()
-              .filter(
-                  m ->
-                      m.getEid().isPresent()
-                          && m.getEid()
-                              .get()
-                              .equals(
-                                  "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"))
-              .findFirst()
-              .orElseThrow();
+      Mod mod = amendingNorm
+        .getMods()
+        .stream()
+        .filter(m ->
+          m.getEid().isPresent() &&
+          m
+            .getEid()
+            .get()
+            .equals("hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1")
+        )
+        .findFirst()
+        .orElseThrow();
       Norm targetNorm = NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml");
       Norm zf0Norm = NormFixtures.loadFromDisk("NormWithPassiveModifications.xml");
       String newTimeBoundaryEid = "#time-boundary-eid";
       when(loadNormPort.loadNorm(any()))
-          .thenReturn(Optional.of(amendingNorm))
-          .thenReturn(Optional.of(targetNorm));
+        .thenReturn(Optional.of(amendingNorm))
+        .thenReturn(Optional.of(targetNorm));
       when(loadZf0Service.loadOrCreateZf0(any())).thenReturn(zf0Norm);
       when(updateNormService.updateActiveModifications(any())).thenReturn(amendingNorm);
       when(updateNormService.updatePassiveModifications(any())).thenReturn(zf0Norm);
@@ -721,17 +739,21 @@ class NormServiceTest {
 
       // When
       service.updateMods(
-          new UpdateModsUseCase.Query(
-              amendingNormEli,
-              List.of(
-                  new UpdateModsUseCase.NewModData(
-                      "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1",
-                      newTimeBoundaryEid)),
-              false));
+        new UpdateModsUseCase.Query(
+          amendingNormEli,
+          List.of(
+            new UpdateModsUseCase.NewModData(
+              "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1",
+              newTimeBoundaryEid
+            )
+          ),
+          false
+        )
+      );
 
       // Then
       verify(singleModValidator, times(1))
-          .validate(argThat(zf0NormArg -> zf0NormArg.equals(zf0Norm)), argThat(m -> m.equals(mod)));
+        .validate(argThat(zf0NormArg -> zf0NormArg.equals(zf0Norm)), argThat(m -> m.equals(mod)));
     }
 
     @Test
@@ -745,8 +767,8 @@ class NormServiceTest {
       String eId = "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1";
       String newTimeBoundaryEid = "#time-boundary-eid";
       when(loadNormPort.loadNorm(any()))
-          .thenReturn(Optional.of(amendingNorm))
-          .thenReturn(Optional.of(targetNorm));
+        .thenReturn(Optional.of(amendingNorm))
+        .thenReturn(Optional.of(targetNorm));
       when(loadZf0Service.loadOrCreateZf0(any())).thenReturn(zf0Norm);
       when(updateNormService.updateActiveModifications(any())).thenReturn(amendingNorm);
       when(updateNormService.updatePassiveModifications(any())).thenReturn(zf0Norm);
@@ -754,36 +776,39 @@ class NormServiceTest {
       when(updateOrSaveNormPort.updateOrSave(any())).thenReturn(zf0Norm);
 
       // When
-      var result =
-          service.updateMods(
-              new UpdateModsUseCase.Query(
-                  amendingNormEli,
-                  List.of(new UpdateModsUseCase.NewModData(eId, newTimeBoundaryEid)),
-                  false));
+      var result = service.updateMods(
+        new UpdateModsUseCase.Query(
+          amendingNormEli,
+          List.of(new UpdateModsUseCase.NewModData(eId, newTimeBoundaryEid)),
+          false
+        )
+      );
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), amendingNormEli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), amendingNormEli)));
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), targetNormEli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), targetNormEli)));
       verify(loadZf0Service, times(1)).loadOrCreateZf0(any());
       verify(updateNormService, times(1))
-          .updateActiveModifications(
-              argThat(
-                  argument ->
-                      Objects.equals(argument.amendingNorm(), amendingNorm)
-                          && Objects.equals(argument.eId(), eId)
-                          && Objects.equals(argument.timeBoundaryEid(), newTimeBoundaryEid)));
+        .updateActiveModifications(
+          argThat(argument ->
+            Objects.equals(argument.amendingNorm(), amendingNorm) &&
+            Objects.equals(argument.eId(), eId) &&
+            Objects.equals(argument.timeBoundaryEid(), newTimeBoundaryEid)
+          )
+        );
       verify(updateNormService, times(1))
-          .updatePassiveModifications(
-              argThat(
-                  argument ->
-                      Objects.equals(argument.zf0Norm(), zf0Norm)
-                          && Objects.equals(argument.amendingNorm(), amendingNorm)));
+        .updatePassiveModifications(
+          argThat(argument ->
+            Objects.equals(argument.zf0Norm(), zf0Norm) &&
+            Objects.equals(argument.amendingNorm(), amendingNorm)
+          )
+        );
       verify(updateNormPort, times(1))
-          .updateNorm(argThat(argument -> Objects.equals(argument.norm(), amendingNorm)));
+        .updateNorm(argThat(argument -> Objects.equals(argument.norm(), amendingNorm)));
       verify(updateOrSaveNormPort, times(1))
-          .updateOrSave(argThat(argument -> Objects.equals(argument.norm(), zf0Norm)));
+        .updateOrSave(argThat(argument -> Objects.equals(argument.norm(), zf0Norm)));
 
       assertThat(result).isPresent();
       final Document amendingXmlDocument = XmlMapper.toDocument(result.get().amendingNormXml());
@@ -792,11 +817,12 @@ class NormServiceTest {
       final Mod mod = resultAmendingNorm.getMods().getFirst();
       assertThat(mod.getTargetRefHref()).isPresent();
       assertThat(mod.getTargetRefHref().get().value())
-          .contains(
-              "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34.xml");
+        .contains(
+          "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34.xml"
+        );
       assertThat(mod.getNewText()).contains("§ 9 Absatz 1 Satz 2, Absatz 2 oder 3");
       assertThat(result.get().targetNormZf0Xml())
-          .isEqualTo(XmlMapper.toString(zf0Norm.getDocument()));
+        .isEqualTo(XmlMapper.toString(zf0Norm.getDocument()));
     }
 
     @Test
@@ -809,8 +835,8 @@ class NormServiceTest {
       Norm zf0Norm = NormFixtures.loadFromDisk("NormWithMultipleSimpleModsTargetNorm.xml");
 
       when(loadNormPort.loadNorm(any()))
-          .thenReturn(Optional.of(amendingNorm))
-          .thenReturn(Optional.of(targetNorm));
+        .thenReturn(Optional.of(amendingNorm))
+        .thenReturn(Optional.of(targetNorm));
       when(loadZf0Service.loadOrCreateZf0(any())).thenReturn(zf0Norm);
       when(updateNormService.updateActiveModifications(any())).thenReturn(amendingNorm);
       when(updateNormService.updatePassiveModifications(any())).thenReturn(zf0Norm);
@@ -818,24 +844,28 @@ class NormServiceTest {
       when(updateOrSaveNormPort.updateOrSave(any())).thenReturn(zf0Norm);
 
       // When
-      var result =
-          service.updateMods(
-              new UpdateModsUseCase.Query(
-                  amendingNormEli,
-                  List.of(
-                      new UpdateModsUseCase.NewModData(
-                          "hauptteil-1_para-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1",
-                          "#meta-1_geltzeiten-1_geltungszeitgr-1"),
-                      new UpdateModsUseCase.NewModData(
-                          "hauptteil-1_para-1_abs-1_untergl-1_listenelem-3_inhalt-1_text-1_ändbefehl-1",
-                          "#meta-1_geltzeiten-1_geltungszeitgr-1")),
-                  false));
+      var result = service.updateMods(
+        new UpdateModsUseCase.Query(
+          amendingNormEli,
+          List.of(
+            new UpdateModsUseCase.NewModData(
+              "hauptteil-1_para-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1",
+              "#meta-1_geltzeiten-1_geltungszeitgr-1"
+            ),
+            new UpdateModsUseCase.NewModData(
+              "hauptteil-1_para-1_abs-1_untergl-1_listenelem-3_inhalt-1_text-1_ändbefehl-1",
+              "#meta-1_geltzeiten-1_geltungszeitgr-1"
+            )
+          ),
+          false
+        )
+      );
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), amendingNormEli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), amendingNormEli)));
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), targetNormEli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), targetNormEli)));
       verify(loadZf0Service, times(1)).loadOrCreateZf0(any());
       verify(updateNormService, times(2)).updateActiveModifications(any());
       verify(updateNormService, times(2)).updatePassiveModifications(any());
@@ -850,14 +880,15 @@ class NormServiceTest {
       // Given
       Norm amendingNorm = NormFixtures.loadFromDisk("NormWithQuotedStructureModsAndUpTo.xml");
       String amendingNormEli = amendingNorm.getEli();
-      Norm targetNorm =
-          NormFixtures.loadFromDisk("NormWithoutPassiveModsQuotedStructureAndUpTo.xml");
+      Norm targetNorm = NormFixtures.loadFromDisk(
+        "NormWithoutPassiveModsQuotedStructureAndUpTo.xml"
+      );
       String targetNormEli = targetNorm.getEli();
       Norm zf0Norm = NormFixtures.loadFromDisk("NormWithPassiveModsQuotedStructureAndUpTo.xml");
 
       when(loadNormPort.loadNorm(any()))
-          .thenReturn(Optional.of(amendingNorm))
-          .thenReturn(Optional.of(targetNorm));
+        .thenReturn(Optional.of(amendingNorm))
+        .thenReturn(Optional.of(targetNorm));
       when(loadZf0Service.loadOrCreateZf0(any())).thenReturn(zf0Norm);
       when(updateNormService.updateActiveModifications(any())).thenReturn(amendingNorm);
       when(updateNormService.updatePassiveModifications(any())).thenReturn(zf0Norm);
@@ -865,24 +896,28 @@ class NormServiceTest {
       when(updateOrSaveNormPort.updateOrSave(any())).thenReturn(zf0Norm);
 
       // When
-      var result =
-          service.updateMods(
-              new UpdateModsUseCase.Query(
-                  amendingNormEli,
-                  List.of(
-                      new UpdateModsUseCase.NewModData(
-                          "hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1",
-                          "#meta-1_geltzeiten-1_geltungszeitgr-2"),
-                      new UpdateModsUseCase.NewModData(
-                          "hauptteil-1_para-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1",
-                          "#meta-1_geltzeiten-1_geltungszeitgr-2")),
-                  false));
+      var result = service.updateMods(
+        new UpdateModsUseCase.Query(
+          amendingNormEli,
+          List.of(
+            new UpdateModsUseCase.NewModData(
+              "hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1",
+              "#meta-1_geltzeiten-1_geltungszeitgr-2"
+            ),
+            new UpdateModsUseCase.NewModData(
+              "hauptteil-1_para-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1",
+              "#meta-1_geltzeiten-1_geltungszeitgr-2"
+            )
+          ),
+          false
+        )
+      );
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), amendingNormEli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), amendingNormEli)));
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), targetNormEli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), targetNormEli)));
       verify(loadZf0Service, times(1)).loadOrCreateZf0(any());
       verify(updateNormService, times(2)).updateActiveModifications(any());
       verify(updateNormService, times(2)).updatePassiveModifications(any());

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/ProprietaryServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/ProprietaryServiceTest.java
@@ -20,13 +20,17 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class ProprietaryServiceTest {
+
   final LoadNormPort loadNormPort = mock(LoadNormPort.class);
   final UpdateNormPort updateNormPort = mock(UpdateNormPort.class);
-  final ProprietaryService proprietaryService =
-      new ProprietaryService(loadNormPort, updateNormPort);
+  final ProprietaryService proprietaryService = new ProprietaryService(
+    loadNormPort,
+    updateNormPort
+  );
 
   @Nested
   class loadProprietary {
+
     @Test
     void throwsNormNotFoundExceptionIfNormNotFound() {
       // given
@@ -36,8 +40,8 @@ class ProprietaryServiceTest {
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.empty());
       // then
       assertThatThrownBy(() -> proprietaryService.loadProprietaryFromNorm(query))
-          // then
-          .isInstanceOf(NormNotFoundException.class);
+        // then
+        .isInstanceOf(NormNotFoundException.class);
     }
 
     @Test
@@ -46,11 +50,12 @@ class ProprietaryServiceTest {
       var eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
       var normWithoutProprietary = NormFixtures.loadFromDisk("NormWithoutProprietary.xml");
       when(loadNormPort.loadNorm(new LoadNormPort.Command(eli)))
-          .thenReturn(Optional.of(normWithoutProprietary));
+        .thenReturn(Optional.of(normWithoutProprietary));
 
       // when
-      var result =
-          proprietaryService.loadProprietaryFromNorm(new LoadProprietaryFromNormUseCase.Query(eli));
+      var result = proprietaryService.loadProprietaryFromNorm(
+        new LoadProprietaryFromNormUseCase.Query(eli)
+      );
 
       // then
       assertThat(result).isInstanceOf(Proprietary.class);
@@ -62,10 +67,11 @@ class ProprietaryServiceTest {
       var eli = "eli/bund/bgbl-1/2002/s1181/2019-11-22/1/deu/rechtsetzungsdokument-1";
       var normWithProprietary = NormFixtures.loadFromDisk("NormWithProprietary.xml");
       when(loadNormPort.loadNorm(new LoadNormPort.Command(eli)))
-          .thenReturn(Optional.of(normWithProprietary));
+        .thenReturn(Optional.of(normWithProprietary));
       // when
-      var result =
-          proprietaryService.loadProprietaryFromNorm(new LoadProprietaryFromNormUseCase.Query(eli));
+      var result = proprietaryService.loadProprietaryFromNorm(
+        new LoadProprietaryFromNormUseCase.Query(eli)
+      );
       // then
       assertThat(result).isInstanceOf(Proprietary.class);
     }
@@ -79,16 +85,28 @@ class ProprietaryServiceTest {
       // given
       var eli = "eli/bund/INVALID_ELI/2002/s1181/2019-11-22/1/deu/rechtsetzungsdokument-1";
       UpdateProprietaryFrameFromNormUseCase.Query query =
-          new UpdateProprietaryFrameFromNormUseCase.Query(
-              eli,
-              LocalDate.parse("2003-01-01"),
-              new UpdateProprietaryFrameFromNormUseCase.Metadata(
-                  "fna", null, null, null, null, null, null, null, null, null, null));
+        new UpdateProprietaryFrameFromNormUseCase.Query(
+          eli,
+          LocalDate.parse("2003-01-01"),
+          new UpdateProprietaryFrameFromNormUseCase.Metadata(
+            "fna",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+          )
+        );
       // when
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.empty());
       assertThatThrownBy(() -> proprietaryService.updateProprietaryFrameFromNorm(query))
-          // then
-          .isInstanceOf(NormNotFoundException.class);
+        // then
+        .isInstanceOf(NormNotFoundException.class);
     }
 
     @Test
@@ -98,16 +116,28 @@ class ProprietaryServiceTest {
       var date = LocalDate.parse("2003-01-01");
       var normWithoutProprietary = NormFixtures.loadFromDisk("NormWithoutProprietary.xml");
       when(loadNormPort.loadNorm(new LoadNormPort.Command(eli)))
-          .thenReturn(Optional.of(normWithoutProprietary));
+        .thenReturn(Optional.of(normWithoutProprietary));
 
       // when
-      var result =
-          proprietaryService.updateProprietaryFrameFromNorm(
-              new UpdateProprietaryFrameFromNormUseCase.Query(
-                  eli,
-                  date,
-                  new UpdateProprietaryFrameFromNormUseCase.Metadata(
-                      "fna", null, null, null, null, null, null, null, null, null, null)));
+      var result = proprietaryService.updateProprietaryFrameFromNorm(
+        new UpdateProprietaryFrameFromNormUseCase.Query(
+          eli,
+          date,
+          new UpdateProprietaryFrameFromNormUseCase.Metadata(
+            "fna",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+          )
+        )
+      );
 
       // then
       assertThat(result).isInstanceOf(Proprietary.class);
@@ -130,26 +160,28 @@ class ProprietaryServiceTest {
       var date = LocalDate.parse("2003-01-01");
       var normWithProprietary = NormFixtures.loadFromDisk("NormWithProprietary.xml");
       when(loadNormPort.loadNorm(new LoadNormPort.Command(eli)))
-          .thenReturn(Optional.of(normWithProprietary));
+        .thenReturn(Optional.of(normWithProprietary));
 
       // when
-      var result =
-          proprietaryService.updateProprietaryFrameFromNorm(
-              new UpdateProprietaryFrameFromNormUseCase.Query(
-                  eli,
-                  date,
-                  new UpdateProprietaryFrameFromNormUseCase.Metadata(
-                      "fna",
-                      "art",
-                      "typ",
-                      "subtype",
-                      "bezeichnungInVorlage",
-                      "ÄN,ÜN",
-                      "DDR",
-                      "Landtag",
-                      false,
-                      "BMJ - Bundesministerium der Justiz",
-                      "andere org einheit")));
+      var result = proprietaryService.updateProprietaryFrameFromNorm(
+        new UpdateProprietaryFrameFromNormUseCase.Query(
+          eli,
+          date,
+          new UpdateProprietaryFrameFromNormUseCase.Metadata(
+            "fna",
+            "art",
+            "typ",
+            "subtype",
+            "bezeichnungInVorlage",
+            "ÄN,ÜN",
+            "DDR",
+            "Landtag",
+            false,
+            "BMJ - Bundesministerium der Justiz",
+            "andere org einheit"
+          )
+        )
+      );
 
       // then
       assertThat(result).isInstanceOf(Proprietary.class);
@@ -173,16 +205,28 @@ class ProprietaryServiceTest {
       var date = LocalDate.parse("2003-01-01");
       var normWithProprietary = NormFixtures.loadFromDisk("NormWithProprietary.xml");
       when(loadNormPort.loadNorm(new LoadNormPort.Command(eli)))
-          .thenReturn(Optional.of(normWithProprietary));
+        .thenReturn(Optional.of(normWithProprietary));
 
       // when
-      var result =
-          proprietaryService.updateProprietaryFrameFromNorm(
-              new UpdateProprietaryFrameFromNormUseCase.Query(
-                  eli,
-                  date,
-                  new UpdateProprietaryFrameFromNormUseCase.Metadata(
-                      null, null, null, null, null, null, null, null, null, null, null)));
+      var result = proprietaryService.updateProprietaryFrameFromNorm(
+        new UpdateProprietaryFrameFromNormUseCase.Query(
+          eli,
+          date,
+          new UpdateProprietaryFrameFromNormUseCase.Metadata(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+          )
+        )
+      );
 
       // then
       assertThat(result).isInstanceOf(Proprietary.class);
@@ -210,16 +254,17 @@ class ProprietaryServiceTest {
       var eid = "hauptteil-1_abschnitt-0_para-1";
       var eli = "eli/bund/INVALID_ELI/2002/s1181/2019-11-22/1/deu/rechtsetzungsdokument-1";
       UpdateProprietarySingleElementFromNormUseCase.Query query =
-          new UpdateProprietarySingleElementFromNormUseCase.Query(
-              eli,
-              eid,
-              LocalDate.parse("2003-01-01"),
-              new UpdateProprietarySingleElementFromNormUseCase.Metadata("SN"));
+        new UpdateProprietarySingleElementFromNormUseCase.Query(
+          eli,
+          eid,
+          LocalDate.parse("2003-01-01"),
+          new UpdateProprietarySingleElementFromNormUseCase.Metadata("SN")
+        );
       // when
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.empty());
       assertThatThrownBy(() -> proprietaryService.updateProprietarySingleElementFromNorm(query))
-          // then
-          .isInstanceOf(NormNotFoundException.class);
+        // then
+        .isInstanceOf(NormNotFoundException.class);
     }
 
     @Test
@@ -230,16 +275,17 @@ class ProprietaryServiceTest {
       var date = LocalDate.parse("2003-01-01");
       var normWithoutProprietary = NormFixtures.loadFromDisk("NormWithoutProprietary.xml");
       when(loadNormPort.loadNorm(new LoadNormPort.Command(eli)))
-          .thenReturn(Optional.of(normWithoutProprietary));
+        .thenReturn(Optional.of(normWithoutProprietary));
 
       // when
-      var result =
-          proprietaryService.updateProprietarySingleElementFromNorm(
-              new UpdateProprietarySingleElementFromNormUseCase.Query(
-                  eli,
-                  eid,
-                  date,
-                  new UpdateProprietarySingleElementFromNormUseCase.Metadata("SN")));
+      var result = proprietaryService.updateProprietarySingleElementFromNorm(
+        new UpdateProprietarySingleElementFromNormUseCase.Query(
+          eli,
+          eid,
+          date,
+          new UpdateProprietarySingleElementFromNormUseCase.Metadata("SN")
+        )
+      );
 
       // then
       assertThat(result).isInstanceOf(Proprietary.class);
@@ -254,16 +300,17 @@ class ProprietaryServiceTest {
       var date = LocalDate.parse("2003-01-01");
       var normWithProprietary = NormFixtures.loadFromDisk("NormWithProprietary.xml");
       when(loadNormPort.loadNorm(new LoadNormPort.Command(eli)))
-          .thenReturn(Optional.of(normWithProprietary));
+        .thenReturn(Optional.of(normWithProprietary));
 
       // when
-      var result =
-          proprietaryService.updateProprietarySingleElementFromNorm(
-              new UpdateProprietarySingleElementFromNormUseCase.Query(
-                  eli,
-                  eid,
-                  date,
-                  new UpdateProprietarySingleElementFromNormUseCase.Metadata("ÜN")));
+      var result = proprietaryService.updateProprietarySingleElementFromNorm(
+        new UpdateProprietarySingleElementFromNormUseCase.Query(
+          eli,
+          eid,
+          date,
+          new UpdateProprietarySingleElementFromNormUseCase.Metadata("ÜN")
+        )
+      );
 
       // then
       assertThat(result).isInstanceOf(Proprietary.class);
@@ -278,16 +325,17 @@ class ProprietaryServiceTest {
       var date = LocalDate.parse("1980-01-01");
       var normWithProprietary = NormFixtures.loadFromDisk("NormWithProprietary.xml");
       when(loadNormPort.loadNorm(new LoadNormPort.Command(eli)))
-          .thenReturn(Optional.of(normWithProprietary));
+        .thenReturn(Optional.of(normWithProprietary));
 
       // when
-      var result =
-          proprietaryService.updateProprietarySingleElementFromNorm(
-              new UpdateProprietarySingleElementFromNormUseCase.Query(
-                  eli,
-                  eid,
-                  date,
-                  new UpdateProprietarySingleElementFromNormUseCase.Metadata(null)));
+      var result = proprietaryService.updateProprietarySingleElementFromNorm(
+        new UpdateProprietarySingleElementFromNormUseCase.Query(
+          eli,
+          eid,
+          date,
+          new UpdateProprietarySingleElementFromNormUseCase.Metadata(null)
+        )
+      );
 
       // then
       assertThat(result).isInstanceOf(Proprietary.class);

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/ReferenceServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/ReferenceServiceTest.java
@@ -32,16 +32,16 @@ class ReferenceServiceTest {
     when(loadNormPort.loadNorm(any())).thenThrow(new NormNotFoundException(eli));
 
     // When
-    var throwable =
-        catchThrowable(
-            () -> service.findAndCreateReferences(new ReferenceRecognitionUseCase.Query(eli)));
+    var throwable = catchThrowable(() ->
+      service.findAndCreateReferences(new ReferenceRecognitionUseCase.Query(eli))
+    );
 
     // Then
     verify(loadNormPort, times(1))
-        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+      .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
     assertThat(throwable).isInstanceOf(NormNotFoundException.class);
     assertThat(throwable.getMessage())
-        .isEqualToIgnoringWhitespace("Norm with eli %s does not exist".formatted(eli));
+      .isEqualToIgnoringWhitespace("Norm with eli %s does not exist".formatted(eli));
   }
 
   @Test
@@ -49,64 +49,67 @@ class ReferenceServiceTest {
     // Given
     final String eli = "NOT NEEDED";
 
-    final Norm norm =
-        Norm.builder()
-            .document(
-                XmlMapper.toDocument(
-                    """
-<?xml version="1.0" encoding="UTF-8"?><?xml-model href="../../../schema/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../schema/legalDocML.de-metadaten.xsd                       http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../schema/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-    <akn:act name="regelungstext">
-        <akn:body GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8" eId="hauptteil-1">
-            <akn:article GUID="cdbfc728-a070-42d9-ba2f-357945afef06" eId="hauptteil-1_art-1" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                <akn:num GUID="25a9acae-7463-4490-bc3f-8258b629d7e9" eId="hauptteil-1_art-1_bezeichnung-1">
-                    <akn:marker GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" name="1"/>Artikel 1</akn:num>
-                <akn:heading GUID="92827aa8-8118-4207-9f93-589345f0bab6" eId="hauptteil-1_art-1_überschrift-1">Änderung des
-                    Bundesverfassungsschutzgesetzes</akn:heading>
-                <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                    <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                        <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                    </akn:num>
-                    <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                        <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                            <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                                                                                                                                                 href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                        </akn:intro>
-                        <akn:point eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2" GUID="b5fa1383-f26a-4904-a638-f48711fbcf2d">
-                            <akn:num eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_bezeichnung-1" GUID="6f0f92b3-1a51-440c-9137-b44ab9d990ac">
-                                <akn:marker eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_bezeichnung-1_zaehlbez-1" GUID="5d7d54f0-8a4e-4d8f-b5d0-93d0ca393e82" name="2" />2.</akn:num>
-                            <akn:content eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1" GUID="6cb14ab5-3a7f-45f4-9e85-00ac2fb0fe5e">
-                                <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1" GUID="db3fbe0f-b758-4cc4-b528-a723cacad94a">
-                                    <akn:mod eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1" GUID="148c2f06-6e33-4af8-9f4a-3da67c888510" refersTo="aenderungsbefehl-ersetzen">In <akn:ref eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1"
-                                                                                                                                                                                                                           GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/0-0.xml">§ 20 Absatz 1 Satz 2</akn:ref> wird die Angabe <akn:quotedText
-                                            eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-1" GUID="694459c4-ef66-4f87-bb78-a332054a2216" startQuote="„" endQuote="“">§ 9 Abs. 1 Satz 2, Abs. 2</akn:quotedText> durch die Wörter <akn:quotedText
-                                            eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2" GUID="dd25bdb6-4ef4-4ef5-808c-27579b6ae196" startQuote="„" endQuote="“">§ 9 Absatz 1 <akn:ref>Satz 2</akn:ref>, Absatz 2 oder 3</akn:quotedText> ersetzt.</akn:mod>
-                                </akn:p>
-                            </akn:content>
-                        </akn:point>
-                    </akn:list>
-                </akn:paragraph>
-            </akn:article>
-        </akn:body>
-    </akn:act>
-</akn:akomaNtoso>
-      """))
-            .build();
+    final Norm norm = Norm
+      .builder()
+      .document(
+        XmlMapper.toDocument(
+          """
+          <?xml version="1.0" encoding="UTF-8"?><?xml-model href="../../../schema/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                          xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../schema/legalDocML.de-metadaten.xsd                       http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../schema/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+              <akn:act name="regelungstext">
+                  <akn:body GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8" eId="hauptteil-1">
+                      <akn:article GUID="cdbfc728-a070-42d9-ba2f-357945afef06" eId="hauptteil-1_art-1" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                          <akn:num GUID="25a9acae-7463-4490-bc3f-8258b629d7e9" eId="hauptteil-1_art-1_bezeichnung-1">
+                              <akn:marker GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" name="1"/>Artikel 1</akn:num>
+                          <akn:heading GUID="92827aa8-8118-4207-9f93-589345f0bab6" eId="hauptteil-1_art-1_überschrift-1">Änderung des
+                              Bundesverfassungsschutzgesetzes</akn:heading>
+                          <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                              <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                                  <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                              </akn:num>
+                              <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                                  <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                                      <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                                                                                                                                                           href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                                  </akn:intro>
+                                  <akn:point eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2" GUID="b5fa1383-f26a-4904-a638-f48711fbcf2d">
+                                      <akn:num eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_bezeichnung-1" GUID="6f0f92b3-1a51-440c-9137-b44ab9d990ac">
+                                          <akn:marker eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_bezeichnung-1_zaehlbez-1" GUID="5d7d54f0-8a4e-4d8f-b5d0-93d0ca393e82" name="2" />2.</akn:num>
+                                      <akn:content eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1" GUID="6cb14ab5-3a7f-45f4-9e85-00ac2fb0fe5e">
+                                          <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1" GUID="db3fbe0f-b758-4cc4-b528-a723cacad94a">
+                                              <akn:mod eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1" GUID="148c2f06-6e33-4af8-9f4a-3da67c888510" refersTo="aenderungsbefehl-ersetzen">In <akn:ref eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1"
+                                                                                                                                                                                                                                     GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/0-0.xml">§ 20 Absatz 1 Satz 2</akn:ref> wird die Angabe <akn:quotedText
+                                                      eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-1" GUID="694459c4-ef66-4f87-bb78-a332054a2216" startQuote="„" endQuote="“">§ 9 Abs. 1 Satz 2, Abs. 2</akn:quotedText> durch die Wörter <akn:quotedText
+                                                      eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2" GUID="dd25bdb6-4ef4-4ef5-808c-27579b6ae196" startQuote="„" endQuote="“">§ 9 Absatz 1 <akn:ref>Satz 2</akn:ref>, Absatz 2 oder 3</akn:quotedText> ersetzt.</akn:mod>
+                                          </akn:p>
+                                      </akn:content>
+                                  </akn:point>
+                              </akn:list>
+                          </akn:paragraph>
+                      </akn:article>
+                  </akn:body>
+              </akn:act>
+          </akn:akomaNtoso>
+                """
+        )
+      )
+      .build();
     when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(norm));
 
     // When
-    final String result =
-        service.findAndCreateReferences(new ReferenceRecognitionUseCase.Query(eli));
+    final String result = service.findAndCreateReferences(
+      new ReferenceRecognitionUseCase.Query(eli)
+    );
 
     // Then
     verify(loadNormPort, times(1))
-        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+      .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
 
-    final Diff diff =
-        DiffBuilder.compare(Input.from(XmlMapper.toDocument(result)))
-            .withTest(Input.from(norm.getDocument()))
-            .build();
+    final Diff diff = DiffBuilder
+      .compare(Input.from(XmlMapper.toDocument(result)))
+      .withTest(Input.from(norm.getDocument()))
+      .build();
     assertThat(diff.hasDifferences()).isFalse();
   }
 
@@ -118,17 +121,18 @@ class ReferenceServiceTest {
     when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(norm));
 
     // When
-    final String result =
-        service.findAndCreateReferences(new ReferenceRecognitionUseCase.Query(eli));
+    final String result = service.findAndCreateReferences(
+      new ReferenceRecognitionUseCase.Query(eli)
+    );
 
     // Then
     verify(loadNormPort, times(1))
-        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+      .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
 
-    final Diff diff =
-        DiffBuilder.compare(Input.from(XmlMapper.toDocument(result)))
-            .withTest(Input.from(norm.getDocument()))
-            .build();
+    final Diff diff = DiffBuilder
+      .compare(Input.from(XmlMapper.toDocument(result)))
+      .withTest(Input.from(norm.getDocument()))
+      .build();
     assertThat(diff.hasDifferences()).isFalse();
   }
 
@@ -141,21 +145,22 @@ class ReferenceServiceTest {
     when(updateNormPort.updateNorm(any())).thenReturn(any());
 
     // When
-    final String result =
-        service.findAndCreateReferences(new ReferenceRecognitionUseCase.Query(eli));
+    final String result = service.findAndCreateReferences(
+      new ReferenceRecognitionUseCase.Query(eli)
+    );
 
     // Then
     verify(loadNormPort, times(1))
-        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+      .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
     verify(updateNormPort, times(1))
-        .updateNorm(argThat(argument -> Objects.equals(argument.norm(), norm)));
+      .updateNorm(argThat(argument -> Objects.equals(argument.norm(), norm)));
 
     final Norm expectedUpdatedNorm = NormFixtures.loadFromDisk("NormWithReferencesFound.xml");
-    final Diff diff =
-        DiffBuilder.compare(Input.from(XmlMapper.toDocument(result)))
-            .withTest(Input.from(expectedUpdatedNorm.getDocument()))
-            .withAttributeFilter(attribute -> !attribute.getName().equals("GUID"))
-            .build();
+    final Diff diff = DiffBuilder
+      .compare(Input.from(XmlMapper.toDocument(result)))
+      .withTest(Input.from(expectedUpdatedNorm.getDocument()))
+      .withAttributeFilter(attribute -> !attribute.getName().equals("GUID"))
+      .build();
     assertThat(diff.hasDifferences()).isFalse();
   }
 
@@ -168,22 +173,23 @@ class ReferenceServiceTest {
     when(updateNormPort.updateNorm(any())).thenReturn(any());
 
     // When
-    final String result =
-        service.findAndCreateReferences(new ReferenceRecognitionUseCase.Query(eli));
+    final String result = service.findAndCreateReferences(
+      new ReferenceRecognitionUseCase.Query(eli)
+    );
 
     // Then
     verify(loadNormPort, times(1))
-        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+      .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
     verify(updateNormPort, times(1))
-        .updateNorm(argThat(argument -> Objects.equals(argument.norm(), norm)));
+      .updateNorm(argThat(argument -> Objects.equals(argument.norm(), norm)));
 
     final Norm sameNormReload = NormFixtures.loadFromDisk("NormWithReferencesInNumToSkip.xml");
-    final Diff diff =
-        DiffBuilder.compare(Input.from(XmlMapper.toDocument(result)))
-            .withTest(Input.from(sameNormReload.getDocument()))
-            .ignoreWhitespace()
-            .withAttributeFilter(attribute -> !attribute.getName().equals("GUID"))
-            .build();
+    final Diff diff = DiffBuilder
+      .compare(Input.from(XmlMapper.toDocument(result)))
+      .withTest(Input.from(sameNormReload.getDocument()))
+      .ignoreWhitespace()
+      .withAttributeFilter(attribute -> !attribute.getName().equals("GUID"))
+      .build();
     assertThat(diff.hasDifferences()).isFalse();
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/ReleaseServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/ReleaseServiceTest.java
@@ -20,78 +20,90 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 class ReleaseServiceTest {
-  private final LoadAnnouncementByNormEliPort loadAnnouncementByNormEliPort =
-      mock(LoadAnnouncementByNormEliPort.class);
+
+  private final LoadAnnouncementByNormEliPort loadAnnouncementByNormEliPort = mock(
+    LoadAnnouncementByNormEliPort.class
+  );
   private final UpdateAnnouncementPort updateAnnouncementPort = mock(UpdateAnnouncementPort.class);
-  private final ReleaseService releaseService =
-      new ReleaseService(loadAnnouncementByNormEliPort, updateAnnouncementPort);
+  private final ReleaseService releaseService = new ReleaseService(
+    loadAnnouncementByNormEliPort,
+    updateAnnouncementPort
+  );
 
   @Test
   void itShouldReleaseAnnouncement() {
     // Given
-    var announcement =
-        Announcement.builder()
-            .norm(
-                Norm.builder()
-                    .document(
-                        XmlMapper.toDocument(
-                            """
-                                  <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                                  <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                     xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                         http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                                     <akn:act name="regelungstext">
-                                        <!-- Metadaten -->
-                                        <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                           <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                              <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                                 <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                              </akn:FRBRExpression>
-                                          </akn:identification>
-                                        </akn:meta>
-                                     </akn:act>
-                                  </akn:akomaNtoso>
-                                """))
-                    .build())
-            .releasedByDocumentalistAt(null)
-            .build();
+    var announcement = Announcement
+      .builder()
+      .norm(
+        Norm
+          .builder()
+          .document(
+            XmlMapper.toDocument(
+              """
+                <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+                <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                       http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                   <akn:act name="regelungstext">
+                      <!-- Metadaten -->
+                      <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                         <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                            <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                               <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                            </akn:FRBRExpression>
+                        </akn:identification>
+                      </akn:meta>
+                   </akn:act>
+                </akn:akomaNtoso>
+              """
+            )
+          )
+          .build()
+      )
+      .releasedByDocumentalistAt(null)
+      .build();
     when(loadAnnouncementByNormEliPort.loadAnnouncementByNormEli(any()))
-        .thenReturn(Optional.of(announcement));
+      .thenReturn(Optional.of(announcement));
 
     // When
     var instantBeforeRelease = Instant.now();
     releaseService.releaseAnnouncement(
-        new ReleaseAnnouncementUseCase.Query(
-            "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"));
+      new ReleaseAnnouncementUseCase.Query(
+        "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"
+      )
+    );
 
     // Then
     verify(loadAnnouncementByNormEliPort, times(1))
-        .loadAnnouncementByNormEli(
-            argThat(
-                argument ->
-                    Objects.equals(
-                        argument.eli(),
-                        "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")));
+      .loadAnnouncementByNormEli(
+        argThat(argument ->
+          Objects.equals(
+            argument.eli(),
+            "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"
+          )
+        )
+      );
 
     var commandCaptor = ArgumentCaptor.forClass(UpdateAnnouncementPort.Command.class);
     verify(updateAnnouncementPort, times(1)).updateAnnouncement(commandCaptor.capture());
     assertThat(commandCaptor.getValue().announcement().getNorm()).isEqualTo(announcement.getNorm());
     assertThat(commandCaptor.getValue().announcement().getReleasedByDocumentalistAt())
-        .isAfter(instantBeforeRelease);
+      .isAfter(instantBeforeRelease);
   }
 
   @Test
   void itShouldThrowForUnknownAnnouncement() {
     // Given
-    final var query =
-        new ReleaseAnnouncementUseCase.Query(
-            "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1");
+    final var query = new ReleaseAnnouncementUseCase.Query(
+      "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"
+    );
     when(loadAnnouncementByNormEliPort.loadAnnouncementByNormEli(any()))
-        .thenReturn(Optional.empty());
+      .thenReturn(Optional.empty());
 
     // when
     assertThatThrownBy(() -> releaseService.releaseAnnouncement(query))
-        // then
-        .isInstanceOf(AnnouncementNotFoundException.class);
+      // then
+      .isInstanceOf(AnnouncementNotFoundException.class);
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/SingleModValidatorTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/SingleModValidatorTest.java
@@ -28,16 +28,14 @@ class SingleModValidatorTest {
 
   @Nested
   class quotedText {
+
     @Test
     void oldTextIsEmpty() {
-
       // given
       final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithMods.xml");
-      final Node modNode =
-          amendingNorm
-              .getNodeByEId(
-                  "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1")
-              .orElseThrow();
+      final Node modNode = amendingNorm
+        .getNodeByEId("hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1")
+        .orElseThrow();
       final Mod mod = new Mod(modNode);
       mod.setOldText("");
 
@@ -48,21 +46,19 @@ class SingleModValidatorTest {
 
       // then
       assertThat(thrown)
-          .isInstanceOf(MandatoryNodeNotFoundException.class)
-          .hasMessageContaining(
-              "Element with xpath 'normalize-space(./quotedText[1])' not found in 'akn:mod' of norm 'eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1'");
+        .isInstanceOf(MandatoryNodeNotFoundException.class)
+        .hasMessageContaining(
+          "Element with xpath 'normalize-space(./quotedText[1])' not found in 'akn:mod' of norm 'eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1'"
+        );
     }
 
     @Test
     void oldTextNotTheSameInZf0Norm() {
-
       // given
       final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithMods.xml");
-      final Node modNode =
-          amendingNorm
-              .getNodeByEId(
-                  "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1")
-              .orElseThrow();
+      final Node modNode = amendingNorm
+        .getNodeByEId("hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1")
+        .orElseThrow();
       final Mod mod = new Mod(modNode);
       mod.setOldText("not the same text as in target law");
 
@@ -73,46 +69,49 @@ class SingleModValidatorTest {
 
       // then
       assertThat(thrown)
-          .isInstanceOf(ValidationException.class)
-          .hasMessageContaining(
-              "The character range 9-34 of passive mod with eId meta-1_analysis-1_pasmod-1_textualmod-2 within ZF0 norm with eli eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu/regelungstext-1 does not resolve to the targeted text to be replaced.");
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining(
+          "The character range 9-34 of passive mod with eId meta-1_analysis-1_pasmod-1_textualmod-2 within ZF0 norm with eli eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu/regelungstext-1 does not resolve to the targeted text to be replaced."
+        );
     }
 
     @Test
     void nodeWithGivenDestEidDoesNotExists() {
       // given
       final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithMods.xml");
-      final Node modNode =
-          amendingNorm
-              .getNodeByEId(
-                  "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1")
-              .orElseThrow();
+      final Node modNode = amendingNorm
+        .getNodeByEId("hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1")
+        .orElseThrow();
       final Mod mod = new Mod(modNode);
       final Norm zf0Norm = NormFixtures.loadFromDisk("NormWithPassiveModifications.xml");
-      final TextualMod passiveMod =
-          zf0Norm.getMeta().getAnalysis().orElseThrow().getPassiveModifications().getFirst();
+      final TextualMod passiveMod = zf0Norm
+        .getMeta()
+        .getAnalysis()
+        .orElseThrow()
+        .getPassiveModifications()
+        .getFirst();
       passiveMod.setDestinationHref(
-          "#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1");
+        "#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"
+      );
 
       // when
       Throwable thrown = catchThrowable(() -> underTest.validate(zf0Norm, mod));
 
       // then
       assertThat(thrown)
-          .isInstanceOf(ValidationException.class)
-          .hasMessageContaining(
-              "Target node with eid hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1 not present");
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining(
+          "Target node with eid hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1 not present"
+        );
     }
 
     @Test
     void validationSuccessful() {
       // given
       final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithMods.xml");
-      final Node modNode =
-          amendingNorm
-              .getNodeByEId(
-                  "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1")
-              .orElseThrow();
+      final Node modNode = amendingNorm
+        .getNodeByEId("hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1")
+        .orElseThrow();
       final Mod mod = new Mod(modNode);
       final Norm zf0Norm = NormFixtures.loadFromDisk("NormWithPassiveModifications.xml");
 
@@ -124,29 +123,26 @@ class SingleModValidatorTest {
     void validationSuccessfulUntilEndOfParagraph() {
       // given
       final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithMods.xml");
-      final Node modNode =
-          amendingNorm
-              .getNodeByEId(
-                  "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1")
-              .orElseThrow();
+      final Node modNode = amendingNorm
+        .getNodeByEId("hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1")
+        .orElseThrow();
       final Mod mod = new Mod(modNode);
       final String amendingNormEli = amendingNorm.getEli();
-      final String href =
-          new Href.Builder()
-              .setEli(amendingNormEli)
-              .setEId("hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1")
-              .setCharacterRange(new CharacterRange("9-112"))
-              .buildAbsolute()
-              .value();
+      final String href = new Href.Builder()
+        .setEli(amendingNormEli)
+        .setEId("hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1")
+        .setCharacterRange(new CharacterRange("9-112"))
+        .buildAbsolute()
+        .value();
 
       // 112 paragraph length
       amendingNorm
-          .getMeta()
-          .getAnalysis()
-          .map(Analysis::getActiveModifications)
-          .orElse(Collections.emptyList())
-          .getFirst()
-          .setDestinationHref(href);
+        .getMeta()
+        .getAnalysis()
+        .map(Analysis::getActiveModifications)
+        .orElse(Collections.emptyList())
+        .getFirst()
+        .setDestinationHref(href);
 
       mod.setTargetRefHref(href);
       mod.setOldText("§ 9 Abs. 1 Satz 2, Abs. 2");
@@ -161,29 +157,26 @@ class SingleModValidatorTest {
     void validationSuccessfulStartingAt0() {
       // given
       final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithMods.xml");
-      final Node modNode =
-          amendingNorm
-              .getNodeByEId(
-                  "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1")
-              .orElseThrow();
+      final Node modNode = amendingNorm
+        .getNodeByEId("hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1")
+        .orElseThrow();
       final Mod mod = new Mod(modNode);
       final String amendingNormEli = amendingNorm.getEli();
-      final String href =
-          new Href.Builder()
-              .setEli(amendingNormEli)
-              .setEId("hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1")
-              .setCharacterRange(new CharacterRange("0-34"))
-              .buildAbsolute()
-              .value();
+      final String href = new Href.Builder()
+        .setEli(amendingNormEli)
+        .setEId("hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1")
+        .setCharacterRange(new CharacterRange("0-34"))
+        .buildAbsolute()
+        .value();
 
       // 112 paragraph length
       amendingNorm
-          .getMeta()
-          .getAnalysis()
-          .map(Analysis::getActiveModifications)
-          .orElse(Collections.emptyList())
-          .getFirst()
-          .setDestinationHref(href);
+        .getMeta()
+        .getAnalysis()
+        .map(Analysis::getActiveModifications)
+        .orElse(Collections.emptyList())
+        .getFirst()
+        .setDestinationHref(href);
 
       mod.setTargetRefHref(href);
       mod.setOldText("§ 9 Abs. 1 Satz 2, Abs. 2");
@@ -199,54 +192,64 @@ class SingleModValidatorTest {
       // given
       final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithMods.xml");
       final String amendingNormEli = amendingNorm.getEli();
-      final Node modNode =
-          amendingNorm
-              .getNodeByEId(
-                  "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1")
-              .orElseThrow();
+      final Node modNode = amendingNorm
+        .getNodeByEId("hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1")
+        .orElseThrow();
       final Mod mod = new Mod(modNode);
       mod.setTargetRefHref(
-          new Href.Builder()
-              .setEli(amendingNormEli)
-              .setEId("hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1")
-              .setCharacterRange(new CharacterRange(""))
-              .buildInternalReference()
-              .value());
+        new Href.Builder()
+          .setEli(amendingNormEli)
+          .setEId("hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1")
+          .setCharacterRange(new CharacterRange(""))
+          .buildInternalReference()
+          .value()
+      );
 
       final Norm zf0Norm = NormFixtures.loadFromDisk("NormWithPassiveModifications.xml");
-      final TextualMod passiveMod =
-          zf0Norm.getMeta().getAnalysis().orElseThrow().getPassiveModifications().getFirst();
+      final TextualMod passiveMod = zf0Norm
+        .getMeta()
+        .getAnalysis()
+        .orElseThrow()
+        .getPassiveModifications()
+        .getFirst();
       passiveMod.setDestinationHref(
-          new Href.Builder()
-              .setEId("hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1")
-              .setCharacterRange(new CharacterRange(""))
-              .buildInternalReference()
-              .value());
+        new Href.Builder()
+          .setEId("hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1")
+          .setCharacterRange(new CharacterRange(""))
+          .buildInternalReference()
+          .value()
+      );
 
       // when
       Throwable thrown = catchThrowable(() -> underTest.validate(zf0Norm, mod));
 
       // then
       assertThat(thrown)
-          .isInstanceOf(ValidationException.class)
-          .hasMessageContaining(
-              "Destination href with value #hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/ of passive mod with eId meta-1_analysis-1_pasmod-1_textualmod-2 within ZF0 norm with eli eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu/regelungstext-1 not present.");
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining(
+          "Destination href with value #hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/ of passive mod with eId meta-1_analysis-1_pasmod-1_textualmod-2 within ZF0 norm with eli eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu/regelungstext-1 not present."
+        );
     }
 
     private static Stream<Arguments> provideParametersForThrowsExceptionWhenCharacterRange() {
       return Stream.of(
-          Arguments.of(
-              "20-20.xml",
-              "The character range 20-20.xml of passive mod with eId meta-1_analysis-1_pasmod-1_textualmod-2 within ZF0 norm with eli eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu/regelungstext-1 has invalid format."),
-          Arguments.of(
-              "-20.xml",
-              "The character range -20.xml of passive mod with eId meta-1_analysis-1_pasmod-1_textualmod-2 within ZF0 norm with eli eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu/regelungstext-1 has invalid format."),
-          Arguments.of(
-              "0-.xml",
-              "The character range 0-.xml of passive mod with eId meta-1_analysis-1_pasmod-1_textualmod-2 within ZF0 norm with eli eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu/regelungstext-1 has invalid format."),
-          Arguments.of(
-              "",
-              "Destination href with value #hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/ of passive mod with eId meta-1_analysis-1_pasmod-1_textualmod-2 within ZF0 norm with eli eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu/regelungstext-1 not present."));
+        Arguments.of(
+          "20-20.xml",
+          "The character range 20-20.xml of passive mod with eId meta-1_analysis-1_pasmod-1_textualmod-2 within ZF0 norm with eli eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu/regelungstext-1 has invalid format."
+        ),
+        Arguments.of(
+          "-20.xml",
+          "The character range -20.xml of passive mod with eId meta-1_analysis-1_pasmod-1_textualmod-2 within ZF0 norm with eli eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu/regelungstext-1 has invalid format."
+        ),
+        Arguments.of(
+          "0-.xml",
+          "The character range 0-.xml of passive mod with eId meta-1_analysis-1_pasmod-1_textualmod-2 within ZF0 norm with eli eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu/regelungstext-1 has invalid format."
+        ),
+        Arguments.of(
+          "",
+          "Destination href with value #hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/ of passive mod with eId meta-1_analysis-1_pasmod-1_textualmod-2 within ZF0 norm with eli eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu/regelungstext-1 not present."
+        )
+      );
     }
 
     @ParameterizedTest
@@ -254,22 +257,25 @@ class SingleModValidatorTest {
     void throwsExceptionWhenCharacterRangeIsMalformed(String cr, String message) {
       // given
       final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithMods.xml");
-      final Node modNode =
-          amendingNorm
-              .getNodeByEId(
-                  "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1")
-              .orElseThrow();
+      final Node modNode = amendingNorm
+        .getNodeByEId("hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1")
+        .orElseThrow();
       final Mod mod = new Mod(modNode);
 
       final Norm zf0Norm = NormFixtures.loadFromDisk("NormWithPassiveModifications.xml");
-      final TextualMod passiveMod =
-          zf0Norm.getMeta().getAnalysis().orElseThrow().getPassiveModifications().getFirst();
+      final TextualMod passiveMod = zf0Norm
+        .getMeta()
+        .getAnalysis()
+        .orElseThrow()
+        .getPassiveModifications()
+        .getFirst();
       passiveMod.setDestinationHref(
-          new Href.Builder()
-              .setEId("hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1")
-              .setCharacterRange(new CharacterRange(cr))
-              .buildInternalReference()
-              .value());
+        new Href.Builder()
+          .setEId("hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1")
+          .setCharacterRange(new CharacterRange(cr))
+          .buildInternalReference()
+          .value()
+      );
 
       // when
       Throwable thrown = catchThrowable(() -> underTest.validate(zf0Norm, mod));
@@ -282,45 +288,48 @@ class SingleModValidatorTest {
     void ThrowsExceptionWhenCharacterRangeEndIsTooHigh() {
       // given
       final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithMods.xml");
-      final Node modNode =
-          amendingNorm
-              .getNodeByEId(
-                  "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1")
-              .orElseThrow();
+      final Node modNode = amendingNorm
+        .getNodeByEId("hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1")
+        .orElseThrow();
       final Mod mod = new Mod(modNode);
 
       final Norm zf0Norm = NormFixtures.loadFromDisk("NormWithPassiveModifications.xml");
-      final TextualMod passiveMod =
-          zf0Norm.getMeta().getAnalysis().orElseThrow().getPassiveModifications().getFirst();
+      final TextualMod passiveMod = zf0Norm
+        .getMeta()
+        .getAnalysis()
+        .orElseThrow()
+        .getPassiveModifications()
+        .getFirst();
       passiveMod.setDestinationHref(
-          new Href.Builder()
-              .setEId("hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1")
-              .setCharacterRange(new CharacterRange("9-1113"))
-              .buildInternalReference()
-              .value());
+        new Href.Builder()
+          .setEId("hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1")
+          .setCharacterRange(new CharacterRange("9-1113"))
+          .buildInternalReference()
+          .value()
+      );
 
       // when
       Throwable thrown = catchThrowable(() -> underTest.validate(zf0Norm, mod));
 
       // then
       assertThat(thrown)
-          .isInstanceOf(ValidationException.class)
-          .hasMessageContaining(
-              "The character range 9-1113 of passive mod with eId meta-1_analysis-1_pasmod-1_textualmod-2 within ZF0 norm with eli eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu/regelungstext-1 is not within the target node.");
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining(
+          "The character range 9-1113 of passive mod with eId meta-1_analysis-1_pasmod-1_textualmod-2 within ZF0 norm with eli eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu/regelungstext-1 is not within the target node."
+        );
     }
   }
 
   @Nested
   class quotedStructure {
+
     @Test
     void validationSuccessNoUpTo() {
       // given
       final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithQuotedStructureMods.xml");
-      final Node modNode =
-          amendingNorm
-              .getNodeByEId(
-                  "hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1")
-              .orElseThrow();
+      final Node modNode = amendingNorm
+        .getNodeByEId("hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1")
+        .orElseThrow();
       final Mod mod = new Mod(modNode);
       final Norm zf0Norm = NormFixtures.loadFromDisk("NormWithPassiveModsQuotedStructure.xml");
 
@@ -332,14 +341,13 @@ class SingleModValidatorTest {
     void validationSuccessWithUpTo() {
       // given
       final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithQuotedStructureModsAndUpTo.xml");
-      final Node modNode =
-          amendingNorm
-              .getNodeByEId(
-                  "hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1")
-              .orElseThrow();
+      final Node modNode = amendingNorm
+        .getNodeByEId("hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1")
+        .orElseThrow();
       final Mod mod = new Mod(modNode);
-      final Norm zf0Norm =
-          NormFixtures.loadFromDisk("NormWithPassiveModsQuotedStructureAndUpTo.xml");
+      final Norm zf0Norm = NormFixtures.loadFromDisk(
+        "NormWithPassiveModsQuotedStructureAndUpTo.xml"
+      );
 
       // when then
       Assertions.assertDoesNotThrow(() -> underTest.validate(zf0Norm, mod));
@@ -349,17 +357,20 @@ class SingleModValidatorTest {
     void upToNodeNotPresent() {
       // given
       final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithQuotedStructureModsAndUpTo.xml");
-      final Node modNode =
-          amendingNorm
-              .getNodeByEId(
-                  "hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1")
-              .orElseThrow();
+      final Node modNode = amendingNorm
+        .getNodeByEId("hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1")
+        .orElseThrow();
       final Mod mod = new Mod(modNode);
-      final Norm zf0Norm =
-          NormFixtures.loadFromDisk("NormWithPassiveModsQuotedStructureAndUpTo.xml");
+      final Norm zf0Norm = NormFixtures.loadFromDisk(
+        "NormWithPassiveModsQuotedStructureAndUpTo.xml"
+      );
 
-      final TextualMod passiveMod =
-          zf0Norm.getMeta().getAnalysis().orElseThrow().getPassiveModifications().getFirst();
+      final TextualMod passiveMod = zf0Norm
+        .getMeta()
+        .getAnalysis()
+        .orElseThrow()
+        .getPassiveModifications()
+        .getFirst();
       passiveMod.setDestinationUpTo("#not-present-href");
 
       // when
@@ -367,54 +378,63 @@ class SingleModValidatorTest {
 
       // then
       assertThat(thrown)
-          .isInstanceOf(ValidationException.class)
-          .hasMessageContaining(
-              "Target upTo node with eid not-present-href not present in ZF0 norm with eli eli/bund/bgbl-1/1999/66/2002-02-20/1/deu/regelungstext-1.");
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining(
+          "Target upTo node with eid not-present-href not present in ZF0 norm with eli eli/bund/bgbl-1/1999/66/2002-02-20/1/deu/regelungstext-1."
+        );
     }
 
     @Test
     void upToNodeAndTargetNodeNotSiblings() {
       // given
       final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithQuotedStructureModsAndUpTo.xml");
-      final Node modNode =
-          amendingNorm
-              .getNodeByEId(
-                  "hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1")
-              .orElseThrow();
+      final Node modNode = amendingNorm
+        .getNodeByEId("hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1")
+        .orElseThrow();
       final Mod mod = new Mod(modNode);
-      final Norm zf0Norm =
-          NormFixtures.loadFromDisk("NormWithPassiveModsQuotedStructureAndUpTo.xml");
+      final Norm zf0Norm = NormFixtures.loadFromDisk(
+        "NormWithPassiveModsQuotedStructureAndUpTo.xml"
+      );
 
-      final TextualMod passiveMod =
-          zf0Norm.getMeta().getAnalysis().orElseThrow().getPassiveModifications().getFirst();
+      final TextualMod passiveMod = zf0Norm
+        .getMeta()
+        .getAnalysis()
+        .orElseThrow()
+        .getPassiveModifications()
+        .getFirst();
       passiveMod.setDestinationUpTo(
-          "#hauptteil-1_para-2_abs-3_untergl-1_listenelem-1_untergl-1_listenelem-b");
+        "#hauptteil-1_para-2_abs-3_untergl-1_listenelem-1_untergl-1_listenelem-b"
+      );
 
       // when
       Throwable thrown = catchThrowable(() -> underTest.validate(zf0Norm, mod));
 
       // then
       assertThat(thrown)
-          .isInstanceOf(ValidationException.class)
-          .hasMessageContaining(
-              "Target node with eid hauptteil-1_para-2_abs-1 and target upTo node with eid hauptteil-1_para-2_abs-3_untergl-1_listenelem-1_untergl-1_listenelem-b are not siblings in ZF0 norm with eli eli/bund/bgbl-1/1999/66/2002-02-20/1/deu/regelungstext-1.");
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining(
+          "Target node with eid hauptteil-1_para-2_abs-1 and target upTo node with eid hauptteil-1_para-2_abs-3_untergl-1_listenelem-1_untergl-1_listenelem-b are not siblings in ZF0 norm with eli eli/bund/bgbl-1/1999/66/2002-02-20/1/deu/regelungstext-1."
+        );
     }
 
     @Test
     void upToNodeBeforeTargetNode() {
       // given
       final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithQuotedStructureModsAndUpTo.xml");
-      final Node modNode =
-          amendingNorm
-              .getNodeByEId(
-                  "hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1")
-              .orElseThrow();
+      final Node modNode = amendingNorm
+        .getNodeByEId("hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1")
+        .orElseThrow();
       final Mod mod = new Mod(modNode);
-      final Norm zf0Norm =
-          NormFixtures.loadFromDisk("NormWithPassiveModsQuotedStructureAndUpTo.xml");
+      final Norm zf0Norm = NormFixtures.loadFromDisk(
+        "NormWithPassiveModsQuotedStructureAndUpTo.xml"
+      );
 
-      final TextualMod passiveMod =
-          zf0Norm.getMeta().getAnalysis().orElseThrow().getPassiveModifications().getFirst();
+      final TextualMod passiveMod = zf0Norm
+        .getMeta()
+        .getAnalysis()
+        .orElseThrow()
+        .getPassiveModifications()
+        .getFirst();
       passiveMod.setDestinationHref("#hauptteil-1_para-2_abs-3");
       passiveMod.setDestinationUpTo("#hauptteil-1_para-2_abs-1");
 
@@ -423,9 +443,10 @@ class SingleModValidatorTest {
 
       // then
       assertThat(thrown)
-          .isInstanceOf(ValidationException.class)
-          .hasMessageContaining(
-              "Target node with eid hauptteil-1_para-2_abs-3 does not appear before target upTo node with eid hauptteil-1_para-2_abs-1 in ZF0 norm with eli eli/bund/bgbl-1/1999/66/2002-02-20/1/deu/regelungstext-1.");
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining(
+          "Target node with eid hauptteil-1_para-2_abs-3 does not appear before target upTo node with eid hauptteil-1_para-2_abs-1 in ZF0 norm with eli eli/bund/bgbl-1/1999/66/2002-02-20/1/deu/regelungstext-1."
+        );
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeBoundaryServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeBoundaryServiceTest.java
@@ -43,159 +43,172 @@ class TimeBoundaryServiceTest {
       // Given
       var eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
 
-      var norm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                                 <akn:act name="regelungstext">
-                                    <!-- Metadaten -->
-                                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                       <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                          <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                              source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                          <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                                              source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                          <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-01-01"
-                                              source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                       </akn:lifecycle>
-                                       <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                           <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                              <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                           </akn:temporalGroup>
-                                           <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
-                                              <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
-                                           </akn:temporalGroup>
-                                       </akn:temporalData>
-                                    </akn:meta>
-                                 </akn:act>
-                              </akn:akomaNtoso>
-                            """))
-              .build();
+      var norm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                          <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                              source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                          <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                              source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                          <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-01-01"
+                              source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                       </akn:lifecycle>
+                       <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                           <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                              <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                           </akn:temporalGroup>
+                           <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
+                              <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
+                           </akn:temporalGroup>
+                       </akn:temporalData>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(norm));
 
       // When
-      var timeBoundaries =
-          service.loadTimeBoundariesOfNorm(new LoadTimeBoundariesUseCase.Query(eli));
+      var timeBoundaries = service.loadTimeBoundariesOfNorm(
+        new LoadTimeBoundariesUseCase.Query(eli)
+      );
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
       assertThat(timeBoundaries).hasSize(2);
 
       // handle 1st time boundary
       assertThat(timeBoundaries.getFirst().getEventRef().getDate())
-          .contains(LocalDate.parse("2023-12-30"));
+        .contains(LocalDate.parse("2023-12-30"));
       assertThat(timeBoundaries.getFirst().getEventRefEid().get())
-          .contains("meta-1_lebzykl-1_ereignis-2");
+        .contains("meta-1_lebzykl-1_ereignis-2");
       assertThat(
-              timeBoundaries
-                  .getFirst()
-                  .getTimeInterval()
-                  .getNode()
-                  .getParentNode()
-                  .getAttributes()
-                  .getNamedItem("eId")
-                  .getNodeValue())
-          .contains("meta-1_geltzeiten-1_geltungszeitgr-1");
+        timeBoundaries
+          .getFirst()
+          .getTimeInterval()
+          .getNode()
+          .getParentNode()
+          .getAttributes()
+          .getNamedItem("eId")
+          .getNodeValue()
+      )
+        .contains("meta-1_geltzeiten-1_geltungszeitgr-1");
       assertThat(
-              timeBoundaries
-                  .getFirst()
-                  .getTimeInterval()
-                  .getNode()
-                  .getParentNode()
-                  .getAttributes()
-                  .getNamedItem("GUID")
-                  .getNodeValue())
-          .contains("ac311ee1-33d3-4b9b-a974-776e55a88396");
+        timeBoundaries
+          .getFirst()
+          .getTimeInterval()
+          .getNode()
+          .getParentNode()
+          .getAttributes()
+          .getNamedItem("GUID")
+          .getNodeValue()
+      )
+        .contains("ac311ee1-33d3-4b9b-a974-776e55a88396");
       assertThat(timeBoundaries.getFirst().getTimeIntervalEid().get())
-          .contains("meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1");
+        .contains("meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1");
       assertThat(
-              timeBoundaries
-                  .getFirst()
-                  .getTimeInterval()
-                  .getNode()
-                  .getAttributes()
-                  .getNamedItem("GUID")
-                  .getNodeValue())
-          .contains("ca9f53aa-d374-4bec-aca3-fff4e3485179");
+        timeBoundaries
+          .getFirst()
+          .getTimeInterval()
+          .getNode()
+          .getAttributes()
+          .getNamedItem("GUID")
+          .getNodeValue()
+      )
+        .contains("ca9f53aa-d374-4bec-aca3-fff4e3485179");
       assertThat(
-              timeBoundaries
-                  .get(0)
-                  .getTimeInterval()
-                  .getNode()
-                  .getAttributes()
-                  .getNamedItem("refersTo")
-                  .getNodeValue())
-          .contains("geltungszeit");
+        timeBoundaries
+          .get(0)
+          .getTimeInterval()
+          .getNode()
+          .getAttributes()
+          .getNamedItem("refersTo")
+          .getNodeValue()
+      )
+        .contains("geltungszeit");
       assertThat(
-              timeBoundaries
-                  .get(0)
-                  .getTimeInterval()
-                  .getNode()
-                  .getAttributes()
-                  .getNamedItem("start")
-                  .getNodeValue())
-          .contains("#" + timeBoundaries.get(0).getEventRefEid().get());
+        timeBoundaries
+          .get(0)
+          .getTimeInterval()
+          .getNode()
+          .getAttributes()
+          .getNamedItem("start")
+          .getNodeValue()
+      )
+        .contains("#" + timeBoundaries.get(0).getEventRefEid().get());
 
       // handle 2nd time boundary
       assertThat(timeBoundaries.get(1).getEventRef().getDate())
-          .contains(LocalDate.parse("2024-01-01"));
+        .contains(LocalDate.parse("2024-01-01"));
       assertThat(timeBoundaries.get(1).getEventRefEid().get())
-          .contains("meta-1_lebzykl-1_ereignis-3");
+        .contains("meta-1_lebzykl-1_ereignis-3");
       assertThat(
-              timeBoundaries
-                  .get(1)
-                  .getTimeInterval()
-                  .getNode()
-                  .getParentNode()
-                  .getAttributes()
-                  .getNamedItem("eId")
-                  .getNodeValue())
-          .contains("meta-1_geltzeiten-1_geltungszeitgr-2");
+        timeBoundaries
+          .get(1)
+          .getTimeInterval()
+          .getNode()
+          .getParentNode()
+          .getAttributes()
+          .getNamedItem("eId")
+          .getNodeValue()
+      )
+        .contains("meta-1_geltzeiten-1_geltungszeitgr-2");
       assertThat(
-              timeBoundaries
-                  .get(1)
-                  .getTimeInterval()
-                  .getNode()
-                  .getParentNode()
-                  .getAttributes()
-                  .getNamedItem("GUID")
-                  .getNodeValue())
-          .contains("fdfaeef0-0300-4e5b-9e8b-14d2162bfb00");
+        timeBoundaries
+          .get(1)
+          .getTimeInterval()
+          .getNode()
+          .getParentNode()
+          .getAttributes()
+          .getNamedItem("GUID")
+          .getNodeValue()
+      )
+        .contains("fdfaeef0-0300-4e5b-9e8b-14d2162bfb00");
       assertThat(timeBoundaries.get(1).getTimeIntervalEid().get())
-          .contains("meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1");
+        .contains("meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1");
       assertThat(
-              timeBoundaries
-                  .get(1)
-                  .getTimeInterval()
-                  .getNode()
-                  .getAttributes()
-                  .getNamedItem("GUID")
-                  .getNodeValue())
-          .contains("8118030a-5fa4-4f9c-a880-b7ba19e5edfb");
+        timeBoundaries
+          .get(1)
+          .getTimeInterval()
+          .getNode()
+          .getAttributes()
+          .getNamedItem("GUID")
+          .getNodeValue()
+      )
+        .contains("8118030a-5fa4-4f9c-a880-b7ba19e5edfb");
       assertThat(
-              timeBoundaries
-                  .get(1)
-                  .getTimeInterval()
-                  .getNode()
-                  .getAttributes()
-                  .getNamedItem("refersTo")
-                  .getNodeValue())
-          .contains("geltungszeit");
+        timeBoundaries
+          .get(1)
+          .getTimeInterval()
+          .getNode()
+          .getAttributes()
+          .getNamedItem("refersTo")
+          .getNodeValue()
+      )
+        .contains("geltungszeit");
       assertThat(
-              timeBoundaries
-                  .get(1)
-                  .getTimeInterval()
-                  .getNode()
-                  .getAttributes()
-                  .getNamedItem("start")
-                  .getNodeValue())
-          .contains("#" + timeBoundaries.get(1).getEventRefEid().get());
+        timeBoundaries
+          .get(1)
+          .getTimeInterval()
+          .getNode()
+          .getAttributes()
+          .getNamedItem("start")
+          .getNodeValue()
+      )
+        .contains("#" + timeBoundaries.get(1).getEventRefEid().get());
     }
 
     @Test
@@ -203,38 +216,41 @@ class TimeBoundaryServiceTest {
       // Given
       var eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
 
-      var norm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                                              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                                              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                                                 <akn:act name="regelungstext">
-                                                    <!-- Metadaten -->
-                                                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                                       <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                                          <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                                              source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                                       </akn:lifecycle>
-                                                       <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                                       </akn:temporalData>
-                                                    </akn:meta>
-                                                 </akn:act>
-                                              </akn:akomaNtoso>
-                                            """))
-              .build();
+      var norm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                          <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                              source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                       </akn:lifecycle>
+                       <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                       </akn:temporalData>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(norm));
 
       // When
-      var timeBoundaries =
-          service.loadTimeBoundariesOfNorm(new LoadTimeBoundariesUseCase.Query(eli));
+      var timeBoundaries = service.loadTimeBoundariesOfNorm(
+        new LoadTimeBoundariesUseCase.Query(eli)
+      );
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
       assertThat(timeBoundaries).isEmpty();
     }
   }
@@ -244,91 +260,92 @@ class TimeBoundaryServiceTest {
 
     @Test
     void itCallsLoadTimeBoundariesAmendedByAndReturnsTimeBoundaries() {
-
       // Given
       var eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
       var amendedBy = "eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/regelungstext-1";
 
-      var norm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                                    <?xml version="1.0" encoding="UTF-8"?>
-                                    <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                                    <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                                                                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                                       <akn:act name="regelungstext">
-                                          <!-- Metadaten -->
-                                          <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                             <akn:analysis eId="meta-1_analysis-1" GUID="5a5d264e-431e-4dc1-b971-4bd81af8a0f4" source="attributsemantik-noch-undefiniert">
-                                                <akn:passiveModifications eId="meta-1_analysis-1_pasmod-1" GUID="77aae58f-06c9-4189-af80-a5f3ada6432c">
-                                                   <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-1" GUID="06fb52c3-fce1-4be8-accc-3035452378ff" type="substitution">
-                                                      <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-1_source-1" GUID="5384f580-110b-4f8a-8794-8b85c29aabdf" href="eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1.xml" />
-                                                      <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-1_destination-1" GUID="2c26512f-fb04-45f2-8283-660274e52fdb" href="#para-9_abs-3" />
-                                                      <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-1_gelzeitnachw-1" GUID="45331583-4386-4e3f-b68f-5af327347874" period="#meta-1_geltzeiten-1_geltungszeitgr-2" />
-                                                   </akn:textualMod>
-                                                   <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-2" GUID="26b091d0-1bb9-4c83-b940-f6788b2922f2" type="substitution">
-                                                      <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-2_source-1" GUID="a5e43d31-65e1-4d99-a1aa-fb4695a94cf5" href="eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml" />
-                                                      <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-2_destination-1" GUID="8c0418f1-b6fa-4110-8820-cf0db752c5bd" href="#para-20_abs-1/100-126" />
-                                                      <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-2_gelzeitnachw-1" GUID="e5962d3b-9bb8-4eb0-8d8f-131a5114fddb" period="#meta-1_geltzeiten-1_geltungszeitgr-3" />
-                                                   </akn:textualMod>
-                                                   <!-- Passive mod from different amending law -->
-                                                   <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-2" GUID="26b091d0-1bb9-4c83-b940-f6788b2922f2" type="substitution">
-                                                      <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-2_source-1" GUID="a5e43d31-65e1-4d99-a1aa-fb4695a94cf5" href="eli/bund/bgbl-1/2024/120/2024-06-28/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml" />
-                                                      <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-2_destination-1" GUID="8c0418f1-b6fa-4110-8820-cf0db752c5bd" href="#para-20_abs-1/100-126" />
-                                                      <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-2_gelzeitnachw-1" GUID="e5962d3b-9bb8-4eb0-8d8f-131a5114fddb" period="#meta-1_geltzeiten-1_geltungszeitgr-4" />
-                                                   </akn:textualMod>
-                                                </akn:passiveModifications>
-                                             </akn:analysis>
-                                             <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29" source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-01-01" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-4" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-02-28" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                             </akn:lifecycle>
-                                             <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                                <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                                   <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                                </akn:temporalGroup>
-                                                <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
-                                                   <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
-                                                </akn:temporalGroup>
-                                                <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-3" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
-                                                   <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4" />
-                                                </akn:temporalGroup>
-                                                <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-4" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
-                                                   <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-4_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4" />
-                                                </akn:temporalGroup>
-                                             </akn:temporalData>
-                                          </akn:meta>
-                                       </akn:act>
-                                    </akn:akomaNtoso>
-                                    """))
-              .build();
+      var norm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                                                                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+               <akn:act name="regelungstext">
+                  <!-- Metadaten -->
+                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                     <akn:analysis eId="meta-1_analysis-1" GUID="5a5d264e-431e-4dc1-b971-4bd81af8a0f4" source="attributsemantik-noch-undefiniert">
+                        <akn:passiveModifications eId="meta-1_analysis-1_pasmod-1" GUID="77aae58f-06c9-4189-af80-a5f3ada6432c">
+                           <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-1" GUID="06fb52c3-fce1-4be8-accc-3035452378ff" type="substitution">
+                              <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-1_source-1" GUID="5384f580-110b-4f8a-8794-8b85c29aabdf" href="eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1.xml" />
+                              <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-1_destination-1" GUID="2c26512f-fb04-45f2-8283-660274e52fdb" href="#para-9_abs-3" />
+                              <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-1_gelzeitnachw-1" GUID="45331583-4386-4e3f-b68f-5af327347874" period="#meta-1_geltzeiten-1_geltungszeitgr-2" />
+                           </akn:textualMod>
+                           <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-2" GUID="26b091d0-1bb9-4c83-b940-f6788b2922f2" type="substitution">
+                              <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-2_source-1" GUID="a5e43d31-65e1-4d99-a1aa-fb4695a94cf5" href="eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml" />
+                              <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-2_destination-1" GUID="8c0418f1-b6fa-4110-8820-cf0db752c5bd" href="#para-20_abs-1/100-126" />
+                              <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-2_gelzeitnachw-1" GUID="e5962d3b-9bb8-4eb0-8d8f-131a5114fddb" period="#meta-1_geltzeiten-1_geltungszeitgr-3" />
+                           </akn:textualMod>
+                           <!-- Passive mod from different amending law -->
+                           <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-2" GUID="26b091d0-1bb9-4c83-b940-f6788b2922f2" type="substitution">
+                              <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-2_source-1" GUID="a5e43d31-65e1-4d99-a1aa-fb4695a94cf5" href="eli/bund/bgbl-1/2024/120/2024-06-28/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml" />
+                              <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-2_destination-1" GUID="8c0418f1-b6fa-4110-8820-cf0db752c5bd" href="#para-20_abs-1/100-126" />
+                              <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-2_gelzeitnachw-1" GUID="e5962d3b-9bb8-4eb0-8d8f-131a5114fddb" period="#meta-1_geltzeiten-1_geltungszeitgr-4" />
+                           </akn:textualMod>
+                        </akn:passiveModifications>
+                     </akn:analysis>
+                     <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                        <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29" source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                        <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                        <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-01-01" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                        <akn:eventRef eId="meta-1_lebzykl-1_ereignis-4" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-02-28" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                     </akn:lifecycle>
+                     <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                        <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                           <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                        </akn:temporalGroup>
+                        <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
+                           <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
+                        </akn:temporalGroup>
+                        <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-3" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
+                           <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4" />
+                        </akn:temporalGroup>
+                        <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-4" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
+                           <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-4_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4" />
+                        </akn:temporalGroup>
+                     </akn:temporalData>
+                  </akn:meta>
+               </akn:act>
+            </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(norm));
 
       // When
-      var timeBoundaries =
-          service.loadTimeBoundariesAmendedBy(
-              new LoadTimeBoundariesAmendedByUseCase.Query(eli, amendedBy));
+      var timeBoundaries = service.loadTimeBoundariesAmendedBy(
+        new LoadTimeBoundariesAmendedByUseCase.Query(eli, amendedBy)
+      );
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
 
       assertThat(timeBoundaries).hasSize(2);
 
       assertThat(timeBoundaries.getFirst().getTemporalGroupEid())
-          .contains("meta-1_geltzeiten-1_geltungszeitgr-2");
+        .contains("meta-1_geltzeiten-1_geltungszeitgr-2");
       assertThat(timeBoundaries.getFirst().getTimeIntervalEid())
-          .contains("meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1");
+        .contains("meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1");
       assertThat(timeBoundaries.getFirst().getEventRefEid())
-          .contains("meta-1_lebzykl-1_ereignis-3");
+        .contains("meta-1_lebzykl-1_ereignis-3");
 
       assertThat(timeBoundaries.getLast().getTemporalGroupEid())
-          .contains("meta-1_geltzeiten-1_geltungszeitgr-3");
+        .contains("meta-1_geltzeiten-1_geltungszeitgr-3");
       assertThat(timeBoundaries.getLast().getTimeIntervalEid())
-          .contains("meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1");
+        .contains("meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1");
       assertThat(timeBoundaries.getLast().getEventRefEid()).contains("meta-1_lebzykl-1_ereignis-4");
     }
 
@@ -340,11 +357,11 @@ class TimeBoundaryServiceTest {
 
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.empty());
 
-      Throwable thrown =
-          catchThrowable(
-              () ->
-                  service.loadTimeBoundariesAmendedBy(
-                      new LoadTimeBoundariesAmendedByUseCase.Query(eli, amendedBy)));
+      Throwable thrown = catchThrowable(() ->
+        service.loadTimeBoundariesAmendedBy(
+          new LoadTimeBoundariesAmendedByUseCase.Query(eli, amendedBy)
+        )
+      );
 
       assertThat(thrown).isInstanceOf(NormNotFoundException.class);
     }
@@ -352,56 +369,56 @@ class TimeBoundaryServiceTest {
 
   @Nested
   class updateTimeBoundariesOfNorm {
+
     @Test
     void itCallsUpdateTimeBoundariesOfNormAndReturnsTimeBoundariesNothingChanged() {
-
       String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
 
       var oldXml =
-          """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                             <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                             <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                             <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-3" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                          </akn:FRBRExpression>
-                      </akn:identification>
-                       <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                          <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                              source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                          <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                              source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                       </akn:lifecycle>
-                       <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                   <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                      <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                   </akn:temporalGroup>
-                       </akn:temporalData>
-                    </akn:meta>
-                    <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
-                        <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
-                           <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
-                              <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
-                              <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
-                              Innern</akn:docProponent>
-                              <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
-                           </akn:p>
-                        </akn:longTitle>
-                        <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
-                           <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
-                        </akn:block>
-                     </akn:preface>
-                 </akn:act>
-              </akn:akomaNtoso>
-              """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                       <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-3" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                    </akn:FRBRExpression>
+                </akn:identification>
+                 <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                 </akn:lifecycle>
+                 <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                             <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                                <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                             </akn:temporalGroup>
+                 </akn:temporalData>
+              </akn:meta>
+              <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                  <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                     <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                        <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
+                        <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
+                        Innern</akn:docProponent>
+                        <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
+                     </akn:p>
+                  </akn:longTitle>
+                  <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                     <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
+                  </akn:block>
+               </akn:preface>
+           </akn:act>
+        </akn:akomaNtoso>
+        """;
 
       var normBefore = Norm.builder().document(XmlMapper.toDocument(oldXml)).build();
       var normAfter = Norm.builder().document(XmlMapper.toDocument(oldXml)).build();
@@ -411,170 +428,168 @@ class TimeBoundaryServiceTest {
       when(updateNormPort.updateNorm(any())).thenReturn(Optional.of(normAfter));
 
       // When
-      var timeBoundaryChangeDataOldStays =
-          new TimeBoundaryChangeData("meta-1_lebzykl-1_ereignis-2", LocalDate.parse("2023-12-30"));
+      var timeBoundaryChangeDataOldStays = new TimeBoundaryChangeData(
+        "meta-1_lebzykl-1_ereignis-2",
+        LocalDate.parse("2023-12-30")
+      );
 
-      var result =
-          service.updateTimeBoundariesOfNorm(
-              new UpdateTimeBoundariesUseCase.Query(eli, List.of(timeBoundaryChangeDataOldStays)));
+      var result = service.updateTimeBoundariesOfNorm(
+        new UpdateTimeBoundariesUseCase.Query(eli, List.of(timeBoundaryChangeDataOldStays))
+      );
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
       verify(updateNormPort, times(1))
-          .updateNorm(argThat(argument -> Objects.equals(argument.norm(), normAfter)));
+        .updateNorm(argThat(argument -> Objects.equals(argument.norm(), normAfter)));
 
       assertThat(result).isNotEmpty();
     }
 
     @Test
     void itCallsUpdateTimeBoundariesOfNormAndReturnsTimeBoundariesNew() {
-
       String eli = "eli/bund/bgbl-1/1964/s593/2000-01-01/1/deu/regelungstext-1";
 
       var xml =
-          """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2000-01-01/1/deu/regelungstext-1" />
-                             <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                             <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                             <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-3" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                          </akn:FRBRExpression>
-                      </akn:identification>
-                       <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                          <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                              source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                          <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                              source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                       </akn:lifecycle>
-                       <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                             <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                             </akn:temporalGroup>
-                       </akn:temporalData>
-                    </akn:meta>
-                    <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
-                        <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
-                           <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
-                              <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
-                              <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
-                              Innern</akn:docProponent>
-                              <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Dritten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
-                           </akn:p>
-                        </akn:longTitle>
-                        <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
-                           <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
-                        </akn:block>
-                     </akn:preface>
-                 </akn:act>
-              </akn:akomaNtoso>
-              """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2000-01-01/1/deu/regelungstext-1" />
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                       <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-3" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                    </akn:FRBRExpression>
+                </akn:identification>
+                 <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                 </akn:lifecycle>
+                 <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                       <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                       </akn:temporalGroup>
+                 </akn:temporalData>
+              </akn:meta>
+              <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                  <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                     <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                        <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
+                        <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
+                        Innern</akn:docProponent>
+                        <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Dritten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
+                     </akn:p>
+                  </akn:longTitle>
+                  <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                     <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
+                  </akn:block>
+               </akn:preface>
+           </akn:act>
+        </akn:akomaNtoso>
+        """;
 
       var normBefore = Norm.builder().document(XmlMapper.toDocument(xml)).build();
 
       // Given
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(normBefore));
       // When
-      var timeBoundaryChangeDataOldStays =
-          new TimeBoundaryChangeData("meta-1_lebzykl-1_ereignis-2", LocalDate.parse("2023-12-30"));
-      var timeBoundaryChangeDataNewDate =
-          new TimeBoundaryChangeData(null, LocalDate.parse("2024-01-02"));
+      var timeBoundaryChangeDataOldStays = new TimeBoundaryChangeData(
+        "meta-1_lebzykl-1_ereignis-2",
+        LocalDate.parse("2023-12-30")
+      );
+      var timeBoundaryChangeDataNewDate = new TimeBoundaryChangeData(
+        null,
+        LocalDate.parse("2024-01-02")
+      );
 
       service.updateTimeBoundariesOfNorm(
-          new UpdateTimeBoundariesUseCase.Query(
-              eli, List.of(timeBoundaryChangeDataOldStays, timeBoundaryChangeDataNewDate)));
+        new UpdateTimeBoundariesUseCase.Query(
+          eli,
+          List.of(timeBoundaryChangeDataOldStays, timeBoundaryChangeDataNewDate)
+        )
+      );
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
       verify(updateNormPort, times(1))
-          .updateNorm(
-              argThat(
-                  argument ->
-                      Objects.equals(
-                              argument
-                                  .norm()
-                                  .getTimeBoundaries()
-                                  .getFirst()
-                                  .getEventRef()
-                                  .getDate()
-                                  .get(),
-                              LocalDate.parse("2023-12-30"))
-                          && Objects.equals(
-                              argument
-                                  .norm()
-                                  .getTimeBoundaries()
-                                  .getLast()
-                                  .getEventRef()
-                                  .getDate()
-                                  .get(),
-                              LocalDate.parse("2024-01-02"))
-                          && argument.norm().getTimeBoundaries().size() == 2));
+        .updateNorm(
+          argThat(argument ->
+            Objects.equals(
+              argument.norm().getTimeBoundaries().getFirst().getEventRef().getDate().get(),
+              LocalDate.parse("2023-12-30")
+            ) &&
+            Objects.equals(
+              argument.norm().getTimeBoundaries().getLast().getEventRef().getDate().get(),
+              LocalDate.parse("2024-01-02")
+            ) &&
+            argument.norm().getTimeBoundaries().size() == 2
+          )
+        );
     }
 
     @Test
     void itCallsUpdateTimeBoundariesOfNormAndReturnsTimeBoundariesDelete() {
-
       String eli = "eli/bund/bgbl-1/1964/s593/2000-01-01/1/deu/regelungstext-1";
 
       var xml =
-          """
-                  <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                  <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                         http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                     <akn:act name="regelungstext">
-                        <!-- Metadaten -->
-                        <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                           <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                              <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                 <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2000-01-01/1/deu/regelungstext-1" />
-                                 <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                                 <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                                 <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-3" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                              </akn:FRBRExpression>
-                          </akn:identification>
-                           <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                              <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                  source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                              <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                                  source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                              <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="9ccda9b8-b213-43c5-8ee0-ec47c3c602bb" date="2024-03-13"
-                                  source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                           </akn:lifecycle>
-                           <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                 <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                 </akn:temporalGroup>
-                                 <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="f550bb38-e322-48ac-acf6-6b53e2e174b8">
-                                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="6ea11eeb-31d2-47a5-9cac-7a31a14b86d1" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
-                                 </akn:temporalGroup>
-                           </akn:temporalData>
-                        </akn:meta>
-                        <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
-                            <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
-                               <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
-                                  <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
-                                  <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
-                                  Innern</akn:docProponent>
-                                  <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Dritten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
-                               </akn:p>
-                            </akn:longTitle>
-                            <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
-                               <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
-                            </akn:block>
-                         </akn:preface>
-                     </akn:act>
-                  </akn:akomaNtoso>
-                  """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2000-01-01/1/deu/regelungstext-1" />
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                       <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-3" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                    </akn:FRBRExpression>
+                </akn:identification>
+                 <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="9ccda9b8-b213-43c5-8ee0-ec47c3c602bb" date="2024-03-13"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                 </akn:lifecycle>
+                 <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                       <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                       </akn:temporalGroup>
+                       <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="f550bb38-e322-48ac-acf6-6b53e2e174b8">
+                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="6ea11eeb-31d2-47a5-9cac-7a31a14b86d1" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
+                       </akn:temporalGroup>
+                 </akn:temporalData>
+              </akn:meta>
+              <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                  <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                     <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                        <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
+                        <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
+                        Innern</akn:docProponent>
+                        <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Dritten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
+                     </akn:p>
+                  </akn:longTitle>
+                  <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                     <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
+                  </akn:block>
+               </akn:preface>
+           </akn:act>
+        </akn:akomaNtoso>
+        """;
 
       var normBefore = Norm.builder().document(XmlMapper.toDocument(xml)).build();
 
@@ -582,65 +597,63 @@ class TimeBoundaryServiceTest {
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(normBefore));
 
       // When
-      var timeBoundaryChangeDataOldStays =
-          new TimeBoundaryChangeData("meta-1_lebzykl-1_ereignis-2", LocalDate.parse("2023-12-30"));
+      var timeBoundaryChangeDataOldStays = new TimeBoundaryChangeData(
+        "meta-1_lebzykl-1_ereignis-2",
+        LocalDate.parse("2023-12-30")
+      );
 
       service.updateTimeBoundariesOfNorm(
-          new UpdateTimeBoundariesUseCase.Query(eli, List.of(timeBoundaryChangeDataOldStays)));
+        new UpdateTimeBoundariesUseCase.Query(eli, List.of(timeBoundaryChangeDataOldStays))
+      );
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
       verify(updateNormPort, times(1))
-          .updateNorm(
-              argThat(
-                  argument ->
-                      Objects.equals(
-                              argument
-                                  .norm()
-                                  .getTimeBoundaries()
-                                  .getLast()
-                                  .getEventRef()
-                                  .getDate()
-                                  .get(),
-                              LocalDate.parse("2023-12-30"))
-                          && argument.norm().getTimeBoundaries().size() == 1));
+        .updateNorm(
+          argThat(argument ->
+            Objects.equals(
+              argument.norm().getTimeBoundaries().getLast().getEventRef().getDate().get(),
+              LocalDate.parse("2023-12-30")
+            ) &&
+            argument.norm().getTimeBoundaries().size() == 1
+          )
+        );
     }
 
     @Test
     void itChangesADate() {
-
       String eli = "eli/bund/bgbl-1/1964/s593/2000-01-01/1/deu/regelungstext-1";
 
       var xml =
-          """
-                  <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                  <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                         http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                     <akn:act name="regelungstext">
-                        <!-- Metadaten -->
-                        <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                           <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                              <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                  source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                              <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                                  source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                              <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="9ccda9b8-b213-43c5-8ee0-ec47c3c602bb" date="2024-03-13"
-                                  source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                           </akn:lifecycle>
-                           <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                 <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                 </akn:temporalGroup>
-                                 <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="f550bb38-e322-48ac-acf6-6b53e2e174b8">
-                                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="6ea11eeb-31d2-47a5-9cac-7a31a14b86d1" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
-                                 </akn:temporalGroup>
-                           </akn:temporalData>
-                        </akn:meta>
-                     </akn:act>
-                  </akn:akomaNtoso>
-                  """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="9ccda9b8-b213-43c5-8ee0-ec47c3c602bb" date="2024-03-13"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                 </akn:lifecycle>
+                 <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                       <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                       </akn:temporalGroup>
+                       <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="f550bb38-e322-48ac-acf6-6b53e2e174b8">
+                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="6ea11eeb-31d2-47a5-9cac-7a31a14b86d1" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
+                       </akn:temporalGroup>
+                 </akn:temporalData>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+        """;
 
       var normBefore = Norm.builder().document(XmlMapper.toDocument(xml)).build();
 
@@ -648,41 +661,39 @@ class TimeBoundaryServiceTest {
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(normBefore));
 
       // When
-      var timeBoundaryChangeDataNewDate1 =
-          new TimeBoundaryChangeData("meta-1_lebzykl-1_ereignis-2", LocalDate.parse("1980-01-01"));
-      var timeBoundaryChangeDataNewDate2 =
-          new TimeBoundaryChangeData("meta-1_lebzykl-1_ereignis-3", LocalDate.parse("1990-01-01"));
+      var timeBoundaryChangeDataNewDate1 = new TimeBoundaryChangeData(
+        "meta-1_lebzykl-1_ereignis-2",
+        LocalDate.parse("1980-01-01")
+      );
+      var timeBoundaryChangeDataNewDate2 = new TimeBoundaryChangeData(
+        "meta-1_lebzykl-1_ereignis-3",
+        LocalDate.parse("1990-01-01")
+      );
 
       service.updateTimeBoundariesOfNorm(
-          new UpdateTimeBoundariesUseCase.Query(
-              eli, List.of(timeBoundaryChangeDataNewDate1, timeBoundaryChangeDataNewDate2)));
+        new UpdateTimeBoundariesUseCase.Query(
+          eli,
+          List.of(timeBoundaryChangeDataNewDate1, timeBoundaryChangeDataNewDate2)
+        )
+      );
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
       verify(updateNormPort, times(1))
-          .updateNorm(
-              argThat(
-                  argument ->
-                      LocalDate.parse("1980-01-01")
-                              .equals(
-                                  argument
-                                      .norm()
-                                      .getTimeBoundaries()
-                                      .getFirst()
-                                      .getEventRef()
-                                      .getDate()
-                                      .get())
-                          && LocalDate.parse("1990-01-01")
-                              .equals(
-                                  argument
-                                      .norm()
-                                      .getTimeBoundaries()
-                                      .get(1)
-                                      .getEventRef()
-                                      .getDate()
-                                      .get())
-                          && argument.norm().getTimeBoundaries().size() == 2));
+        .updateNorm(
+          argThat(argument ->
+            LocalDate
+              .parse("1980-01-01")
+              .equals(
+                argument.norm().getTimeBoundaries().getFirst().getEventRef().getDate().get()
+              ) &&
+            LocalDate
+              .parse("1990-01-01")
+              .equals(argument.norm().getTimeBoundaries().get(1).getEventRef().getDate().get()) &&
+            argument.norm().getTimeBoundaries().size() == 2
+          )
+        );
     }
 
     @Test
@@ -698,34 +709,34 @@ class TimeBoundaryServiceTest {
       String eli = "eli/bund/bgbl-1/1964/s593/2000-01-01/1/deu/regelungstext-1";
 
       var xml =
-          """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="9ccda9b8-b213-43c5-8ee0-ec47c3c602bb" date="2024-03-13"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                               </akn:lifecycle>
-                               <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                     <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                     </akn:temporalGroup>
-                                     <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="f550bb38-e322-48ac-acf6-6b53e2e174b8">
-                                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="6ea11eeb-31d2-47a5-9cac-7a31a14b86d1" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
-                                     </akn:temporalGroup>
-                               </akn:temporalData>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                      """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="9ccda9b8-b213-43c5-8ee0-ec47c3c602bb" date="2024-03-13"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                 </akn:lifecycle>
+                 <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                       <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                       </akn:temporalGroup>
+                       <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="f550bb38-e322-48ac-acf6-6b53e2e174b8">
+                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="6ea11eeb-31d2-47a5-9cac-7a31a14b86d1" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
+                       </akn:temporalGroup>
+                 </akn:temporalData>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+        """;
 
       var normBefore = Norm.builder().document(XmlMapper.toDocument(xml)).build();
 
@@ -733,23 +744,27 @@ class TimeBoundaryServiceTest {
       when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(normBefore));
 
       // When
-      var timeBoundaryChangeDataNewDate1 =
-          new TimeBoundaryChangeData(
-              "meta-1_lebzykl-1_ereignis-1000", LocalDate.parse("1970-01-01"));
+      var timeBoundaryChangeDataNewDate1 = new TimeBoundaryChangeData(
+        "meta-1_lebzykl-1_ereignis-1000",
+        LocalDate.parse("1970-01-01")
+      );
 
       service.updateTimeBoundariesOfNorm(
-          new UpdateTimeBoundariesUseCase.Query(eli, List.of(timeBoundaryChangeDataNewDate1)));
+        new UpdateTimeBoundariesUseCase.Query(eli, List.of(timeBoundaryChangeDataNewDate1))
+      );
 
       // Then
       verify(loadNormPort, times(1))
-          .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
+        .loadNorm(argThat(argument -> Objects.equals(argument.eli(), eli)));
       verify(updateNormPort, times(1)).updateNorm(any());
 
       assertThat(
-              memoryAppender.contains(
-                  "The following time boundaries should be changed but the eId was not found: [TimeBoundaryChangeData[eid=meta-1_lebzykl-1_ereignis-1000, date=1970-01-01]]",
-                  Level.ERROR))
-          .isTrue();
+        memoryAppender.contains(
+          "The following time boundaries should be changed but the eId was not found: [TimeBoundaryChangeData[eid=meta-1_lebzykl-1_ereignis-1000, date=1970-01-01]]",
+          Level.ERROR
+        )
+      )
+        .isTrue();
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineServiceTest.java
@@ -20,44 +20,48 @@ import org.xmlunit.builder.Input;
 import org.xmlunit.diff.Diff;
 
 class TimeMachineServiceTest {
+
   final NormService normService = mock(NormService.class);
 
   final TimeMachineService timeMachineService = new TimeMachineService(normService);
 
   @Nested
   class applyPassiveModifications {
+
     @Test
     void returnUnchangedIfNoPassiveModifications() {
       // given
-      final var norm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                  <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                      <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
-                                      <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
-                                      <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
-                                   </akn:FRBRWork>
-                              </akn:identification>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                      """))
-              .build();
+      final var norm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+               <akn:act name="regelungstext">
+                  <!-- Metadaten -->
+                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                        <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                            <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                            <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                            <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                         </akn:FRBRWork>
+                    </akn:identification>
+                  </akn:meta>
+               </akn:act>
+            </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
       // when
-      Norm result =
-          timeMachineService.applyPassiveModifications(
-              new ApplyPassiveModificationsUseCase.Query(norm, Instant.MAX));
+      Norm result = timeMachineService.applyPassiveModifications(
+        new ApplyPassiveModificationsUseCase.Query(norm, Instant.MAX)
+      );
 
       // then
       assertThat(result).isEqualTo(norm);
@@ -73,19 +77,20 @@ class TimeMachineServiceTest {
       when(normService.loadNorm(any())).thenReturn(amendingLaw);
 
       // when
-      Norm result =
-          timeMachineService.applyPassiveModifications(
-              new ApplyPassiveModificationsUseCase.Query(norm, Instant.MAX));
+      Norm result = timeMachineService.applyPassiveModifications(
+        new ApplyPassiveModificationsUseCase.Query(norm, Instant.MAX)
+      );
 
       // then
-      var changedNodeValue =
-          NodeParser.getValueFromExpression(
-              "//*[@eId=\"hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1\"]",
-              result.getDocument());
+      var changedNodeValue = NodeParser.getValueFromExpression(
+        "//*[@eId=\"hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1\"]",
+        result.getDocument()
+      );
       assertThat(changedNodeValue).isPresent();
       assertThat(changedNodeValue.get())
-          .isEqualToIgnoringWhitespace(
-              "entgegen § 9 Absatz 1 Satz 2, Absatz 2 oder 3 Kennezichen eines verbotenen Vereins oder einer Ersatzorganisation verwendet,");
+        .isEqualToIgnoringWhitespace(
+          "entgegen § 9 Absatz 1 Satz 2, Absatz 2 oder 3 Kennezichen eines verbotenen Vereins oder einer Ersatzorganisation verwendet,"
+        );
     }
 
     @Test
@@ -98,57 +103,61 @@ class TimeMachineServiceTest {
       when(normService.loadNorm(any())).thenReturn(amendingLaw);
 
       // when
-      Norm result =
-          timeMachineService.applyPassiveModifications(
-              new ApplyPassiveModificationsUseCase.Query(norm, Instant.MAX));
+      Norm result = timeMachineService.applyPassiveModifications(
+        new ApplyPassiveModificationsUseCase.Query(norm, Instant.MAX)
+      );
 
       // then
-      var changedNodeValue =
-          NodeParser.getValueFromExpression(
-              "//*[@eId=\"hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1\"]",
-              result.getDocument());
+      var changedNodeValue = NodeParser.getValueFromExpression(
+        "//*[@eId=\"hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1\"]",
+        result.getDocument()
+      );
       assertThat(changedNodeValue).isPresent();
       assertThat(changedNodeValue.get())
-          .isEqualToIgnoringWhitespace(
-              "entgegen § 9 Absatz 1 Satz 2, Absatz 2, 3 oder 4 Kennezichen eines verbotenen Vereins oder einer Ersatzorganisation verwendet,");
+        .isEqualToIgnoringWhitespace(
+          "entgegen § 9 Absatz 1 Satz 2, Absatz 2, 3 oder 4 Kennezichen eines verbotenen Vereins oder einer Ersatzorganisation verwendet,"
+        );
     }
 
     @Test
     void applyPassiveModificationsWhereTargetNodeEqualsNodeToChange() {
       // given
-      final var norm =
-          NormFixtures.loadFromDisk("NormWithPassiveModsWhereTargetNodeEqualsNodeToChange.xml");
+      final var norm = NormFixtures.loadFromDisk(
+        "NormWithPassiveModsWhereTargetNodeEqualsNodeToChange.xml"
+      );
 
-      final var amendingLaw =
-          NormFixtures.loadFromDisk("NormWithModsWhereTargetNodeEqualsNodeToChange.xml");
+      final var amendingLaw = NormFixtures.loadFromDisk(
+        "NormWithModsWhereTargetNodeEqualsNodeToChange.xml"
+      );
       when(normService.loadNorm(any())).thenReturn(amendingLaw);
 
       // when
-      Norm result =
-          timeMachineService.applyPassiveModifications(
-              new ApplyPassiveModificationsUseCase.Query(norm, Instant.MAX));
+      Norm result = timeMachineService.applyPassiveModifications(
+        new ApplyPassiveModificationsUseCase.Query(norm, Instant.MAX)
+      );
 
       // then
-      var changedNodeValue =
-          NodeParser.getValueFromExpression(
-              "//*[@eId=\"hauptteil-1_abschnitt-erster_art-6_abs-3_inhalt-1_text-1\"]",
-              result.getDocument());
+      var changedNodeValue = NodeParser.getValueFromExpression(
+        "//*[@eId=\"hauptteil-1_abschnitt-erster_art-6_abs-3_inhalt-1_text-1\"]",
+        result.getDocument()
+      );
       assertThat(changedNodeValue).isPresent();
       assertThat(changedNodeValue.get())
-          .isEqualToIgnoringWhitespace(
-              """
-                              Das Bundesamt für Verfassungsschutz trifft für die gemeinsamen Dateien die technischen und organisatorischen Maßnahmen
-                                                              entsprechend §
-                                                              64 des Bundesdatenschutzgesetzes. Es hat bei jedem Zugriff für Zwecke der Datenschutzkontrolle den Zeitpunkt, die
-                                                              Angaben, die die
-                                                              Feststellung der abgefragten Datensätze ermöglichen, sowie die abfragende Stelle zu protokollieren. Die Auswertung der
-                                                              Protokolldaten
-                                                              ist nach dem Stand der Technik zu gewährleisten. Die protokollierten Daten dürfen nur für Zwecke der
-                                                              Datenschutzkontrolle, der
-                                                              Datensicherung oder zur Sicherstellung eines ordnungsgemäßen Betriebs der Datenverarbeitungsanlage verwendet werden.
-                                                              Die
-                                                              Protokolldaten sind nach Ablauf von fünf Jahren zu löschen.
-                              """);
+        .isEqualToIgnoringWhitespace(
+          """
+          Das Bundesamt für Verfassungsschutz trifft für die gemeinsamen Dateien die technischen und organisatorischen Maßnahmen
+                                          entsprechend §
+                                          64 des Bundesdatenschutzgesetzes. Es hat bei jedem Zugriff für Zwecke der Datenschutzkontrolle den Zeitpunkt, die
+                                          Angaben, die die
+                                          Feststellung der abgefragten Datensätze ermöglichen, sowie die abfragende Stelle zu protokollieren. Die Auswertung der
+                                          Protokolldaten
+                                          ist nach dem Stand der Technik zu gewährleisten. Die protokollierten Daten dürfen nur für Zwecke der
+                                          Datenschutzkontrolle, der
+                                          Datensicherung oder zur Sicherstellung eines ordnungsgemäßen Betriebs der Datenverarbeitungsanlage verwendet werden.
+                                          Die
+                                          Protokolldaten sind nach Ablauf von fünf Jahren zu löschen.
+          """
+        );
     }
 
     @Test
@@ -160,20 +169,20 @@ class TimeMachineServiceTest {
       when(normService.loadNorm(any())).thenReturn(amendingLaw);
 
       // when
-      Norm result =
-          timeMachineService.applyPassiveModifications(
-              new ApplyPassiveModificationsUseCase.Query(
-                  norm, Instant.parse("2017-03-01T00:00:00.000Z")));
+      Norm result = timeMachineService.applyPassiveModifications(
+        new ApplyPassiveModificationsUseCase.Query(norm, Instant.parse("2017-03-01T00:00:00.000Z"))
+      );
 
       // then
-      var changedNodeValue =
-          NodeParser.getValueFromExpression(
-              "//*[@eId=\"hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1\"]",
-              result.getDocument());
+      var changedNodeValue = NodeParser.getValueFromExpression(
+        "//*[@eId=\"hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1\"]",
+        result.getDocument()
+      );
       assertThat(changedNodeValue).isPresent();
       assertThat(changedNodeValue.get())
-          .isEqualToIgnoringWhitespace(
-              "entgegen § 9 Absatz 1 Satz 2, Absatz 2 oder 3 Kennezichen eines verbotenen Vereins oder einer Ersatzorganisation verwendet,");
+        .isEqualToIgnoringWhitespace(
+          "entgegen § 9 Absatz 1 Satz 2, Absatz 2 oder 3 Kennezichen eines verbotenen Vereins oder einer Ersatzorganisation verwendet,"
+        );
     }
 
     @Test
@@ -184,19 +193,20 @@ class TimeMachineServiceTest {
       final var amendingLaw = NormFixtures.loadFromDisk("NormWithMods.xml");
 
       // when
-      Norm result =
-          timeMachineService.applyPassiveModifications(
-              new ApplyPassiveModificationsUseCase.Query(norm, Instant.MAX, Set.of(amendingLaw)));
+      Norm result = timeMachineService.applyPassiveModifications(
+        new ApplyPassiveModificationsUseCase.Query(norm, Instant.MAX, Set.of(amendingLaw))
+      );
 
       // then
-      var changedNodeValue =
-          NodeParser.getValueFromExpression(
-              "//*[@eId=\"hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1\"]",
-              result.getDocument());
+      var changedNodeValue = NodeParser.getValueFromExpression(
+        "//*[@eId=\"hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1\"]",
+        result.getDocument()
+      );
       assertThat(changedNodeValue).isPresent();
       assertThat(changedNodeValue.get())
-          .isEqualToIgnoringWhitespace(
-              "entgegen § 9 Absatz 1 Satz 2, Absatz 2 oder 3 Kennezichen eines verbotenen Vereins oder einer Ersatzorganisation verwendet,");
+        .isEqualToIgnoringWhitespace(
+          "entgegen § 9 Absatz 1 Satz 2, Absatz 2 oder 3 Kennezichen eines verbotenen Vereins oder einer Ersatzorganisation verwendet,"
+        );
     }
 
     @Test
@@ -210,19 +220,20 @@ class TimeMachineServiceTest {
       when(normService.loadNorm(any())).thenReturn(amendingLaw);
 
       // when
-      Norm result =
-          timeMachineService.applyPassiveModifications(
-              new ApplyPassiveModificationsUseCase.Query(norm, Instant.MAX));
+      Norm result = timeMachineService.applyPassiveModifications(
+        new ApplyPassiveModificationsUseCase.Query(norm, Instant.MAX)
+      );
 
       // then
-      var changedNodeValue =
-          NodeParser.getValueFromExpression(
-              "//*[@eId=\"hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1\"]",
-              result.getDocument());
+      var changedNodeValue = NodeParser.getValueFromExpression(
+        "//*[@eId=\"hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1\"]",
+        result.getDocument()
+      );
       assertThat(changedNodeValue).isPresent();
       assertThat(changedNodeValue.get())
-          .isEqualToIgnoringWhitespace(
-              "entgegen § 9 Abs. 1 Satz 2, Abs. 2 Kennezichen eines verbotenen Vereins oder einer Ersatzorganisation verwendet,");
+        .isEqualToIgnoringWhitespace(
+          "entgegen § 9 Abs. 1 Satz 2, Abs. 2 Kennezichen eines verbotenen Vereins oder einer Ersatzorganisation verwendet,"
+        );
     }
 
     @Test
@@ -235,44 +246,47 @@ class TimeMachineServiceTest {
       when(normService.loadNorm(any())).thenReturn(amendingLawNorm);
 
       // when
-      Norm result =
-          timeMachineService.applyPassiveModifications(
-              new ApplyPassiveModificationsUseCase.Query(targetLawNorm, Instant.MAX));
+      Norm result = timeMachineService.applyPassiveModifications(
+        new ApplyPassiveModificationsUseCase.Query(targetLawNorm, Instant.MAX)
+      );
 
       // then
-      final Diff diff =
-          DiffBuilder.compare(Input.from(result.getDocument()))
-              .withTest(Input.from(expectedResult.getDocument()))
-              .ignoreWhitespace()
-              .withNodeFilter(node -> !node.getNodeName().equals("akn:meta"))
-              .build();
+      final Diff diff = DiffBuilder
+        .compare(Input.from(result.getDocument()))
+        .withTest(Input.from(expectedResult.getDocument()))
+        .ignoreWhitespace()
+        .withNodeFilter(node -> !node.getNodeName().equals("akn:meta"))
+        .build();
       assertThat(diff.hasDifferences()).isFalse();
     }
 
     @Test
     void applyOnePassiveModificationQuotedStructureWithUpTo() {
       // given
-      final var targetLawNorm =
-          NormFixtures.loadFromDisk("NormWithPassiveModsQuotedStructureAndUpTo.xml");
-      final var amendingLawNorm =
-          NormFixtures.loadFromDisk("NormWithQuotedStructureModsAndUpTo.xml");
-      final var expectedResult =
-          NormFixtures.loadFromDisk("NormWithAppliedQuotedStructureAndUpTo.xml");
+      final var targetLawNorm = NormFixtures.loadFromDisk(
+        "NormWithPassiveModsQuotedStructureAndUpTo.xml"
+      );
+      final var amendingLawNorm = NormFixtures.loadFromDisk(
+        "NormWithQuotedStructureModsAndUpTo.xml"
+      );
+      final var expectedResult = NormFixtures.loadFromDisk(
+        "NormWithAppliedQuotedStructureAndUpTo.xml"
+      );
 
       when(normService.loadNorm(any())).thenReturn(amendingLawNorm);
 
       // when
-      Norm result =
-          timeMachineService.applyPassiveModifications(
-              new ApplyPassiveModificationsUseCase.Query(targetLawNorm, Instant.MAX));
+      Norm result = timeMachineService.applyPassiveModifications(
+        new ApplyPassiveModificationsUseCase.Query(targetLawNorm, Instant.MAX)
+      );
 
       // then
-      final Diff diff =
-          DiffBuilder.compare(Input.from(result.getDocument()))
-              .withTest(Input.from(expectedResult.getDocument()))
-              .ignoreWhitespace()
-              .withNodeFilter(node -> !node.getNodeName().equals("akn:meta"))
-              .build();
+      final Diff diff = DiffBuilder
+        .compare(Input.from(result.getDocument()))
+        .withTest(Input.from(expectedResult.getDocument()))
+        .ignoreWhitespace()
+        .withNodeFilter(node -> !node.getNodeName().equals("akn:meta"))
+        .build();
       assertThat(diff.hasDifferences()).isFalse();
     }
 
@@ -283,31 +297,31 @@ class TimeMachineServiceTest {
 
       final var amendingLaw = NormFixtures.loadFromDisk("NormWithQuotedTextModAndRefs.xml");
 
-      final Node expectedNode =
-          XmlMapper.toNode(
-              """
-<?xml version="1.0" encoding="UTF-8"?><akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" GUID="0ba9a471-e9ef-44c4-b5da-f69f068a4483" eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1">entgegen § 9 Absatz 1 <akn:ref GUID="514f37b3-5f75-4ee4-a110-6bad8c5a46c3" eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ref-1" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1">Satz 2</akn:ref>, Absatz 2 oder 3
-                                        Kennezichen eines verbotenen Vereins oder einer Ersatzorganisation verwendet,</akn:p>
-                """);
+      final Node expectedNode = XmlMapper.toNode(
+        """
+        <?xml version="1.0" encoding="UTF-8"?><akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" GUID="0ba9a471-e9ef-44c4-b5da-f69f068a4483" eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1">entgegen § 9 Absatz 1 <akn:ref GUID="514f37b3-5f75-4ee4-a110-6bad8c5a46c3" eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ref-1" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1">Satz 2</akn:ref>, Absatz 2 oder 3
+                                                Kennezichen eines verbotenen Vereins oder einer Ersatzorganisation verwendet,</akn:p>
+                        """
+      );
 
       when(normService.loadNorm(any())).thenReturn(amendingLaw);
 
       // when
-      Norm result =
-          timeMachineService.applyPassiveModifications(
-              new ApplyPassiveModificationsUseCase.Query(norm, Instant.MAX));
+      Norm result = timeMachineService.applyPassiveModifications(
+        new ApplyPassiveModificationsUseCase.Query(norm, Instant.MAX)
+      );
 
       // then
-      final Optional<Node> updatedNode =
-          NodeParser.getNodeFromExpression(
-              "//*[@eId=\"hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1\"]",
-              result.getDocument());
+      final Optional<Node> updatedNode = NodeParser.getNodeFromExpression(
+        "//*[@eId=\"hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1\"]",
+        result.getDocument()
+      );
       assertThat(updatedNode).isPresent();
-      final Diff diff =
-          DiffBuilder.compare(Input.from(updatedNode.get()))
-              .withTest(Input.from(expectedNode))
-              .normalizeWhitespace()
-              .build();
+      final Diff diff = DiffBuilder
+        .compare(Input.from(updatedNode.get()))
+        .withTest(Input.from(expectedNode))
+        .normalizeWhitespace()
+        .build();
       assertThat(diff.hasDifferences()).isFalse();
     }
 
@@ -320,30 +334,30 @@ class TimeMachineServiceTest {
 
       when(normService.loadNorm(any())).thenReturn(amendingLaw);
 
-      final Node expectedNode =
-          XmlMapper.toNode(
-              """
-                  <?xml version="1.0" encoding="UTF-8"?><akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" GUID="0ba9a471-e9ef-44c4-b5da-f69f068a4483" eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1"><akn:ref GUID="514f37b3-5f75-4ee4-a110-6bad8c5a4bbb" eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ref-1" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1">entgegen</akn:ref> § 9 Absatz 1 <akn:ref GUID="514f37b3-5f75-4ee4-a110-6bad8c5a46c3" eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ref-2" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1">Satz 2</akn:ref>, Absatz 2 oder 3
-                     Kennezichen eines verbotenen Vereins oder einer <akn:ref GUID="514f37b3-5f75-4ee4-a110-6bad8c5a33c3" eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ref-3" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1">Ersatzorganisation</akn:ref> verwendet,
-                  </akn:p>
-                                  """);
+      final Node expectedNode = XmlMapper.toNode(
+        """
+        <?xml version="1.0" encoding="UTF-8"?><akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" GUID="0ba9a471-e9ef-44c4-b5da-f69f068a4483" eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1"><akn:ref GUID="514f37b3-5f75-4ee4-a110-6bad8c5a4bbb" eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ref-1" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1">entgegen</akn:ref> § 9 Absatz 1 <akn:ref GUID="514f37b3-5f75-4ee4-a110-6bad8c5a46c3" eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ref-2" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1">Satz 2</akn:ref>, Absatz 2 oder 3
+           Kennezichen eines verbotenen Vereins oder einer <akn:ref GUID="514f37b3-5f75-4ee4-a110-6bad8c5a33c3" eId="hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ref-3" href="eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1">Ersatzorganisation</akn:ref> verwendet,
+        </akn:p>
+                        """
+      );
 
       // when
-      Norm result =
-          timeMachineService.applyPassiveModifications(
-              new ApplyPassiveModificationsUseCase.Query(norm, Instant.MAX));
+      Norm result = timeMachineService.applyPassiveModifications(
+        new ApplyPassiveModificationsUseCase.Query(norm, Instant.MAX)
+      );
 
       // then
-      final Optional<Node> updatedNode =
-          NodeParser.getNodeFromExpression(
-              "//*[@eId=\"hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1\"]",
-              result.getDocument());
+      final Optional<Node> updatedNode = NodeParser.getNodeFromExpression(
+        "//*[@eId=\"hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1\"]",
+        result.getDocument()
+      );
       assertThat(updatedNode).isPresent();
-      final Diff diff =
-          DiffBuilder.compare(Input.from(updatedNode.get()))
-              .withTest(Input.from(expectedNode))
-              .normalizeWhitespace()
-              .build();
+      final Diff diff = DiffBuilder
+        .compare(Input.from(updatedNode.get()))
+        .withTest(Input.from(expectedNode))
+        .normalizeWhitespace()
+        .build();
       assertThat(diff.hasDifferences()).isFalse();
     }
   }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/UpdateNormServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/UpdateNormServiceTest.java
@@ -13,258 +13,282 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class UpdateNormServiceTest {
+
   final UpdateNormService updateNormService = new UpdateNormService();
 
   @Nested
   class updatePassiveModifications {
+
     @Test
     void itChangesNothingImportantIfPassiveModificationsAlreadyExist() {
-
       // Given
       Norm amendingLaw = NormFixtures.loadFromDisk("NormWithMods.xml");
       Norm targetLaw = NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml");
       Norm zf0Law = NormFixtures.loadFromDisk("NormWithPassiveModifications.xml");
 
       // When
-      var updatedZfoLaw =
-          updateNormService.updatePassiveModifications(
-              new UpdatePassiveModificationsUseCase.Query(zf0Law, amendingLaw, targetLaw.getEli()));
+      var updatedZfoLaw = updateNormService.updatePassiveModifications(
+        new UpdatePassiveModificationsUseCase.Query(zf0Law, amendingLaw, targetLaw.getEli())
+      );
 
       // Then
-      final List<TextualMod> passiveModifications =
-          updatedZfoLaw
-              .getMeta()
-              .getAnalysis()
-              .map(Analysis::getPassiveModifications)
-              .orElse(Collections.emptyList());
+      final List<TextualMod> passiveModifications = updatedZfoLaw
+        .getMeta()
+        .getAnalysis()
+        .map(Analysis::getPassiveModifications)
+        .orElse(Collections.emptyList());
       assertThat(passiveModifications).hasSize(1);
       assertThat(updatedZfoLaw.getTimeBoundaries()).hasSize(4);
 
       var passiveModification = passiveModifications.getFirst();
       assertThat(passiveModification.getType()).contains("substitution");
       assertThat(passiveModification.getSourceHref())
-          .contains(
-              new Href(
-                  "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"));
+        .contains(
+          new Href(
+            "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"
+          )
+        );
       assertThat(passiveModification.getDestinationHref())
-          .contains(
-              new Href("#hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34"));
+        .contains(
+          new Href("#hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34")
+        );
       assertThat(passiveModification.getForcePeriodEid())
-          .contains("meta-1_geltzeiten-1_geltungszeitgr-4");
+        .contains("meta-1_geltzeiten-1_geltungszeitgr-4");
     }
 
     @Test
     void itAddsPassiveModificationsIfNoneExist() {
-
       // Given
       Norm amendingLaw = NormFixtures.loadFromDisk("NormWithMods.xml");
       Norm zf0Law = NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml");
 
       // When
-      var updatedZf0Law =
-          updateNormService.updatePassiveModifications(
-              new UpdatePassiveModificationsUseCase.Query(
-                  zf0Law,
-                  amendingLaw,
-                  "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"));
+      var updatedZf0Law = updateNormService.updatePassiveModifications(
+        new UpdatePassiveModificationsUseCase.Query(
+          zf0Law,
+          amendingLaw,
+          "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"
+        )
+      );
 
       // Then
-      final List<TextualMod> passiveModifications =
-          updatedZf0Law
-              .getMeta()
-              .getAnalysis()
-              .map(Analysis::getPassiveModifications)
-              .orElse(Collections.emptyList());
+      final List<TextualMod> passiveModifications = updatedZf0Law
+        .getMeta()
+        .getAnalysis()
+        .map(Analysis::getPassiveModifications)
+        .orElse(Collections.emptyList());
       assertThat(passiveModifications).hasSize(1);
-      assertThat(updatedZf0Law.getTimeBoundaries())
-          .hasSize(4); // 3 existing time-boundaries + 1 new one for the mod
+      assertThat(updatedZf0Law.getTimeBoundaries()).hasSize(4); // 3 existing time-boundaries + 1 new one for the mod
       var eventRefNode = updatedZf0Law.getTimeBoundaries().get(3).getEventRef().getNode();
       assertThat(NodeParser.getValueFromExpression("@type", eventRefNode))
-          .contains(EventRefType.AMENDMENT.getValue());
+        .contains(EventRefType.AMENDMENT.getValue());
 
       var newPassiveModification = passiveModifications.getFirst();
       assertThat(newPassiveModification.getType()).contains("substitution");
       assertThat(newPassiveModification.getSourceHref())
-          .contains(
-              new Href(
-                  "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"));
+        .contains(
+          new Href(
+            "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"
+          )
+        );
       assertThat(newPassiveModification.getDestinationHref())
-          .contains(
-              new Href("#hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34"));
+        .contains(
+          new Href("#hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34")
+        );
       assertThat(
-              updatedZf0Law.getStartDateForTemporalGroup(
-                  newPassiveModification.getForcePeriodEid().orElseThrow()))
-          .contains("2023-12-30");
+        updatedZf0Law.getStartDateForTemporalGroup(
+          newPassiveModification.getForcePeriodEid().orElseThrow()
+        )
+      )
+        .contains("2023-12-30");
     }
 
     @Test
     void itAddsMultiplePassiveModificationsIfNoneExist() {
-
       // Given
       Norm amendingLaw = NormFixtures.loadFromDisk("NormWithMultipleMods.xml");
       Norm targetLaw = NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml");
       Norm zf0Law = NormFixtures.loadFromDisk("NormWithPassiveModifications.xml");
 
       // When
-      var updatedZfoLaw =
-          updateNormService.updatePassiveModifications(
-              new UpdatePassiveModificationsUseCase.Query(zf0Law, amendingLaw, targetLaw.getEli()));
+      var updatedZfoLaw = updateNormService.updatePassiveModifications(
+        new UpdatePassiveModificationsUseCase.Query(zf0Law, amendingLaw, targetLaw.getEli())
+      );
 
       // Then
-      final List<TextualMod> passiveModifications =
-          updatedZfoLaw
-              .getMeta()
-              .getAnalysis()
-              .map(Analysis::getPassiveModifications)
-              .orElse(Collections.emptyList());
+      final List<TextualMod> passiveModifications = updatedZfoLaw
+        .getMeta()
+        .getAnalysis()
+        .map(Analysis::getPassiveModifications)
+        .orElse(Collections.emptyList());
       assertThat(passiveModifications).hasSize(2);
-      assertThat(updatedZfoLaw.getTimeBoundaries())
-          .hasSize(4); // 3 existing time-boundaries + 1 new one for both mods
+      assertThat(updatedZfoLaw.getTimeBoundaries()).hasSize(4); // 3 existing time-boundaries + 1 new one for both mods
 
       var newPassiveModification1 = passiveModifications.getFirst();
       assertThat(newPassiveModification1.getType()).contains("substitution");
       assertThat(newPassiveModification1.getSourceHref())
-          .contains(
-              new Href(
-                  "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"));
+        .contains(
+          new Href(
+            "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"
+          )
+        );
       assertThat(newPassiveModification1.getDestinationHref())
-          .contains(
-              new Href("#hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/10-34"));
+        .contains(
+          new Href("#hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/10-34")
+        );
       assertThat(
-              updatedZfoLaw.getStartDateForTemporalGroup(
-                  newPassiveModification1.getForcePeriodEid().orElseThrow()))
-          .contains("2023-12-30");
+        updatedZfoLaw.getStartDateForTemporalGroup(
+          newPassiveModification1.getForcePeriodEid().orElseThrow()
+        )
+      )
+        .contains("2023-12-30");
 
-      final TextualMod newPassiveModification2 =
-          updatedZfoLaw
-              .getMeta()
-              .getAnalysis()
-              .map(Analysis::getPassiveModifications)
-              .orElse(Collections.emptyList())
-              .get(1);
+      final TextualMod newPassiveModification2 = updatedZfoLaw
+        .getMeta()
+        .getAnalysis()
+        .map(Analysis::getPassiveModifications)
+        .orElse(Collections.emptyList())
+        .get(1);
       assertThat(newPassiveModification2.getType()).contains("substitution");
       assertThat(newPassiveModification2.getSourceHref())
-          .contains(
-              new Href(
-                  "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-2_ändbefehl-1.xml"));
+        .contains(
+          new Href(
+            "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-2_ändbefehl-1.xml"
+          )
+        );
       assertThat(newPassiveModification2.getDestinationHref())
-          .contains(
-              new Href("#hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/10-34"));
+        .contains(
+          new Href("#hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/10-34")
+        );
       assertThat(
-              updatedZfoLaw.getStartDateForTemporalGroup(
-                  newPassiveModification2.getForcePeriodEid().orElseThrow()))
-          .contains("2023-12-30");
+        updatedZfoLaw.getStartDateForTemporalGroup(
+          newPassiveModification2.getForcePeriodEid().orElseThrow()
+        )
+      )
+        .contains("2023-12-30");
     }
 
     @Test
     void itAddsPassiveModificationWithoutForcePeriodIfNoneExist() {
-
       // Given
       Norm amendingLaw = NormFixtures.loadFromDisk("NormWithMods.xml");
       amendingLaw.deleteByEId("meta-1_analysis-1_activemod-1_textualmod-1_gelzeitnachw-1");
       Norm zf0Law = NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml");
 
       // When
-      var updatedZf0Law =
-          updateNormService.updatePassiveModifications(
-              new UpdatePassiveModificationsUseCase.Query(
-                  zf0Law,
-                  amendingLaw,
-                  "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"));
+      var updatedZf0Law = updateNormService.updatePassiveModifications(
+        new UpdatePassiveModificationsUseCase.Query(
+          zf0Law,
+          amendingLaw,
+          "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"
+        )
+      );
 
       // Then
       assertThat(
-              updatedZf0Law
-                  .getMeta()
-                  .getAnalysis()
-                  .map(Analysis::getPassiveModifications)
-                  .orElse(Collections.emptyList()))
-          .hasSize(1);
+        updatedZf0Law
+          .getMeta()
+          .getAnalysis()
+          .map(Analysis::getPassiveModifications)
+          .orElse(Collections.emptyList())
+      )
+        .hasSize(1);
       assertThat(updatedZf0Law.getTimeBoundaries()).hasSize(3); // 3 existing time-boundaries
 
-      var newPassiveModification =
-          updatedZf0Law
-              .getMeta()
-              .getAnalysis()
-              .map(Analysis::getPassiveModifications)
-              .orElse(Collections.emptyList())
-              .getFirst();
+      var newPassiveModification = updatedZf0Law
+        .getMeta()
+        .getAnalysis()
+        .map(Analysis::getPassiveModifications)
+        .orElse(Collections.emptyList())
+        .getFirst();
       assertThat(newPassiveModification.getType()).contains("substitution");
       assertThat(newPassiveModification.getSourceHref())
-          .contains(
-              new Href(
-                  "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"));
+        .contains(
+          new Href(
+            "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"
+          )
+        );
       assertThat(newPassiveModification.getDestinationHref())
-          .contains(
-              new Href("#hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34"));
+        .contains(
+          new Href("#hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34")
+        );
       assertThat(newPassiveModification.getForcePeriodEid()).isEmpty();
     }
 
     @Test
     void itAddsOnePassiveModificationWithUpTo() {
-
       // Given
       final Norm amendingLaw = NormFixtures.loadFromDisk("NormWithQuotedStructureModsAndUpTo.xml");
-      final TextualMod activeMod =
-          amendingLaw.getMeta().getOrCreateAnalysis().getActiveModifications().getFirst();
+      final TextualMod activeMod = amendingLaw
+        .getMeta()
+        .getOrCreateAnalysis()
+        .getActiveModifications()
+        .getFirst();
       activeMod.setDestinationUpTo(
-          "eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/hauptteil-1_para-2_abs-2.xml");
+        "eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/hauptteil-1_para-2_abs-2.xml"
+      );
 
-      final Norm zf0Law =
-          NormFixtures.loadFromDisk("NormWithPassiveModsQuotedStructureAndUpTo.xml");
+      final Norm zf0Law = NormFixtures.loadFromDisk(
+        "NormWithPassiveModsQuotedStructureAndUpTo.xml"
+      );
       final String targetLawELi = "eli/bund/bgbl-1/1999/66/1999-01-01/1/deu/regelungstext-1";
 
       // When
-      var updatedZfoLaw =
-          updateNormService.updatePassiveModifications(
-              new UpdatePassiveModificationsUseCase.Query(zf0Law, amendingLaw, targetLawELi));
+      var updatedZfoLaw = updateNormService.updatePassiveModifications(
+        new UpdatePassiveModificationsUseCase.Query(zf0Law, amendingLaw, targetLawELi)
+      );
 
       // Then
-      final List<TextualMod> passiveModifications =
-          updatedZfoLaw
-              .getMeta()
-              .getAnalysis()
-              .map(Analysis::getPassiveModifications)
-              .orElse(Collections.emptyList());
+      final List<TextualMod> passiveModifications = updatedZfoLaw
+        .getMeta()
+        .getAnalysis()
+        .map(Analysis::getPassiveModifications)
+        .orElse(Collections.emptyList());
       assertThat(passiveModifications).hasSize(2);
 
       var firstPassMod = passiveModifications.getFirst();
       assertThat(firstPassMod.getType()).contains("substitution");
       assertThat(firstPassMod.getSourceHref())
-          .contains(
-              new Href(
-                  "eli/bund/bgbl-1/2002/22/2002-02-20/1/deu/regelungstext-1/hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1.xml"));
+        .contains(
+          new Href(
+            "eli/bund/bgbl-1/2002/22/2002-02-20/1/deu/regelungstext-1/hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1.xml"
+          )
+        );
       assertThat(firstPassMod.getDestinationHref()).contains(new Href("#hauptteil-1_para-2_abs-1"));
       assertThat(firstPassMod.getDestinationUpTo()).contains(new Href("#hauptteil-1_para-2_abs-2"));
       assertThat(
-              updatedZfoLaw.getStartDateForTemporalGroup(
-                  firstPassMod.getForcePeriodEid().orElseThrow()))
-          .contains("2002-02-21");
+        updatedZfoLaw.getStartDateForTemporalGroup(firstPassMod.getForcePeriodEid().orElseThrow())
+      )
+        .contains("2002-02-21");
 
       var secondPassMod = passiveModifications.getLast();
       assertThat(secondPassMod.getType()).contains("substitution");
       assertThat(secondPassMod.getSourceHref())
-          .contains(
-              new Href(
-                  "eli/bund/bgbl-1/2002/22/2002-02-20/1/deu/regelungstext-1/hauptteil-1_para-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"));
+        .contains(
+          new Href(
+            "eli/bund/bgbl-1/2002/22/2002-02-20/1/deu/regelungstext-1/hauptteil-1_para-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"
+          )
+        );
       assertThat(secondPassMod.getDestinationHref())
-          .contains(
-              new Href("#hauptteil-1_para-2_abs-3_untergl-1_listenelem-1_untergl-1_listenelem-b"));
+        .contains(
+          new Href("#hauptteil-1_para-2_abs-3_untergl-1_listenelem-1_untergl-1_listenelem-b")
+        );
       assertThat(secondPassMod.getDestinationUpTo())
-          .contains(
-              new Href("#hauptteil-1_para-2_abs-3_untergl-1_listenelem-1_untergl-1_listenelem-f"));
+        .contains(
+          new Href("#hauptteil-1_para-2_abs-3_untergl-1_listenelem-1_untergl-1_listenelem-f")
+        );
       assertThat(
-              updatedZfoLaw.getStartDateForTemporalGroup(
-                  secondPassMod.getForcePeriodEid().orElseThrow()))
-          .contains("2002-02-21");
+        updatedZfoLaw.getStartDateForTemporalGroup(secondPassMod.getForcePeriodEid().orElseThrow())
+      )
+        .contains("2002-02-21");
     }
   }
 
   @Nested
   class updateActiveModifications {
+
     @Test
     void itChangesActiveModForQuotedText() {
-
       // Given
       Norm amendingLaw = NormFixtures.loadFromDisk("NormWithMods.xml");
       Norm targetNorm = NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml");
@@ -272,286 +296,297 @@ class UpdateNormServiceTest {
       String eId = "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1";
       String newCharacterRange = "20-25";
       String newDestinationHref =
-          targetNormEli
-              + "/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/"
-              + newCharacterRange
-              + ".xml";
+        targetNormEli +
+        "/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/" +
+        newCharacterRange +
+        ".xml";
       String newTimeBoundaryEid = "#time-boundary-eid";
       String newContent = "new-text";
 
       // When
-      var updatedAmendingNorm =
-          updateNormService.updateActiveModifications(
-              new UpdateActiveModificationsUseCase.Query(
-                  amendingLaw, eId, newDestinationHref, null, newTimeBoundaryEid, newContent));
+      var updatedAmendingNorm = updateNormService.updateActiveModifications(
+        new UpdateActiveModificationsUseCase.Query(
+          amendingLaw,
+          eId,
+          newDestinationHref,
+          null,
+          newTimeBoundaryEid,
+          newContent
+        )
+      );
 
       // Then
-      final TextualMod activeModifications =
-          updatedAmendingNorm
-              .getMeta()
-              .getAnalysis()
-              .map(Analysis::getActiveModifications)
-              .orElse(Collections.emptyList())
-              .getFirst();
+      final TextualMod activeModifications = updatedAmendingNorm
+        .getMeta()
+        .getAnalysis()
+        .map(Analysis::getActiveModifications)
+        .orElse(Collections.emptyList())
+        .getFirst();
       assertThat(activeModifications.getDestinationHref()).contains(new Href(newDestinationHref));
       assertThat(activeModifications.getForcePeriodEid()).contains(newTimeBoundaryEid);
-      final Mod mod =
-          updatedAmendingNorm.getMods().stream()
-              .filter(f -> f.getEid().orElseThrow().equals(eId))
-              .findFirst()
-              .orElseThrow();
+      final Mod mod = updatedAmendingNorm
+        .getMods()
+        .stream()
+        .filter(f -> f.getEid().orElseThrow().equals(eId))
+        .findFirst()
+        .orElseThrow();
       assertThat(mod.getNewText()).contains(newContent);
     }
 
     @Test
     void itChangesActiveModForQuotedStructureRangeMod() {
-
       // Given
       Norm amendingLaw = NormFixtures.loadFromDisk("NormWithQuotedStructureMods.xml");
       Norm targetNorm = NormFixtures.loadFromDisk("NormWithoutPassiveModsQuotedStructure.xml");
       String targetNormEli = targetNorm.getEli();
       String eId = "hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1";
       String newDestinationHref =
-          targetNormEli + "/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/";
+        targetNormEli + "/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/";
       String newDestinationUpTo =
-          targetNormEli + "/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-2/";
+        targetNormEli + "/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-2/";
       String newTimeBoundaryEid = "#time-boundary-eid";
       String newContent = "new-text";
 
       // When
-      var updatedAmendingNorm =
-          updateNormService.updateActiveModifications(
-              new UpdateActiveModificationsUseCase.Query(
-                  amendingLaw,
-                  eId,
-                  newDestinationHref,
-                  newDestinationUpTo,
-                  newTimeBoundaryEid,
-                  newContent));
+      var updatedAmendingNorm = updateNormService.updateActiveModifications(
+        new UpdateActiveModificationsUseCase.Query(
+          amendingLaw,
+          eId,
+          newDestinationHref,
+          newDestinationUpTo,
+          newTimeBoundaryEid,
+          newContent
+        )
+      );
 
       // Then
-      final Optional<TextualMod> activeModifications =
-          updatedAmendingNorm
-              .getMeta()
-              .getAnalysis()
-              .map(Analysis::getActiveModifications)
-              .orElse(Collections.emptyList())
-              .stream()
-              .filter(
-                  activeMod ->
-                      activeMod.getSourceHref().get().toString().replace("#", "").equals(eId))
-              .findFirst();
+      final Optional<TextualMod> activeModifications = updatedAmendingNorm
+        .getMeta()
+        .getAnalysis()
+        .map(Analysis::getActiveModifications)
+        .orElse(Collections.emptyList())
+        .stream()
+        .filter(activeMod -> activeMod.getSourceHref().get().toString().replace("#", "").equals(eId)
+        )
+        .findFirst();
       assertThat(activeModifications).isPresent();
       assertThat(activeModifications.get().getForcePeriodEid()).contains(newTimeBoundaryEid);
       assertThat(activeModifications.get().getDestinationHref())
-          .contains(new Href(newDestinationHref));
+        .contains(new Href(newDestinationHref));
       assertThat(activeModifications.get().getDestinationUpTo())
-          .contains(new Href(newDestinationUpTo));
+        .contains(new Href(newDestinationUpTo));
     }
 
     @Test
     void itChangesActiveModForQuotedStructureSingleTargetMod() {
-
       // Given
       Norm amendingLaw = NormFixtures.loadFromDisk("NormWithQuotedStructureMods.xml");
       Norm targetNorm = NormFixtures.loadFromDisk("NormWithoutPassiveModsQuotedStructure.xml");
       String targetNormEli = targetNorm.getEli();
       String eId = "hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1";
       String newDestinationHref =
-          targetNormEli + "/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/";
+        targetNormEli + "/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/";
       String newDestinationUpTo = null;
       String newTimeBoundaryEid = "#time-boundary-eid";
       String newContent = "new-text";
 
       // When
-      var updatedAmendingNorm =
-          updateNormService.updateActiveModifications(
-              new UpdateActiveModificationsUseCase.Query(
-                  amendingLaw,
-                  eId,
-                  newDestinationHref,
-                  newDestinationUpTo,
-                  newTimeBoundaryEid,
-                  newContent));
+      var updatedAmendingNorm = updateNormService.updateActiveModifications(
+        new UpdateActiveModificationsUseCase.Query(
+          amendingLaw,
+          eId,
+          newDestinationHref,
+          newDestinationUpTo,
+          newTimeBoundaryEid,
+          newContent
+        )
+      );
 
       // Then
-      final Optional<TextualMod> activeModifications =
-          updatedAmendingNorm
-              .getMeta()
-              .getAnalysis()
-              .map(Analysis::getActiveModifications)
-              .orElse(Collections.emptyList())
-              .stream()
-              .filter(
-                  activeMod ->
-                      activeMod.getSourceHref().get().toString().replace("#", "").equals(eId))
-              .findFirst();
+      final Optional<TextualMod> activeModifications = updatedAmendingNorm
+        .getMeta()
+        .getAnalysis()
+        .map(Analysis::getActiveModifications)
+        .orElse(Collections.emptyList())
+        .stream()
+        .filter(activeMod -> activeMod.getSourceHref().get().toString().replace("#", "").equals(eId)
+        )
+        .findFirst();
       assertThat(activeModifications).isPresent();
       assertThat(activeModifications.get().getDestinationHref())
-          .contains(new Href(newDestinationHref));
+        .contains(new Href(newDestinationHref));
       assertThat(activeModifications.get().getDestinationUpTo()).isNotPresent();
       assertThat(activeModifications.get().getForcePeriodEid()).contains(newTimeBoundaryEid);
     }
 
     @Test
     void itDeletesUpToInActiveModForQuotedStructureSingleTargetMod() {
-
       // Given
       Norm amendingLawSetup = NormFixtures.loadFromDisk("NormWithQuotedStructureMods.xml");
       Norm targetNormSetup = NormFixtures.loadFromDisk("NormWithoutPassiveModsQuotedStructure.xml");
       String targetNormEliSetup = targetNormSetup.getEli();
       String eIdSetup =
-          "hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1";
+        "hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1";
       String newDestinationHrefSetup =
-          targetNormEliSetup + "/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/";
+        targetNormEliSetup + "/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/";
       String newDestinationUpToSetup =
-          targetNormEliSetup + "/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-2/";
+        targetNormEliSetup + "/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-2/";
       String newTimeBoundaryEidSetup = "#time-boundary-eid";
       String newContentSetup = "new-text";
 
       updateNormService.updateActiveModifications(
-          new UpdateActiveModificationsUseCase.Query(
-              amendingLawSetup,
-              eIdSetup,
-              newDestinationHrefSetup,
-              newDestinationUpToSetup,
-              newTimeBoundaryEidSetup,
-              newContentSetup));
+        new UpdateActiveModificationsUseCase.Query(
+          amendingLawSetup,
+          eIdSetup,
+          newDestinationHrefSetup,
+          newDestinationUpToSetup,
+          newTimeBoundaryEidSetup,
+          newContentSetup
+        )
+      );
 
       Norm amendingLaw = NormFixtures.loadFromDisk("NormWithQuotedStructureMods.xml");
       Norm targetNorm = NormFixtures.loadFromDisk("NormWithoutPassiveModsQuotedStructure.xml");
       String targetNormEli = targetNorm.getEli();
       String eId = "hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1";
       String newDestinationHref =
-          targetNormEli + "/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/";
+        targetNormEli + "/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/";
       String newDestinationUpTo = null;
       String newTimeBoundaryEid = "#time-boundary-eid";
       String newContent = "new-text";
 
       // When
-      var updatedAmendingNorm =
-          updateNormService.updateActiveModifications(
-              new UpdateActiveModificationsUseCase.Query(
-                  amendingLaw,
-                  eId,
-                  newDestinationHref,
-                  newDestinationUpTo,
-                  newTimeBoundaryEid,
-                  newContent));
+      var updatedAmendingNorm = updateNormService.updateActiveModifications(
+        new UpdateActiveModificationsUseCase.Query(
+          amendingLaw,
+          eId,
+          newDestinationHref,
+          newDestinationUpTo,
+          newTimeBoundaryEid,
+          newContent
+        )
+      );
 
       // Then
-      final Optional<TextualMod> activeModifications =
-          updatedAmendingNorm
-              .getMeta()
-              .getAnalysis()
-              .map(Analysis::getActiveModifications)
-              .orElse(Collections.emptyList())
-              .stream()
-              .filter(
-                  activeMod ->
-                      activeMod.getSourceHref().get().toString().replace("#", "").equals(eId))
-              .findFirst();
+      final Optional<TextualMod> activeModifications = updatedAmendingNorm
+        .getMeta()
+        .getAnalysis()
+        .map(Analysis::getActiveModifications)
+        .orElse(Collections.emptyList())
+        .stream()
+        .filter(activeMod -> activeMod.getSourceHref().get().toString().replace("#", "").equals(eId)
+        )
+        .findFirst();
       assertThat(activeModifications).isPresent();
       assertThat(activeModifications.get().getDestinationHref())
-          .contains(new Href(newDestinationHref));
+        .contains(new Href(newDestinationHref));
       assertThat(activeModifications.get().getDestinationUpTo()).isNotPresent();
       assertThat(activeModifications.get().getForcePeriodEid()).contains(newTimeBoundaryEid);
     }
 
     @Test
     void itReplacesRefWithRrefAfterPassingUpTo() {
-
       // Given
       final Norm amendingLaw = NormFixtures.loadFromDisk("NormWithQuotedStructureMods.xml");
-      final Norm targetNorm =
-          NormFixtures.loadFromDisk("NormWithoutPassiveModsQuotedStructure.xml");
+      final Norm targetNorm = NormFixtures.loadFromDisk(
+        "NormWithoutPassiveModsQuotedStructure.xml"
+      );
       final String modEid =
-          "hauptteil-1_para-1_abs-1_untergl-1_listenelem-5_untergl-1_listenelem-a_inhalt-1_text-1_ändbefehl-1";
+        "hauptteil-1_para-1_abs-1_untergl-1_listenelem-5_untergl-1_listenelem-a_inhalt-1_text-1_ändbefehl-1";
       final String newDestinationHref = targetNorm.getEli() + "/hauptteil-1_para-2_abs-1.xml";
       final String newDestinationUpTo = targetNorm.getEli() + "/hauptteil-1_para-2_abs-3.xml";
 
-      final Optional<Mod> modBeforeUpdate =
-          amendingLaw.getMods().stream()
-              .filter(m -> m.getMandatoryEid().equals(modEid))
-              .findFirst();
+      final Optional<Mod> modBeforeUpdate = amendingLaw
+        .getMods()
+        .stream()
+        .filter(m -> m.getMandatoryEid().equals(modEid))
+        .findFirst();
 
       // When
-      var updatedAmendingNorm =
-          updateNormService.updateActiveModifications(
-              new UpdateActiveModificationsUseCase.Query(
-                  amendingLaw,
-                  modEid,
-                  newDestinationHref,
-                  newDestinationUpTo,
-                  "#time-boundary-eid",
-                  "<test></test>"));
+      var updatedAmendingNorm = updateNormService.updateActiveModifications(
+        new UpdateActiveModificationsUseCase.Query(
+          amendingLaw,
+          modEid,
+          newDestinationHref,
+          newDestinationUpTo,
+          "#time-boundary-eid",
+          "<test></test>"
+        )
+      );
 
       // Then
-      final Optional<Mod> updatedMod =
-          updatedAmendingNorm.getMods().stream()
-              .filter(m -> m.getMandatoryEid().equals(modEid))
-              .findFirst();
+      final Optional<Mod> updatedMod = updatedAmendingNorm
+        .getMods()
+        .stream()
+        .filter(m -> m.getMandatoryEid().equals(modEid))
+        .findFirst();
       assertThat(updatedMod).isPresent();
       assertThat(updatedMod.get().getTargetRefHref()).isEmpty();
       assertThat(updatedMod.get().getTargetRrefFrom()).isPresent();
       assertThat(updatedMod.get().getTargetRrefFrom())
-          .isPresent()
-          .get()
-          .hasToString(
-              "eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/hauptteil-1_para-2_abs-1.xml");
+        .isPresent()
+        .get()
+        .hasToString(
+          "eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/hauptteil-1_para-2_abs-1.xml"
+        );
       assertThat(updatedMod.get().getTargetRrefUpTo()).isPresent();
       assertThat(updatedMod.get().getTargetRrefUpTo())
-          .isPresent()
-          .get()
-          .hasToString(
-              "eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/hauptteil-1_para-2_abs-3.xml");
+        .isPresent()
+        .get()
+        .hasToString(
+          "eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/hauptteil-1_para-2_abs-3.xml"
+        );
       assertThat(updatedMod.get().getNode().getTextContent())
-          .isEqualTo(modBeforeUpdate.get().getNode().getTextContent());
+        .isEqualTo(modBeforeUpdate.get().getNode().getTextContent());
     }
 
     @Test
     void itReplacesRrefWithRefAfterNotPassingUpTo() {
-
       // Given
       final Norm amendingLaw = NormFixtures.loadFromDisk("NormWithQuotedStructureModsAndUpTo.xml");
-      final Norm targetNorm =
-          NormFixtures.loadFromDisk("NormWithoutPassiveModsQuotedStructure.xml");
+      final Norm targetNorm = NormFixtures.loadFromDisk(
+        "NormWithoutPassiveModsQuotedStructure.xml"
+      );
       final String modEid =
-          "hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1";
+        "hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1";
       final String newDestinationHref = targetNorm.getEli() + "/hauptteil-1_para-2_abs-2.xml";
 
-      final Optional<Mod> modBeforeUpdate =
-          amendingLaw.getMods().stream()
-              .filter(m -> m.getMandatoryEid().equals(modEid))
-              .findFirst();
+      final Optional<Mod> modBeforeUpdate = amendingLaw
+        .getMods()
+        .stream()
+        .filter(m -> m.getMandatoryEid().equals(modEid))
+        .findFirst();
 
       // When
-      var updatedAmendingNorm =
-          updateNormService.updateActiveModifications(
-              new UpdateActiveModificationsUseCase.Query(
-                  amendingLaw,
-                  modEid,
-                  newDestinationHref,
-                  null,
-                  "#time-boundary-eid",
-                  "<test></test>"));
+      var updatedAmendingNorm = updateNormService.updateActiveModifications(
+        new UpdateActiveModificationsUseCase.Query(
+          amendingLaw,
+          modEid,
+          newDestinationHref,
+          null,
+          "#time-boundary-eid",
+          "<test></test>"
+        )
+      );
 
       // Then
-      final Optional<Mod> updatedMod =
-          updatedAmendingNorm.getMods().stream()
-              .filter(m -> m.getMandatoryEid().equals(modEid))
-              .findFirst();
+      final Optional<Mod> updatedMod = updatedAmendingNorm
+        .getMods()
+        .stream()
+        .filter(m -> m.getMandatoryEid().equals(modEid))
+        .findFirst();
       assertThat(updatedMod).isPresent();
       assertThat(updatedMod.get().getTargetRrefFrom()).isEmpty();
       assertThat(updatedMod.get().getTargetRrefUpTo()).isEmpty();
       assertThat(updatedMod.get().getTargetRefHref()).isPresent();
       assertThat(updatedMod.get().getTargetRefHref())
-          .isPresent()
-          .get()
-          .hasToString(
-              "eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/hauptteil-1_para-2_abs-2.xml");
+        .isPresent()
+        .get()
+        .hasToString(
+          "eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/hauptteil-1_para-2_abs-2.xml"
+        );
       assertThat(updatedMod.get().getNode().getTextContent())
-          .isEqualTo(modBeforeUpdate.get().getNode().getTextContent());
+        .isEqualTo(modBeforeUpdate.get().getNode().getTextContent());
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/XsltTransformationServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/XsltTransformationServiceTest.java
@@ -28,9 +28,11 @@ import org.springframework.core.io.FileUrlResource;
 import org.springframework.core.io.Resource;
 
 class XsltTransformationServiceTest {
+
   final Resource xsltResource = mock(Resource.class);
-  final XsltTransformationService xsltTransformationService =
-      new XsltTransformationService(xsltResource);
+  final XsltTransformationService xsltTransformationService = new XsltTransformationService(
+    xsltResource
+  );
 
   @BeforeAll
   public static void setUp() {
@@ -40,26 +42,27 @@ class XsltTransformationServiceTest {
   @Test
   void shouldReturnTransformedXml() throws IOException {
     when(xsltResource.getInputStream())
-        .thenReturn(
-            new ByteArrayInputStream(
-                """
-                    <?xml version="1.0" encoding="UTF-8"?>
-                    <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-                      <xsl:output method="html" encoding="UTF-8" />
+      .thenReturn(
+        new ByteArrayInputStream(
+          """
+          <?xml version="1.0" encoding="UTF-8"?>
+          <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+            <xsl:output method="html" encoding="UTF-8" />
 
-                      <xsl:template match="/data">
-                        <span>
-                          <xsl:apply-templates />
-                        </span>
-                      </xsl:template>
-                    </xsl:stylesheet>
-                    """
-                    .getBytes()));
+            <xsl:template match="/data">
+              <span>
+                <xsl:apply-templates />
+              </span>
+            </xsl:template>
+          </xsl:stylesheet>
+          """.getBytes()
+        )
+      );
     when(xsltResource.getURL()).thenReturn(URL.of(URI.create("https://example.com/"), null));
 
-    var result =
-        xsltTransformationService.transformLegalDocMlToHtml(
-            new TransformLegalDocMlToHtmlUseCase.Query("<data>Test</data>", false, false));
+    var result = xsltTransformationService.transformLegalDocMlToHtml(
+      new TransformLegalDocMlToHtmlUseCase.Query("<data>Test</data>", false, false)
+    );
 
     assertThat(result).isEqualToIgnoringWhitespace("<span>Test</span>");
   }
@@ -67,146 +70,155 @@ class XsltTransformationServiceTest {
   @Test
   void shouldReturnTransformedXmlWithMetadata() throws IOException {
     when(xsltResource.getInputStream())
-        .thenReturn(
-            new ByteArrayInputStream(
-                """
-                    <?xml version="1.0" encoding="UTF-8"?>
-                    <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-                      <xsl:param name="show-metadata" />
+      .thenReturn(
+        new ByteArrayInputStream(
+          """
+          <?xml version="1.0" encoding="UTF-8"?>
+          <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+            <xsl:param name="show-metadata" />
 
-                      <xsl:output method="html" encoding="UTF-8" />
+            <xsl:output method="html" encoding="UTF-8" />
 
-                       <xsl:template match="/">
-                        <body>
-                          <xsl:if test="$show-metadata">
-                            <h1>METADATA</h1>
-                          </xsl:if>
-                          <xsl:apply-templates />
-                        </body>
-                      </xsl:template>
+             <xsl:template match="/">
+              <body>
+                <xsl:if test="$show-metadata">
+                  <h1>METADATA</h1>
+                </xsl:if>
+                <xsl:apply-templates />
+              </body>
+            </xsl:template>
 
-                      <xsl:template match="/data">
-                        <span>
-                          <xsl:apply-templates />
-                        </span>
-                      </xsl:template>
+            <xsl:template match="/data">
+              <span>
+                <xsl:apply-templates />
+              </span>
+            </xsl:template>
 
-                    </xsl:stylesheet>
-                    """
-                    .getBytes()));
+          </xsl:stylesheet>
+          """.getBytes()
+        )
+      );
     when(xsltResource.getURL()).thenReturn(URL.of(URI.create("https://example.com/"), null));
 
-    var result =
-        xsltTransformationService.transformLegalDocMlToHtml(
-            new TransformLegalDocMlToHtmlUseCase.Query("<data>Test</data>", true, false));
+    var result = xsltTransformationService.transformLegalDocMlToHtml(
+      new TransformLegalDocMlToHtmlUseCase.Query("<data>Test</data>", true, false)
+    );
 
     assertThat(result)
-        .isEqualToIgnoringWhitespace(
-            """
-            <body>
-              <h1>METADATA</h1>
-              <span>Test</span>
-            </body>
-            """);
+      .isEqualToIgnoringWhitespace(
+        """
+        <body>
+          <h1>METADATA</h1>
+          <span>Test</span>
+        </body>
+        """
+      );
   }
 
   @Test
   void shouldReturnTransformedXmlWithoutMetadata() throws IOException {
     when(xsltResource.getInputStream())
-        .thenReturn(
-            new ByteArrayInputStream(
-                """
-                                <?xml version="1.0" encoding="UTF-8"?>
-                                <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-                                  <xsl:param name="show-metadata" />
+      .thenReturn(
+        new ByteArrayInputStream(
+          """
+          <?xml version="1.0" encoding="UTF-8"?>
+          <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+            <xsl:param name="show-metadata" />
 
-                                  <xsl:output method="html" encoding="UTF-8" />
+            <xsl:output method="html" encoding="UTF-8" />
 
-                                   <xsl:template match="/">
-                                    <body>
-                                      <xsl:if test="$show-metadata">
-                                        <h1>METADATA</h1>
-                                      </xsl:if>
-                                      <xsl:apply-templates />
-                                    </body>
-                                  </xsl:template>
+             <xsl:template match="/">
+              <body>
+                <xsl:if test="$show-metadata">
+                  <h1>METADATA</h1>
+                </xsl:if>
+                <xsl:apply-templates />
+              </body>
+            </xsl:template>
 
-                                  <xsl:template match="/data">
-                                    <span>
-                                      <xsl:apply-templates />
-                                    </span>
-                                  </xsl:template>
+            <xsl:template match="/data">
+              <span>
+                <xsl:apply-templates />
+              </span>
+            </xsl:template>
 
-                                </xsl:stylesheet>
-                                """
-                    .getBytes()));
+          </xsl:stylesheet>
+          """.getBytes()
+        )
+      );
     when(xsltResource.getURL()).thenReturn(URL.of(URI.create("https://example.com/"), null));
 
-    var result =
-        xsltTransformationService.transformLegalDocMlToHtml(
-            new TransformLegalDocMlToHtmlUseCase.Query("<data>Test</data>", false, false));
+    var result = xsltTransformationService.transformLegalDocMlToHtml(
+      new TransformLegalDocMlToHtmlUseCase.Query("<data>Test</data>", false, false)
+    );
 
     assertThat(result)
-        .isEqualToIgnoringWhitespace(
-            """
-                    <body>
-                      <span>Test</span>
-                    </body>
-                    """);
+      .isEqualToIgnoringWhitespace(
+        """
+        <body>
+          <span>Test</span>
+        </body>
+        """
+      );
   }
 
   @Test
   void shouldThrowXmlTransformationExceptionWhenXmlIsNotValid() throws IOException {
     when(xsltResource.getInputStream())
-        .thenReturn(
-            new ByteArrayInputStream(
-                """
-                    <?xml version="1.0" encoding="UTF-8"?>
-                    <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-                      <xsl:output method="html" encoding="UTF-8" />
+      .thenReturn(
+        new ByteArrayInputStream(
+          """
+          <?xml version="1.0" encoding="UTF-8"?>
+          <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+            <xsl:output method="html" encoding="UTF-8" />
 
-                      <xsl:template match="/data">
-                        <span>
-                          <xsl:apply-templates />
-                        </span>
-                      </xsl:template>
-                    </xsl:stylesheet>
-                    """
-                    .getBytes()));
+            <xsl:template match="/data">
+              <span>
+                <xsl:apply-templates />
+              </span>
+            </xsl:template>
+          </xsl:stylesheet>
+          """.getBytes()
+        )
+      );
     when(xsltResource.getURL()).thenReturn(URL.of(URI.create("https://example.com/"), null));
 
-    var throwable =
-        catchThrowable(
-            () ->
-                xsltTransformationService.transformLegalDocMlToHtml(
-                    new TransformLegalDocMlToHtmlUseCase.Query(
-                        "<data><invalid xml</data>", false, false)));
+    var throwable = catchThrowable(() ->
+      xsltTransformationService.transformLegalDocMlToHtml(
+        new TransformLegalDocMlToHtmlUseCase.Query("<data><invalid xml</data>", false, false)
+      )
+    );
 
     assertThat(throwable).isInstanceOf(XmlProcessingException.class);
     assertThat(throwable.getMessage())
-        .isEqualToIgnoringWhitespace(
-            """
-            SXXP0003   Error reported by XML parser: Attribute name "xml" associated with an element type "invalid" must be followed by the ' = ' character.
-            """);
+      .isEqualToIgnoringWhitespace(
+        """
+        SXXP0003   Error reported by XML parser: Attribute name "xml" associated with an element type "invalid" must be followed by the ' = ' character.
+        """
+      );
   }
 
   /** To generate new expected files see {@link #generateExpectedHtmlForShouldTransformXml} */
   @ParameterizedTest(name = "{0}")
   @MethodSource("shouldTransformXmlArgumentsProvider")
   void shouldTransformXml(
-      String xmlFile, Boolean showMetadata, String expectedHtmlFile, Boolean snippet)
-      throws IOException {
+    String xmlFile,
+    Boolean showMetadata,
+    String expectedHtmlFile,
+    Boolean snippet
+  ) throws IOException {
     var xml = loadTestResource(xmlFile);
     var expectedHtml = loadTestResource(expectedHtmlFile);
-    var resource =
-        new FileUrlResource(
-            Objects.requireNonNull(
-                XsltTransformationService.class.getResource("/XSLT/html/legislation.xslt")));
+    var resource = new FileUrlResource(
+      Objects.requireNonNull(
+        XsltTransformationService.class.getResource("/XSLT/html/legislation.xslt")
+      )
+    );
 
-    var result =
-        new XsltTransformationService(resource)
-            .transformLegalDocMlToHtml(
-                new TransformLegalDocMlToHtmlUseCase.Query(xml, showMetadata, snippet));
+    var result = new XsltTransformationService(resource)
+      .transformLegalDocMlToHtml(
+        new TransformLegalDocMlToHtmlUseCase.Query(xml, showMetadata, snippet)
+      );
 
     assertThat(result).isEqualToIgnoringWhitespace(expectedHtml);
   }
@@ -220,18 +232,22 @@ class XsltTransformationServiceTest {
   @MethodSource("shouldTransformXmlArgumentsProvider")
   @Disabled("This is not a real test but can be used to regenerate the expected html files.")
   void generateExpectedHtmlForShouldTransformXml(
-      String xmlFile, Boolean showMetadata, String expectedHtmlFile, Boolean snippet)
-      throws IOException {
+    String xmlFile,
+    Boolean showMetadata,
+    String expectedHtmlFile,
+    Boolean snippet
+  ) throws IOException {
     var xml = loadTestResource(xmlFile);
-    var resource =
-        new FileUrlResource(
-            Objects.requireNonNull(
-                XsltTransformationService.class.getResource("/XSLT/html/legislation.xslt")));
+    var resource = new FileUrlResource(
+      Objects.requireNonNull(
+        XsltTransformationService.class.getResource("/XSLT/html/legislation.xslt")
+      )
+    );
 
-    var result =
-        new XsltTransformationService(resource)
-            .transformLegalDocMlToHtml(
-                new TransformLegalDocMlToHtmlUseCase.Query(xml, showMetadata, snippet));
+    var result = new XsltTransformationService(resource)
+      .transformLegalDocMlToHtml(
+        new TransformLegalDocMlToHtmlUseCase.Query(xml, showMetadata, snippet)
+      );
 
     assertThat(result).isNotEmpty();
 
@@ -240,40 +256,45 @@ class XsltTransformationServiceTest {
 
   static String loadTestResource(String fileName) throws IOException {
     var resource =
-        XsltTransformationServiceTest.class.getResource("xsltTransformationService/" + fileName);
+      XsltTransformationServiceTest.class.getResource("xsltTransformationService/" + fileName);
     assert resource != null;
     return IOUtils.toString(resource, StandardCharsets.UTF_8);
   }
 
   static void saveTestResource(String fileName, String result) throws IOException {
     var resource =
-        XsltTransformationServiceTest.class.getResource("xsltTransformationService/" + fileName);
+      XsltTransformationServiceTest.class.getResource("xsltTransformationService/" + fileName);
     assert resource != null;
     FileUtils.writeStringToFile(new File(resource.getFile()), result, StandardCharsets.UTF_8);
   }
 
   static Stream<Arguments> shouldTransformXmlArgumentsProvider() {
     return Stream.of(
-        Arguments.arguments(
-            "Bundesverfassungsschutzgesetz.xml",
-            false,
-            "Bundesverfassungsschutzgesetz.html",
-            false),
-        Arguments.arguments(
-            "Bundesverfassungsschutzgesetz.xml",
-            true,
-            "Bundesverfassungsschutzgesetz-with-metadata.html",
-            false),
-        Arguments.arguments(
-            "Gesetz_zum_ersten_Teil_der_Reform_des_Nachrichtendienstrechts.xml",
-            false,
-            "Gesetz_zum_ersten_Teil_der_Reform_des_Nachrichtendienstrechts.html",
-            false),
-        Arguments.arguments(
-            "Erstes_Gesetz_zur_Änderung_des_Strukturänderungsgesetzes.xml",
-            false,
-            "Erstes_Gesetz_zur_Änderung_des_Strukturänderungsgesetzes.html",
-            false),
-        Arguments.arguments("Snippet.xml", false, "Snippet.html", true));
+      Arguments.arguments(
+        "Bundesverfassungsschutzgesetz.xml",
+        false,
+        "Bundesverfassungsschutzgesetz.html",
+        false
+      ),
+      Arguments.arguments(
+        "Bundesverfassungsschutzgesetz.xml",
+        true,
+        "Bundesverfassungsschutzgesetz-with-metadata.html",
+        false
+      ),
+      Arguments.arguments(
+        "Gesetz_zum_ersten_Teil_der_Reform_des_Nachrichtendienstrechts.xml",
+        false,
+        "Gesetz_zum_ersten_Teil_der_Reform_des_Nachrichtendienstrechts.html",
+        false
+      ),
+      Arguments.arguments(
+        "Erstes_Gesetz_zur_Änderung_des_Strukturänderungsgesetzes.xml",
+        false,
+        "Erstes_Gesetz_zur_Änderung_des_Strukturänderungsgesetzes.html",
+        false
+      ),
+      Arguments.arguments("Snippet.xml", false, "Snippet.html", true)
+    );
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/conventions/ArchitectureFitnessTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/conventions/ArchitectureFitnessTest.java
@@ -42,7 +42,7 @@ class ArchitectureFitnessTest {
   static final String ADAPTER_LAYER_PACKAGES = BASE_PACKAGE + ".adapter..";
 
   static final String REPOSITORY_LAYER_PACKAGES =
-      BASE_PACKAGE + ".adapter.output.database.repository";
+    BASE_PACKAGE + ".adapter.output.database.repository";
   static final String ADAPTER_OUTPUT = BASE_PACKAGE + ".adapter.output..";
   static final String DOMAIN_LAYER_PACKAGES = BASE_PACKAGE + ".domain..";
   static final String ENTITY_LAYER_PACKAGES = BASE_PACKAGE + ".domain.entity";
@@ -50,323 +50,320 @@ class ArchitectureFitnessTest {
   static final String EXCEPTIONS_LAYER_PACKAGES = BASE_PACKAGE + ".domain.exceptions";
   static final String UTILS_LAYER_PACKAGES = BASE_PACKAGE + ".utils..";
 
-  static final String[] DOMAIN_LAYER_ALLOWED_PACKAGES =
-      new String[] {
-        "kotlin..",
-        "java..",
-        "org.jetbrains.annotations..",
-        "lombok..",
-        "org.w3c.dom..",
-        "org.apache.commons.lang3.."
-      };
-  static final String[] UTILITY_LAYER_ALLOWED_PACKAGES =
-      new String[] {
-        UTILS_LAYER_PACKAGES,
-        DOMAIN_LAYER_PACKAGES,
-        "kotlin..",
-        "java..",
-        "javax.xml..",
-        "org.jetbrains.annotations..",
-        "lombok..",
-        "org.w3c.dom..",
-        "net.sf.saxon..",
-        "org.xml.sax..",
-        "org.slf4j..",
-      };
+  static final String[] DOMAIN_LAYER_ALLOWED_PACKAGES = new String[] {
+    "kotlin..",
+    "java..",
+    "org.jetbrains.annotations..",
+    "lombok..",
+    "org.w3c.dom..",
+    "org.apache.commons.lang3..",
+  };
+  static final String[] UTILITY_LAYER_ALLOWED_PACKAGES = new String[] {
+    UTILS_LAYER_PACKAGES,
+    DOMAIN_LAYER_PACKAGES,
+    "kotlin..",
+    "java..",
+    "javax.xml..",
+    "org.jetbrains.annotations..",
+    "lombok..",
+    "org.w3c.dom..",
+    "net.sf.saxon..",
+    "org.xml.sax..",
+    "org.slf4j..",
+  };
 
   @BeforeAll
   static void setUp() {
     classes =
-        new ClassFileImporter()
-            .withImportOption(Predefined.DO_NOT_INCLUDE_TESTS)
-            .importPackages("de.bund.digitalservice.ris.norms");
+    new ClassFileImporter()
+      .withImportOption(Predefined.DO_NOT_INCLUDE_TESTS)
+      .importPackages("de.bund.digitalservice.ris.norms");
   }
 
   @Test
   void packagesShouldBeFreeOfCycles() {
-    SliceRule rule =
-        SlicesRuleDefinition.slices()
-            .matching("de.bund.digitalservice.ris.norms.(*)")
-            .should()
-            .beFreeOfCycles();
+    SliceRule rule = SlicesRuleDefinition
+      .slices()
+      .matching("de.bund.digitalservice.ris.norms.(*)")
+      .should()
+      .beFreeOfCycles();
     rule.check(classes);
   }
 
   @Test
   void domainClassesShouldOnlyDependOnDomainUtilsOrSpecificStandardLibraries() {
-    ArchRule rule =
-        ArchRuleDefinition.classes()
-            .that()
-            .resideInAPackage(DOMAIN_LAYER_PACKAGES)
-            .should(
-                onlyDependOnClassesThat(
-                    resideInAPackage(DOMAIN_LAYER_PACKAGES)
-                        .or(resideInAPackage(UTILS_LAYER_PACKAGES))
-                        .or(
-                            JavaClass.Predicates.resideInAnyPackage(
-                                DOMAIN_LAYER_ALLOWED_PACKAGES))));
+    ArchRule rule = ArchRuleDefinition
+      .classes()
+      .that()
+      .resideInAPackage(DOMAIN_LAYER_PACKAGES)
+      .should(
+        onlyDependOnClassesThat(
+          resideInAPackage(DOMAIN_LAYER_PACKAGES)
+            .or(resideInAPackage(UTILS_LAYER_PACKAGES))
+            .or(JavaClass.Predicates.resideInAnyPackage(DOMAIN_LAYER_ALLOWED_PACKAGES))
+        )
+      );
     rule.check(classes);
   }
 
   @Test
   void utilsClassesShouldOnlyDependOnUtilsOrSpecificStandardLibraries() {
-    ArchRule rule =
-        ArchRuleDefinition.classes()
-            .that()
-            .resideInAPackage(UTILS_LAYER_PACKAGES)
-            .should()
-            .onlyDependOnClassesThat()
-            .resideInAnyPackage(UTILITY_LAYER_ALLOWED_PACKAGES);
+    ArchRule rule = ArchRuleDefinition
+      .classes()
+      .that()
+      .resideInAPackage(UTILS_LAYER_PACKAGES)
+      .should()
+      .onlyDependOnClassesThat()
+      .resideInAnyPackage(UTILITY_LAYER_ALLOWED_PACKAGES);
     rule.check(classes);
   }
 
   @Test
   void allClassesOfDomainShouldBeSortedIntoPackages() {
-    ArchRule rule =
-        ArchRuleDefinition.classes()
-            .that()
-            .resideInAPackage(DOMAIN_LAYER_PACKAGES)
-            .should()
-            .resideInAnyPackage(
-                ENTITY_LAYER_PACKAGES, VALUE_LAYER_PACKAGES, EXCEPTIONS_LAYER_PACKAGES);
+    ArchRule rule = ArchRuleDefinition
+      .classes()
+      .that()
+      .resideInAPackage(DOMAIN_LAYER_PACKAGES)
+      .should()
+      .resideInAnyPackage(ENTITY_LAYER_PACKAGES, VALUE_LAYER_PACKAGES, EXCEPTIONS_LAYER_PACKAGES);
 
     rule.check(classes);
   }
 
   @Test
   void controllerClassesShouldNotResideOutsideOfAdapterPackage() {
-    ArchRule rule =
-        ArchRuleDefinition.noClasses()
-            .that()
-            .areAnnotatedWith(Controller.class)
-            .or()
-            .areAnnotatedWith(RestController.class)
-            .should()
-            .resideOutsideOfPackage(ADAPTER_LAYER_PACKAGES);
+    ArchRule rule = ArchRuleDefinition
+      .noClasses()
+      .that()
+      .areAnnotatedWith(Controller.class)
+      .or()
+      .areAnnotatedWith(RestController.class)
+      .should()
+      .resideOutsideOfPackage(ADAPTER_LAYER_PACKAGES);
     rule.check(classes);
   }
 
   @Test
   void controllerClassesShouldNotDependOnEachOther() {
-    ArchRule rule =
-        ArchRuleDefinition.noClasses()
-            .that()
-            .haveSimpleNameEndingWith("Controller")
-            .should()
-            .dependOnClassesThat()
-            .resideInAPackage(ADAPTER_LAYER_PACKAGES)
-            .andShould()
-            .dependOnClassesThat()
-            .areAnnotatedWith(Controller.class)
-            .andShould()
-            .dependOnClassesThat()
-            .areAnnotatedWith(RestController.class);
+    ArchRule rule = ArchRuleDefinition
+      .noClasses()
+      .that()
+      .haveSimpleNameEndingWith("Controller")
+      .should()
+      .dependOnClassesThat()
+      .resideInAPackage(ADAPTER_LAYER_PACKAGES)
+      .andShould()
+      .dependOnClassesThat()
+      .areAnnotatedWith(Controller.class)
+      .andShould()
+      .dependOnClassesThat()
+      .areAnnotatedWith(RestController.class);
     rule.check(classes);
   }
 
   @Test
   void controllerClassesShouldOnlyHaveUseCasesFields() {
-    ArchRule rule =
-        ArchRuleDefinition.noClasses()
-            .that()
-            .haveSimpleNameEndingWith("Controller")
-            .and()
-            .areAnnotatedWith(Controller.class)
-            .or()
-            .areAnnotatedWith(RestController.class)
-            .should(ArchCondition.from((new ShouldOnlyHaveUseCaseFields())))
-            .because(
-                "Controllers should only depend on use case interfaces, not on service implementations");
+    ArchRule rule = ArchRuleDefinition
+      .noClasses()
+      .that()
+      .haveSimpleNameEndingWith("Controller")
+      .and()
+      .areAnnotatedWith(Controller.class)
+      .or()
+      .areAnnotatedWith(RestController.class)
+      .should(ArchCondition.from((new ShouldOnlyHaveUseCaseFields())))
+      .because(
+        "Controllers should only depend on use case interfaces, not on service implementations"
+      );
     rule.check(classes);
   }
 
   @Test
   void onlyRepositoryInterfacesAllowed() {
-    ArchRule rule =
-        ArchRuleDefinition.classes()
-            .that()
-            .resideInAPackage(ADAPTER_LAYER_PACKAGES)
-            .and()
-            .haveSimpleNameEndingWith("Repository")
-            .should()
-            .beInterfaces();
+    ArchRule rule = ArchRuleDefinition
+      .classes()
+      .that()
+      .resideInAPackage(ADAPTER_LAYER_PACKAGES)
+      .and()
+      .haveSimpleNameEndingWith("Repository")
+      .should()
+      .beInterfaces();
     rule.check(classes);
   }
 
   @Test
   void implementationOutputPortsOnlyAllowedInTheAdapterPackageAsRepositories() {
-    DescribedPredicate<JavaClass> predicate =
-        JavaClass.Predicates.resideInAPackage(OUTPUT_PORT_LAYER_PACKAGES)
-            .and(JavaClass.Predicates.INTERFACES);
-    ArchRule rule =
-        ArchRuleDefinition.classes()
-            .that()
-            .implement(predicate)
-            .should()
-            .resideInAPackage(ADAPTER_LAYER_PACKAGES)
-            .andShould()
-            .beAnnotatedWith(Service.class);
+    DescribedPredicate<JavaClass> predicate = JavaClass.Predicates
+      .resideInAPackage(OUTPUT_PORT_LAYER_PACKAGES)
+      .and(JavaClass.Predicates.INTERFACES);
+    ArchRule rule = ArchRuleDefinition
+      .classes()
+      .that()
+      .implement(predicate)
+      .should()
+      .resideInAPackage(ADAPTER_LAYER_PACKAGES)
+      .andShould()
+      .beAnnotatedWith(Service.class);
     rule.check(classes);
   }
 
   @Test
   void implementationInputPortsOnlyAllowedInTheApplicationPackageAsServices() {
-    DescribedPredicate<JavaClass> predicate =
-        JavaClass.Predicates.resideInAPackage(INPUT_PORT_LAYER_PACKAGES)
-            .and(JavaClass.Predicates.INTERFACES);
-    ArchRule rule =
-        ArchRuleDefinition.classes()
-            .that()
-            .implement(predicate)
-            .should()
-            .resideInAPackage(APPLICATION_LAYER_PACKAGES)
-            .andShould()
-            .beAnnotatedWith(Service.class);
+    DescribedPredicate<JavaClass> predicate = JavaClass.Predicates
+      .resideInAPackage(INPUT_PORT_LAYER_PACKAGES)
+      .and(JavaClass.Predicates.INTERFACES);
+    ArchRule rule = ArchRuleDefinition
+      .classes()
+      .that()
+      .implement(predicate)
+      .should()
+      .resideInAPackage(APPLICATION_LAYER_PACKAGES)
+      .andShould()
+      .beAnnotatedWith(Service.class);
     rule.check(classes);
   }
 
   @Test
   void repositoryInRepositoryPackageAreInterfacesWhichExtendJpaRepository() {
-    ArchRule rule =
-        ArchRuleDefinition.classes()
-            .that()
-            .resideInAPackage(REPOSITORY_LAYER_PACKAGES)
-            .and()
-            .haveSimpleNameEndingWith("Repository")
-            .should()
-            .beInterfaces()
-            .andShould()
-            .beAssignableTo(JpaRepository.class);
+    ArchRule rule = ArchRuleDefinition
+      .classes()
+      .that()
+      .resideInAPackage(REPOSITORY_LAYER_PACKAGES)
+      .and()
+      .haveSimpleNameEndingWith("Repository")
+      .should()
+      .beInterfaces()
+      .andShould()
+      .beAssignableTo(JpaRepository.class);
     rule.check(classes);
   }
 
   @Test
   void applicationPackageShouldNotDependOnAdapterPackage() {
-    ArchRule rule =
-        ArchRuleDefinition.classes()
-            .that()
-            .resideInAPackage(APPLICATION_LAYER_PACKAGES)
-            .should()
-            .onlyDependOnClassesThat()
-            .resideOutsideOfPackage(ADAPTER_LAYER_PACKAGES);
+    ArchRule rule = ArchRuleDefinition
+      .classes()
+      .that()
+      .resideInAPackage(APPLICATION_LAYER_PACKAGES)
+      .should()
+      .onlyDependOnClassesThat()
+      .resideOutsideOfPackage(ADAPTER_LAYER_PACKAGES);
     rule.check(classes);
   }
 
   @Test
   void outputPortMayNotDependOnApplicationLayerExceptions() {
-    ArchRule rule =
-        ArchRuleDefinition.classes()
-            .that()
-            .resideInAPackage(ADAPTER_OUTPUT)
-            .should()
-            .onlyDependOnClassesThat()
-            .resideOutsideOfPackage(APPLICATION_EXCEPTION_PACKAGES);
+    ArchRule rule = ArchRuleDefinition
+      .classes()
+      .that()
+      .resideInAPackage(ADAPTER_OUTPUT)
+      .should()
+      .onlyDependOnClassesThat()
+      .resideOutsideOfPackage(APPLICATION_EXCEPTION_PACKAGES);
     rule.check(classes);
   }
 
   @Test
   void allClassesOfTheApplicationShouldBeSortedIntoTheFollowingPackages() {
-    ArchRule rule =
-        ArchRuleDefinition.classes()
-            .that()
-            .resideInAPackage(APPLICATION_LAYER_PACKAGES)
-            .should()
-            .resideInAnyPackage(
-                INPUT_PORT_LAYER_PACKAGES,
-                OUTPUT_PORT_LAYER_PACKAGES,
-                SERVICE_LAYER_PACKAGES,
-                APPLICATION_EXCEPTION_PACKAGES);
+    ArchRule rule = ArchRuleDefinition
+      .classes()
+      .that()
+      .resideInAPackage(APPLICATION_LAYER_PACKAGES)
+      .should()
+      .resideInAnyPackage(
+        INPUT_PORT_LAYER_PACKAGES,
+        OUTPUT_PORT_LAYER_PACKAGES,
+        SERVICE_LAYER_PACKAGES,
+        APPLICATION_EXCEPTION_PACKAGES
+      );
     rule.check(classes);
   }
 
   @Test
   void portsAreInterfaces() {
-    ArchRule rule =
-        ArchRuleDefinition.classes()
-            .that(
-                (resideInAPackage(INPUT_PORT_LAYER_PACKAGES).and(simpleNameEndingWith("UseCase")))
-                    .or(
-                        resideInAPackage(OUTPUT_PORT_LAYER_PACKAGES)
-                            .and(simpleNameEndingWith("Port"))))
-            .should(beInterfaces());
+    ArchRule rule = ArchRuleDefinition
+      .classes()
+      .that(
+        (resideInAPackage(INPUT_PORT_LAYER_PACKAGES).and(simpleNameEndingWith("UseCase"))).or(
+            resideInAPackage(OUTPUT_PORT_LAYER_PACKAGES).and(simpleNameEndingWith("Port"))
+          )
+      )
+      .should(beInterfaces());
     rule.check(classes);
   }
 
   @Test
   void portsShouldNotDependOnEachOther() {
-    SliceRule rule =
-        SlicesRuleDefinition.slices()
-            .matching(BASE_PACKAGE + ".application.port.(*)..")
-            .should()
-            .notDependOnEachOther();
+    SliceRule rule = SlicesRuleDefinition
+      .slices()
+      .matching(BASE_PACKAGE + ".application.port.(*)..")
+      .should()
+      .notDependOnEachOther();
     rule.check(classes);
   }
 
   @Test
   void portsHaveASinglePublicMethodOnly() {
-
     final HaveExactNumberOfMethods haveASingleMethod = new HaveExactNumberOfMethods(1);
 
-    ArchRule rule =
-        ArchRuleDefinition.classes()
-            .that()
-            .resideInAnyPackage(INPUT_PORT_LAYER_PACKAGES, OUTPUT_PORT_LAYER_PACKAGES)
-            .and(new IsNotRecordClass())
-            .and()
-            .areNotAssignableTo(Exception.class)
-            .should(ArchCondition.from((haveASingleMethod)))
-            .andShould(bePublic());
+    ArchRule rule = ArchRuleDefinition
+      .classes()
+      .that()
+      .resideInAnyPackage(INPUT_PORT_LAYER_PACKAGES, OUTPUT_PORT_LAYER_PACKAGES)
+      .and(new IsNotRecordClass())
+      .and()
+      .areNotAssignableTo(Exception.class)
+      .should(ArchCondition.from((haveASingleMethod)))
+      .andShould(bePublic());
     rule.check(classes);
   }
 
   @Test
   void portMethodsHaveASingleCommandOrQueryParameter() {
-
-    final HaveAParameterWithTypeName haveACommandParameter =
-        new HaveAParameterWithTypeName("Command");
+    final HaveAParameterWithTypeName haveACommandParameter = new HaveAParameterWithTypeName(
+      "Command"
+    );
     final HaveAParameterWithTypeName haveAQueryParameter = new HaveAParameterWithTypeName("Query");
     final HaveExactNumberOfParameters haveASingleParameter = new HaveExactNumberOfParameters(1);
     final HaveExactNumberOfParameters haveNoParameters = new HaveExactNumberOfParameters(0);
 
-    ArchRule rule =
-        ArchRuleDefinition.methods()
-            .that()
-            .areDeclaredInClassesThat()
-            .resideInAnyPackage(INPUT_PORT_LAYER_PACKAGES, OUTPUT_PORT_LAYER_PACKAGES)
-            .and()
-            .doNotHaveName("equals")
-            .should(
-                ArchCondition.from((haveASingleParameter))
-                    .and(ArchCondition.from(haveAQueryParameter)))
-            .orShould(
-                ArchCondition.from((haveASingleParameter))
-                    .and(ArchCondition.from(haveACommandParameter)))
-            .orShould(ArchCondition.from(haveNoParameters));
+    ArchRule rule = ArchRuleDefinition
+      .methods()
+      .that()
+      .areDeclaredInClassesThat()
+      .resideInAnyPackage(INPUT_PORT_LAYER_PACKAGES, OUTPUT_PORT_LAYER_PACKAGES)
+      .and()
+      .doNotHaveName("equals")
+      .should(
+        ArchCondition.from((haveASingleParameter)).and(ArchCondition.from(haveAQueryParameter))
+      )
+      .orShould(
+        ArchCondition.from((haveASingleParameter)).and(ArchCondition.from(haveACommandParameter))
+      )
+      .orShould(ArchCondition.from(haveNoParameters));
     rule.check(classes);
   }
 
   @Test
   void applicationServicesDoNotImplementOutputPorts() {
-    ArchRule rule =
-        ArchRuleDefinition.classes()
-            .that()
-            .resideInAPackage(SERVICE_LAYER_PACKAGES)
-            .and()
-            .haveSimpleNameEndingWith("Service")
-            .should(
-                notImplement(
-                    resideInAPackage(OUTPUT_PORT_LAYER_PACKAGES)
-                        .and(simpleNameEndingWith("Port"))));
+    ArchRule rule = ArchRuleDefinition
+      .classes()
+      .that()
+      .resideInAPackage(SERVICE_LAYER_PACKAGES)
+      .and()
+      .haveSimpleNameEndingWith("Service")
+      .should(
+        notImplement(resideInAPackage(OUTPUT_PORT_LAYER_PACKAGES).and(simpleNameEndingWith("Port")))
+      );
     rule.check(classes);
   }
 
   @Test
   void adaptersShouldNotDependOnEachOther() {
-    SliceRule rule =
-        SlicesRuleDefinition.slices()
-            .matching(BASE_PACKAGE + ".adapter.(*)..")
-            .should()
-            .notDependOnEachOther();
+    SliceRule rule = SlicesRuleDefinition
+      .slices()
+      .matching(BASE_PACKAGE + ".adapter.(*)..")
+      .should()
+      .notDependOnEachOther();
     rule.check(classes);
   }
 
@@ -396,11 +393,12 @@ class ArchitectureFitnessTest {
 
     @Override
     public boolean test(JavaMethod javaMethod) {
-      final List<String> matched =
-          javaMethod.getParameters().stream()
-              .map(it -> it.getRawType().getSimpleName())
-              .filter(f -> Objects.equals(f, typeName))
-              .toList();
+      final List<String> matched = javaMethod
+        .getParameters()
+        .stream()
+        .map(it -> it.getRawType().getSimpleName())
+        .filter(f -> Objects.equals(f, typeName))
+        .toList();
       return !matched.isEmpty();
     }
   }
@@ -434,14 +432,13 @@ class ArchitectureFitnessTest {
 
   static class ShouldOnlyHaveUseCaseFields extends DescribedPredicate<JavaClass> {
 
-    final Set<String> useCaseInterfaces =
-        classes.stream()
-            .filter(
-                javaClass ->
-                    javaClass.isInterface()
-                        && javaClass.getPackageName().startsWith(INPUT_PORT_LAYER_PACKAGES))
-            .map(JavaClass::getName)
-            .collect(Collectors.toSet());
+    final Set<String> useCaseInterfaces = classes
+      .stream()
+      .filter(javaClass ->
+        javaClass.isInterface() && javaClass.getPackageName().startsWith(INPUT_PORT_LAYER_PACKAGES)
+      )
+      .map(JavaClass::getName)
+      .collect(Collectors.toSet());
 
     public ShouldOnlyHaveUseCaseFields() {
       super("Class has only fields that are use case interfaces");
@@ -449,8 +446,10 @@ class ArchitectureFitnessTest {
 
     @Override
     public boolean test(JavaClass javaClass) {
-      return javaClass.getFields().stream()
-          .anyMatch(f -> !useCaseInterfaces.contains(f.getRawType().getName()));
+      return javaClass
+        .getFields()
+        .stream()
+        .anyMatch(f -> !useCaseInterfaces.contains(f.getRawType().getName()));
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/AnalysisTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/AnalysisTest.java
@@ -10,27 +10,29 @@ class AnalysisTest {
 
   @Test
   void getActiveModifications() {
-    final Analysis analysis =
-        Analysis.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:analysis xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
-                              <akn:activeModifications eId="meta-1_analysis-1_activemod-1" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3ac">
-                                  <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-2" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
-                                      <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-2_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
-                                      <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-2_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
-                                      <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-2_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
-                                  </akn:textualMod>
-                                  <akn:textualMod eId="meta-1_analysis-1_activemod-2_textualmod-1" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
-                                      <akn:source eId="meta-1_analysis-1_activemod-2_textualmod-1_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
-                                      <akn:destination eId="meta-1_analysis-1_activemod-2_textualmod-1_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
-                                      <akn:force eId="meta-1_analysis-1_activemod-2_textualmod-1_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
-                                  </akn:textualMod>
-                              </akn:activeModifications>
-                          </akn:analysis>
-                          """))
-            .build();
+    final Analysis analysis = Analysis
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:analysis xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
+                <akn:activeModifications eId="meta-1_analysis-1_activemod-1" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3ac">
+                    <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-2" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
+                        <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-2_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
+                        <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-2_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
+                        <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-2_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
+                    </akn:textualMod>
+                    <akn:textualMod eId="meta-1_analysis-1_activemod-2_textualmod-1" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
+                        <akn:source eId="meta-1_analysis-1_activemod-2_textualmod-1_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
+                        <akn:destination eId="meta-1_analysis-1_activemod-2_textualmod-1_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
+                        <akn:force eId="meta-1_analysis-1_activemod-2_textualmod-1_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
+                    </akn:textualMod>
+                </akn:activeModifications>
+            </akn:analysis>
+            """
+        )
+      )
+      .build();
 
     // then
     assertThat(analysis.getActiveModifications()).hasSize(2);
@@ -38,15 +40,17 @@ class AnalysisTest {
 
   @Test
   void getActiveModificationsEmpty() {
-    final Analysis analysis =
-        Analysis.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:analysis xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
-                                          </akn:analysis>
-                                           """))
-            .build();
+    final Analysis analysis = Analysis
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:analysis xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
+                            </akn:analysis>
+                             """
+        )
+      )
+      .build();
 
     // then
     assertThat(analysis.getActiveModifications()).isEmpty();
@@ -54,27 +58,29 @@ class AnalysisTest {
 
   @Test
   void getPassiveModifications() {
-    final Analysis analysis =
-        Analysis.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:analysis xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
-                                              <akn:passiveModifications eId="meta-1_analysis-1_activemod-1" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3ac">
-                                                  <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-2" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
-                                                      <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-2_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
-                                                      <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-2_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
-                                                      <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-2_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
-                                                  </akn:textualMod>
-                                                  <akn:textualMod eId="meta-1_analysis-1_activemod-2_textualmod-1" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
-                                                      <akn:source eId="meta-1_analysis-1_activemod-2_textualmod-1_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
-                                                      <akn:destination eId="meta-1_analysis-1_activemod-2_textualmod-1_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
-                                                      <akn:force eId="meta-1_analysis-1_activemod-2_textualmod-1_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
-                                                  </akn:textualMod>
-                                              </akn:passiveModifications>
-                                          </akn:analysis>
-                                          """))
-            .build();
+    final Analysis analysis = Analysis
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:analysis xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
+                                <akn:passiveModifications eId="meta-1_analysis-1_activemod-1" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3ac">
+                                    <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-2" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
+                                        <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-2_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
+                                        <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-2_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
+                                        <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-2_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
+                                    </akn:textualMod>
+                                    <akn:textualMod eId="meta-1_analysis-1_activemod-2_textualmod-1" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
+                                        <akn:source eId="meta-1_analysis-1_activemod-2_textualmod-1_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
+                                        <akn:destination eId="meta-1_analysis-1_activemod-2_textualmod-1_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
+                                        <akn:force eId="meta-1_analysis-1_activemod-2_textualmod-1_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
+                                    </akn:textualMod>
+                                </akn:passiveModifications>
+                            </akn:analysis>
+                            """
+        )
+      )
+      .build();
 
     // then
     assertThat(analysis.getPassiveModifications()).hasSize(2);
@@ -82,15 +88,17 @@ class AnalysisTest {
 
   @Test
   void getPassiveModificationsEmpty() {
-    final Analysis analysis =
-        Analysis.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:analysis xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
-                                              </akn:analysis>
-                                               """))
-            .build();
+    final Analysis analysis = Analysis
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:analysis xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
+                                </akn:analysis>
+                                 """
+        )
+      )
+      .build();
 
     // then
     assertThat(analysis.getPassiveModifications()).isEmpty();
@@ -98,15 +106,17 @@ class AnalysisTest {
 
   @Test
   void itShouldCreatesThePassiveModificationsNodeIfItDoesNotExist() {
-    final Analysis analysis =
-        Analysis.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:analysis xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
-                                                              </akn:analysis>
-                                                               """))
-            .build();
+    final Analysis analysis = Analysis
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:analysis xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
+                                                </akn:analysis>
+                                                 """
+        )
+      )
+      .build();
 
     // when
     final var passiveModificationsNode = analysis.getOrCreatePassiveModificationsNode();
@@ -118,27 +128,29 @@ class AnalysisTest {
 
   @Test
   void itShouldFindThePassiveModificationsNodeIfItExist() {
-    final Analysis analysis =
-        Analysis.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:analysis xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
-                                                              <akn:passiveModifications eId="meta-1_analysis-1_activemod-1" GUID="77aae58f-06c9-4189-af80-a5f3ada6432c">
-                                                                  <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-2" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
-                                                                      <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-2_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
-                                                                      <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-2_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
-                                                                      <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-2_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
-                                                                  </akn:textualMod>
-                                                                  <akn:textualMod eId="meta-1_analysis-1_activemod-2_textualmod-1" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
-                                                                      <akn:source eId="meta-1_analysis-1_activemod-2_textualmod-1_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
-                                                                      <akn:destination eId="meta-1_analysis-1_activemod-2_textualmod-1_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
-                                                                      <akn:force eId="meta-1_analysis-1_activemod-2_textualmod-1_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
-                                                                  </akn:textualMod>
-                                                              </akn:passiveModifications>
-                                                          </akn:analysis>
-                                                          """))
-            .build();
+    final Analysis analysis = Analysis
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:analysis xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
+                                                <akn:passiveModifications eId="meta-1_analysis-1_activemod-1" GUID="77aae58f-06c9-4189-af80-a5f3ada6432c">
+                                                    <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-2" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
+                                                        <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-2_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
+                                                        <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-2_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
+                                                        <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-2_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
+                                                    </akn:textualMod>
+                                                    <akn:textualMod eId="meta-1_analysis-1_activemod-2_textualmod-1" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
+                                                        <akn:source eId="meta-1_analysis-1_activemod-2_textualmod-1_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
+                                                        <akn:destination eId="meta-1_analysis-1_activemod-2_textualmod-1_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
+                                                        <akn:force eId="meta-1_analysis-1_activemod-2_textualmod-1_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
+                                                    </akn:textualMod>
+                                                </akn:passiveModifications>
+                                            </akn:analysis>
+                                            """
+        )
+      )
+      .build();
 
     // when
     final var passiveModificationsNode = analysis.getOrCreatePassiveModificationsNode();
@@ -146,90 +158,100 @@ class AnalysisTest {
     // then
     assertThat(passiveModificationsNode).isNotNull();
     assertThat(NodeParser.getValueFromExpression("@GUID", passiveModificationsNode))
-        .contains("77aae58f-06c9-4189-af80-a5f3ada6432c");
+      .contains("77aae58f-06c9-4189-af80-a5f3ada6432c");
   }
 
   @Test
   void itShouldCreateANewPassiveModificationWithouUpTo() {
-    final Analysis analysis =
-        Analysis.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:analysis xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
-                                      <akn:passiveModifications eId="meta-1_analysis-1_activemod-1" GUID="77aae58f-06c9-4189-af80-a5f3ada6432c">
-                                          <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-2" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
-                                              <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-2_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
-                                              <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-2_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
-                                              <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-2_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
-                                          </akn:textualMod>
-                                      </akn:passiveModifications>
-                                  </akn:analysis>
-                              """))
-            .build();
+    final Analysis analysis = Analysis
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:analysis xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
+                        <akn:passiveModifications eId="meta-1_analysis-1_activemod-1" GUID="77aae58f-06c9-4189-af80-a5f3ada6432c">
+                            <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-2" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
+                                <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-2_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
+                                <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-2_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
+                                <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-2_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
+                            </akn:textualMod>
+                        </akn:passiveModifications>
+                    </akn:analysis>
+                """
+        )
+      )
+      .build();
 
     assertThat(analysis.getPassiveModifications()).hasSize(1);
     analysis.addPassiveModification(
-        "substitution",
-        "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml",
-        "#hauptteil-1_para-20_abs-1/100-126",
-        "#meta-1_geltzeiten-1_geltungszeitgr-2",
-        null);
+      "substitution",
+      "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml",
+      "#hauptteil-1_para-20_abs-1/100-126",
+      "#meta-1_geltzeiten-1_geltungszeitgr-2",
+      null
+    );
     assertThat(analysis.getPassiveModifications()).hasSize(2);
 
     final TextualMod addedPassiveMod = analysis.getPassiveModifications().getLast();
 
     assertThat(addedPassiveMod.getSourceHref())
-        .contains(
-            new Href(
-                "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"));
+      .contains(
+        new Href(
+          "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"
+        )
+      );
     assertThat(addedPassiveMod.getType()).contains("substitution");
     assertThat(addedPassiveMod.getDestinationHref())
-        .contains(new Href("#hauptteil-1_para-20_abs-1/100-126"));
+      .contains(new Href("#hauptteil-1_para-20_abs-1/100-126"));
     assertThat(addedPassiveMod.getForcePeriodEid())
-        .contains("meta-1_geltzeiten-1_geltungszeitgr-2");
+      .contains("meta-1_geltzeiten-1_geltungszeitgr-2");
   }
 
   @Test
   void itShouldCreateANewPassiveModificationWithUpTo() {
-    final Analysis analysis =
-        Analysis.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:analysis xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="72cd555b-de7d-4d5e-ba2e-4dc50800400f" eId="meta-1_analysis-1" source="attributsemantik-noch-undefiniert">
-                                            <akn:passiveModifications GUID="ca13a0cc-8f37-42c7-920b-f0d2fb59c81c" eId="meta-1_analysis-1_activemod-1">
-                                              <akn:textualMod GUID="ae8e4880-4385-4e54-9b7c-1337d8015d33" eId="meta-1_analysis-1_activemod-1_textualmod-1" type="substitution">
-                                                <akn:source GUID="30406542-d2e5-41fb-81ae-da19efa66aae" eId="meta-1_analysis-1_activemod-1_textualmod-1_source-1" href="eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1"/>
-                                                <akn:destination GUID="dc780027-452c-41eb-850c-af483bbdc2dc" eId="meta-1_analysis-1_activemod-1_textualmod-1_destination-1" href="#hauptteil-1_para-2_abs-1.xml" upTo="#hauptteil-1_para-2_abs-3.xml"/>
-                                                <akn:force GUID="9a8da48a-b837-45ea-8395-09bc895df4b0" eId="meta-1_analysis-1_activemod-1_textualmod-1_gelzeitnachw-1" period="#meta-1_geltzeiten-1_geltungszeitgr-2"/>
-                                              </akn:textualMod>
-                                            </akn:passiveModifications>
-                                          </akn:analysis>
-                                          """))
-            .build();
+    final Analysis analysis = Analysis
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:analysis xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="72cd555b-de7d-4d5e-ba2e-4dc50800400f" eId="meta-1_analysis-1" source="attributsemantik-noch-undefiniert">
+                              <akn:passiveModifications GUID="ca13a0cc-8f37-42c7-920b-f0d2fb59c81c" eId="meta-1_analysis-1_activemod-1">
+                                <akn:textualMod GUID="ae8e4880-4385-4e54-9b7c-1337d8015d33" eId="meta-1_analysis-1_activemod-1_textualmod-1" type="substitution">
+                                  <akn:source GUID="30406542-d2e5-41fb-81ae-da19efa66aae" eId="meta-1_analysis-1_activemod-1_textualmod-1_source-1" href="eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1"/>
+                                  <akn:destination GUID="dc780027-452c-41eb-850c-af483bbdc2dc" eId="meta-1_analysis-1_activemod-1_textualmod-1_destination-1" href="#hauptteil-1_para-2_abs-1.xml" upTo="#hauptteil-1_para-2_abs-3.xml"/>
+                                  <akn:force GUID="9a8da48a-b837-45ea-8395-09bc895df4b0" eId="meta-1_analysis-1_activemod-1_textualmod-1_gelzeitnachw-1" period="#meta-1_geltzeiten-1_geltungszeitgr-2"/>
+                                </akn:textualMod>
+                              </akn:passiveModifications>
+                            </akn:analysis>
+                            """
+        )
+      )
+      .build();
 
     assertThat(analysis.getPassiveModifications()).hasSize(1);
     analysis.addPassiveModification(
-        "substitution",
-        "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml",
-        "#hauptteil-1_para-20_abs-1",
-        "#meta-1_geltzeiten-1_geltungszeitgr-2",
-        "#hauptteil-1_para-20_abs-3");
+      "substitution",
+      "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml",
+      "#hauptteil-1_para-20_abs-1",
+      "#meta-1_geltzeiten-1_geltungszeitgr-2",
+      "#hauptteil-1_para-20_abs-3"
+    );
     assertThat(analysis.getPassiveModifications()).hasSize(2);
 
     final TextualMod addedPassiveMod = analysis.getPassiveModifications().getLast();
 
     assertThat(addedPassiveMod.getSourceHref())
-        .contains(
-            new Href(
-                "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"));
+      .contains(
+        new Href(
+          "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"
+        )
+      );
     assertThat(addedPassiveMod.getType()).contains("substitution");
     assertThat(addedPassiveMod.getDestinationHref())
-        .contains(new Href("#hauptteil-1_para-20_abs-1"));
+      .contains(new Href("#hauptteil-1_para-20_abs-1"));
     assertThat(addedPassiveMod.getDestinationUpTo())
-        .contains(new Href("#hauptteil-1_para-20_abs-3"));
+      .contains(new Href("#hauptteil-1_para-20_abs-3"));
     assertThat(addedPassiveMod.getForcePeriodEid())
-        .contains("meta-1_geltzeiten-1_geltungszeitgr-2");
+      .contains("meta-1_geltzeiten-1_geltungszeitgr-2");
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/ArticleTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/ArticleTest.java
@@ -13,15 +13,16 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class ArticleTest {
+
   private final LoadNormPort loadNormPort = mock(LoadNormPort.class);
 
   @Test
   void getGuid() {
     // given
     String articleString =
-        """
-            <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung"></akn:article>
-                """;
+      """
+      <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung"></akn:article>
+          """;
 
     var article = new Article(toNode(articleString));
     var expectedGuid = "cdbfc728-a070-42d9-ba2f-357945afef06";
@@ -37,14 +38,14 @@ class ArticleTest {
   void getEnumeration() {
     // given
     String articleString =
-        """
-            <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                  <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                    <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />
-                    Artikel 1
-                  </akn:num>
-                </akn:article>
-                """;
+      """
+      <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+            <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+              <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />
+              Artikel 1
+            </akn:num>
+          </akn:article>
+          """;
 
     var article = new Article(toNode(articleString));
 
@@ -59,10 +60,10 @@ class ArticleTest {
   void getEid() {
     // given
     String articleString =
-        """
-            <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                </akn:article>
-                """;
+      """
+      <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+          </akn:article>
+          """;
 
     var article = new Article(toNode(articleString));
     var expectedEid = "hauptteil-1_art-1";
@@ -78,10 +79,10 @@ class ArticleTest {
   void getMandatoryEid() {
     // given
     String articleString =
-        """
-            <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                    </akn:article>
-                    """;
+      """
+      <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+              </akn:article>
+              """;
 
     var article = new Article(toNode(articleString));
     var expectedEid = "hauptteil-1_art-1";
@@ -99,11 +100,11 @@ class ArticleTest {
     final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithMods.xml");
     when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(amendingNorm));
     amendingNorm
-        .getNodeByEId("hauptteil-1_art-1")
-        .get()
-        .getAttributes()
-        .getNamedItem("eId")
-        .setTextContent("");
+      .getNodeByEId("hauptteil-1_art-1")
+      .get()
+      .getAttributes()
+      .getNamedItem("eId")
+      .setTextContent("");
 
     var article = amendingNorm.getArticles().getFirst();
 
@@ -112,20 +113,21 @@ class ArticleTest {
 
     // when/then
     assertThat(thrown)
-        .isInstanceOf(MandatoryNodeNotFoundException.class)
-        .hasMessageContaining(
-            "Element with xpath './@eId' not found in 'akn:article' of norm 'eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1'");
+      .isInstanceOf(MandatoryNodeNotFoundException.class)
+      .hasMessageContaining(
+        "Element with xpath './@eId' not found in 'akn:article' of norm 'eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1'"
+      );
   }
 
   @Test
   void getHeading() {
     // given
     String articleString =
-        """
-            <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                   <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                </akn:article>
-                """;
+      """
+      <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+             <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+          </akn:article>
+          """;
 
     var article = new Article(toNode(articleString));
     var expectedHeading = "Änderung des Vereinsgesetzes";
@@ -141,25 +143,25 @@ class ArticleTest {
   void getAffectedDocumentEli() {
     // given
     String articleString =
-        """
-            <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                  <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                      <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                   <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                   <!-- Absatz (1) -->
-                   <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                      <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                         <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                      </akn:num>
-                      <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                         <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                            <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                  href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                         </akn:intro>
-                      </akn:list>
-                   </akn:paragraph>
-                </akn:article>
-                """;
+      """
+      <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+            <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+             <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+             <!-- Absatz (1) -->
+             <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                   <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                </akn:num>
+                <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                   <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                      <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                            href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                   </akn:intro>
+                </akn:list>
+             </akn:paragraph>
+          </akn:article>
+          """;
 
     var article = new Article(toNode(articleString));
     var expectedEli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
@@ -175,25 +177,25 @@ class ArticleTest {
   void setAffectedDocumentEli() {
     // given
     String articleString =
-        """
-            <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                      <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                          <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                       <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                       <!-- Absatz (1) -->
-                       <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                          <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                             <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                          </akn:num>
-                          <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                             <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                      href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                             </akn:intro>
-                          </akn:list>
-                       </akn:paragraph>
-                    </akn:article>
-                    """;
+      """
+      <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                    <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                 <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                 <!-- Absatz (1) -->
+                 <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                    <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                       <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                    </akn:num>
+                    <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                       <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                          <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                       </akn:intro>
+                    </akn:list>
+                 </akn:paragraph>
+              </akn:article>
+              """;
 
     var article = new Article(toNode(articleString));
     var expectedEli = "newEli";
@@ -210,25 +212,25 @@ class ArticleTest {
   void getRefersTo() {
     // given
     String articleString =
-        """
-            <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                      <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                          <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                       <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                       <!-- Absatz (1) -->
-                       <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                          <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                             <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                          </akn:num>
-                          <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                             <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                      href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                             </akn:intro>
-                          </akn:list>
-                       </akn:paragraph>
-                    </akn:article>
-                    """;
+      """
+      <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                    <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                 <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                 <!-- Absatz (1) -->
+                 <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                    <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                       <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                    </akn:num>
+                    <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                       <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                          <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                       </akn:intro>
+                    </akn:list>
+                 </akn:paragraph>
+              </akn:article>
+              """;
 
     var article = new Article(toNode(articleString));
     var expectedRefersTo = "hauptaenderung";
@@ -244,92 +246,92 @@ class ArticleTest {
   void getMods() {
     // given
     String articleString =
-        """
-            <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1"
-                             GUID="cdbfc728-a070-42d9-ba2f-357945afef06"
-                             period="#geltungszeitgr-1"
-                             refersTo="hauptaenderung">
-                    <akn:num eId="hauptteil-1_art-1_bezeichnung-1"
-                             GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                        <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1"
-                                    GUID="81c9c481-9427-4f03-9f51-099aa9b2201e"
-                                    name="1"/>Artikel 1
-                    </akn:num>
-                    <akn:heading eId="hauptteil-1_art-1_überschrift-1"
-                                 GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes
-                    </akn:heading>
-                    <!-- Absatz (1) -->
-                    <akn:paragraph eId="hauptteil-1_art-1_abs-1"
-                                   GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                        <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1"
-                                 GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                            <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1"
-                                        GUID="eab5a7e7-b649-4c23-b495-648b8ec71843"
-                                        name="1"/>
-                        </akn:num>
-                        <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1"
-                                  GUID="41675622-ed62-46e3-869f-94d99908b010">
-                            <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1"
-                                       GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1"
-                                       GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5">Das <akn:affectedDocument
-                                        eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1"
-                                        GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                        href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom
-                                    5. August 1964 (BGBl. I S. 593), das zuletzt
-                                    durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:
-                                </akn:p>
-                            </akn:intro>
+      """
+      <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1"
+                       GUID="cdbfc728-a070-42d9-ba2f-357945afef06"
+                       period="#geltungszeitgr-1"
+                       refersTo="hauptaenderung">
+              <akn:num eId="hauptteil-1_art-1_bezeichnung-1"
+                       GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                  <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1"
+                              GUID="81c9c481-9427-4f03-9f51-099aa9b2201e"
+                              name="1"/>Artikel 1
+              </akn:num>
+              <akn:heading eId="hauptteil-1_art-1_überschrift-1"
+                           GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes
+              </akn:heading>
+              <!-- Absatz (1) -->
+              <akn:paragraph eId="hauptteil-1_art-1_abs-1"
+                             GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                  <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1"
+                           GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                      <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1"
+                                  GUID="eab5a7e7-b649-4c23-b495-648b8ec71843"
+                                  name="1"/>
+                  </akn:num>
+                  <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1"
+                            GUID="41675622-ed62-46e3-869f-94d99908b010">
+                      <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1"
+                                 GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                          <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1"
+                                 GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5">Das <akn:affectedDocument
+                                  eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1"
+                                  GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                  href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom
+                              5. August 1964 (BGBl. I S. 593), das zuletzt
+                              durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:
+                          </akn:p>
+                      </akn:intro>
 
-                            <!-- Nummer 2 -->
-                            <akn:point eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2"
-                                       GUID="b5fa1383-f26a-4904-a638-f48711fbcf2d">
-                                <akn:num eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_bezeichnung-1"
-                                         GUID="6f0f92b3-1a51-440c-9137-b44ab9d990ac">
-                                    <akn:marker
-                                            eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_bezeichnung-1_zaehlbez-1"
-                                            GUID="5d7d54f0-8a4e-4d8f-b5d0-93d0ca393e82"
-                                            name="2"/>2.
-                                </akn:num>
-                                <akn:content eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1"
-                                             GUID="6cb14ab5-3a7f-45f4-9e85-00ac2fb0fe5e">
-                                    <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1"
-                                           GUID="db3fbe0f-b758-4cc4-b528-a723cacad94a">
-                                        <akn:mod
-                                                eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"
-                                                GUID="148c2f06-6e33-4af8-9f4a-3da67c888510"
-                                                refersTo="aenderungsbefehl-ersetzen">In <akn:ref
-                                                eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1"
-                                                GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206"
-                                                href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1/100-126.xml">
-                                            § 20 Absatz 1 Satz 2
-                                        </akn:ref> wird
-                                            die Angabe <akn:quotedText
-                                                    eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-1"
-                                                    GUID="694459c4-ef66-4f87-bb78-a332054a2216"
-                                                    startQuote="„"
-                                                    endQuote="“">§ 9 Abs. 1 Satz 2, Abs. 2
-                                            </akn:quotedText> durch die
-                                            Wörter
-                                            <akn:quotedText
-                                                    eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2"
-                                                    GUID="dd25bdb6-4ef4-4ef5-808c-27579b6ae196"
-                                                    startQuote="„"
-                                                    endQuote="“">§ 9 Absatz 1 Satz 2, Absatz 2 oder 3
-                                            </akn:quotedText>
-                                            ersetzt.
-                                        </akn:mod>
-                                    </akn:p>
-                                </akn:content>
-                            </akn:point>
-                        </akn:list>
-                    </akn:paragraph>
-                </akn:article>
-                """;
+                      <!-- Nummer 2 -->
+                      <akn:point eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2"
+                                 GUID="b5fa1383-f26a-4904-a638-f48711fbcf2d">
+                          <akn:num eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_bezeichnung-1"
+                                   GUID="6f0f92b3-1a51-440c-9137-b44ab9d990ac">
+                              <akn:marker
+                                      eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_bezeichnung-1_zaehlbez-1"
+                                      GUID="5d7d54f0-8a4e-4d8f-b5d0-93d0ca393e82"
+                                      name="2"/>2.
+                          </akn:num>
+                          <akn:content eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1"
+                                       GUID="6cb14ab5-3a7f-45f4-9e85-00ac2fb0fe5e">
+                              <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1"
+                                     GUID="db3fbe0f-b758-4cc4-b528-a723cacad94a">
+                                  <akn:mod
+                                          eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"
+                                          GUID="148c2f06-6e33-4af8-9f4a-3da67c888510"
+                                          refersTo="aenderungsbefehl-ersetzen">In <akn:ref
+                                          eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1"
+                                          GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206"
+                                          href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1/100-126.xml">
+                                      § 20 Absatz 1 Satz 2
+                                  </akn:ref> wird
+                                      die Angabe <akn:quotedText
+                                              eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-1"
+                                              GUID="694459c4-ef66-4f87-bb78-a332054a2216"
+                                              startQuote="„"
+                                              endQuote="“">§ 9 Abs. 1 Satz 2, Abs. 2
+                                      </akn:quotedText> durch die
+                                      Wörter
+                                      <akn:quotedText
+                                              eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2"
+                                              GUID="dd25bdb6-4ef4-4ef5-808c-27579b6ae196"
+                                              startQuote="„"
+                                              endQuote="“">§ 9 Absatz 1 Satz 2, Absatz 2 oder 3
+                                      </akn:quotedText>
+                                      ersetzt.
+                                  </akn:mod>
+                              </akn:p>
+                          </akn:content>
+                      </akn:point>
+                  </akn:list>
+              </akn:paragraph>
+          </akn:article>
+          """;
 
     var article = new Article(toNode(articleString));
     var expectedModEId =
-        "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1";
+      "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1";
 
     // when
     var mod = article.getMods();
@@ -343,116 +345,116 @@ class ArticleTest {
   void get2Mods() {
     // given
     String articleString =
-        """
-            <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1"
-                             GUID="cdbfc728-a070-42d9-ba2f-357945afef06"
-                             period="#geltungszeitgr-1"
-                             refersTo="hauptaenderung">
-                    <akn:num eId="hauptteil-1_art-1_bezeichnung-1"
-                             GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                        <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1"
-                                    GUID="81c9c481-9427-4f03-9f51-099aa9b2201e"
-                                    name="1"/>Artikel 1
-                    </akn:num>
-                    <akn:heading eId="hauptteil-1_art-1_überschrift-1"
-                                 GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes
-                    </akn:heading>
-                    <!-- Absatz (1) -->
-                    <akn:paragraph eId="hauptteil-1_art-1_abs-1"
-                                   GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                        <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1"
-                                 GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                            <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1"
-                                        GUID="eab5a7e7-b649-4c23-b495-648b8ec71843"
-                                        name="1"/>
-                        </akn:num>
-                        <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1"
-                                  GUID="41675622-ed62-46e3-869f-94d99908b010">
-                            <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1"
-                                       GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1"
-                                       GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5">Das <akn:affectedDocument
-                                        eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1"
-                                        GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                        href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom
-                                    5. August 1964 (BGBl. I S. 593), das zuletzt
-                                    durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:
-                                </akn:p>
-                            </akn:intro>
+      """
+      <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1"
+                       GUID="cdbfc728-a070-42d9-ba2f-357945afef06"
+                       period="#geltungszeitgr-1"
+                       refersTo="hauptaenderung">
+              <akn:num eId="hauptteil-1_art-1_bezeichnung-1"
+                       GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                  <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1"
+                              GUID="81c9c481-9427-4f03-9f51-099aa9b2201e"
+                              name="1"/>Artikel 1
+              </akn:num>
+              <akn:heading eId="hauptteil-1_art-1_überschrift-1"
+                           GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes
+              </akn:heading>
+              <!-- Absatz (1) -->
+              <akn:paragraph eId="hauptteil-1_art-1_abs-1"
+                             GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                  <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1"
+                           GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                      <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1"
+                                  GUID="eab5a7e7-b649-4c23-b495-648b8ec71843"
+                                  name="1"/>
+                  </akn:num>
+                  <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1"
+                            GUID="41675622-ed62-46e3-869f-94d99908b010">
+                      <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1"
+                                 GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                          <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1"
+                                 GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5">Das <akn:affectedDocument
+                                  eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1"
+                                  GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                  href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom
+                              5. August 1964 (BGBl. I S. 593), das zuletzt
+                              durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:
+                          </akn:p>
+                      </akn:intro>
 
-                            <!-- Nummer 2 -->
-                            <akn:point eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2"
-                                       GUID="b5fa1383-f26a-4904-a638-f48711fbcf2d">
-                                <akn:num eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_bezeichnung-1"
-                                         GUID="6f0f92b3-1a51-440c-9137-b44ab9d990ac">
-                                    <akn:marker
-                                            eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_bezeichnung-1_zaehlbez-1"
-                                            GUID="5d7d54f0-8a4e-4d8f-b5d0-93d0ca393e82"
-                                            name="2"/>2.
-                                </akn:num>
-                                <akn:content eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1"
-                                             GUID="6cb14ab5-3a7f-45f4-9e85-00ac2fb0fe5e">
-                                    <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1"
-                                           GUID="db3fbe0f-b758-4cc4-b528-a723cacad94a">
-                                        <akn:mod
-                                                eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"
-                                                GUID="148c2f06-6e33-4af8-9f4a-3da67c888510"
-                                                refersTo="aenderungsbefehl-ersetzen">In <akn:ref
-                                                eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1"
-                                                GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206"
-                                                href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1/100-126.xml">
-                                            § 20 Absatz 1 Satz 2
-                                        </akn:ref> wird
-                                            die Angabe <akn:quotedText
-                                                    eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-1"
-                                                    GUID="694459c4-ef66-4f87-bb78-a332054a2216"
-                                                    startQuote="„"
-                                                    endQuote="“">§ 9 Abs. 1 Satz 2, Abs. 2
-                                            </akn:quotedText> durch die
-                                            Wörter
-                                            <akn:quotedText
-                                                    eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2"
-                                                    GUID="dd25bdb6-4ef4-4ef5-808c-27579b6ae196"
-                                                    startQuote="„"
-                                                    endQuote="“">§ 9 Absatz 1 Satz 2, Absatz 2 oder 3
-                                            </akn:quotedText>
-                                            ersetzt.
-                                        </akn:mod>
-                                        <akn:mod
-                                                eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-2"
-                                                GUID="148c2f06-6e33-4af8-9f4a-3da67c888510"
-                                                refersTo="aenderungsbefehl-ersetzen">In <akn:ref
-                                                eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1"
-                                                GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206"
-                                                href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1/100-126.xml">
-                                            § 20 Absatz 1 Satz 2
-                                        </akn:ref> wird
-                                            die Angabe <akn:quotedText
-                                                    eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-1"
-                                                    GUID="694459c4-ef66-4f87-bb78-a332054a2216"
-                                                    startQuote="„"
-                                                    endQuote="“">§ 9 Abs. 1 Satz 2, Abs. 2
-                                            </akn:quotedText> durch die
-                                            Wörter
-                                            <akn:quotedText
-                                                    eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2"
-                                                    GUID="dd25bdb6-4ef4-4ef5-808c-27579b6ae196"
-                                                    startQuote="„"
-                                                    endQuote="“">§ 9 Absatz 1 Satz 2, Absatz 2 oder 3
-                                            </akn:quotedText>
-                                            ersetzt.
-                                        </akn:mod>
-                                    </akn:p>
-                                </akn:content>
-                            </akn:point>
-                        </akn:list>
-                    </akn:paragraph>
-                </akn:article>
-                """;
+                      <!-- Nummer 2 -->
+                      <akn:point eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2"
+                                 GUID="b5fa1383-f26a-4904-a638-f48711fbcf2d">
+                          <akn:num eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_bezeichnung-1"
+                                   GUID="6f0f92b3-1a51-440c-9137-b44ab9d990ac">
+                              <akn:marker
+                                      eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_bezeichnung-1_zaehlbez-1"
+                                      GUID="5d7d54f0-8a4e-4d8f-b5d0-93d0ca393e82"
+                                      name="2"/>2.
+                          </akn:num>
+                          <akn:content eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1"
+                                       GUID="6cb14ab5-3a7f-45f4-9e85-00ac2fb0fe5e">
+                              <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1"
+                                     GUID="db3fbe0f-b758-4cc4-b528-a723cacad94a">
+                                  <akn:mod
+                                          eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"
+                                          GUID="148c2f06-6e33-4af8-9f4a-3da67c888510"
+                                          refersTo="aenderungsbefehl-ersetzen">In <akn:ref
+                                          eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1"
+                                          GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206"
+                                          href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1/100-126.xml">
+                                      § 20 Absatz 1 Satz 2
+                                  </akn:ref> wird
+                                      die Angabe <akn:quotedText
+                                              eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-1"
+                                              GUID="694459c4-ef66-4f87-bb78-a332054a2216"
+                                              startQuote="„"
+                                              endQuote="“">§ 9 Abs. 1 Satz 2, Abs. 2
+                                      </akn:quotedText> durch die
+                                      Wörter
+                                      <akn:quotedText
+                                              eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2"
+                                              GUID="dd25bdb6-4ef4-4ef5-808c-27579b6ae196"
+                                              startQuote="„"
+                                              endQuote="“">§ 9 Absatz 1 Satz 2, Absatz 2 oder 3
+                                      </akn:quotedText>
+                                      ersetzt.
+                                  </akn:mod>
+                                  <akn:mod
+                                          eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-2"
+                                          GUID="148c2f06-6e33-4af8-9f4a-3da67c888510"
+                                          refersTo="aenderungsbefehl-ersetzen">In <akn:ref
+                                          eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1"
+                                          GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206"
+                                          href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1/100-126.xml">
+                                      § 20 Absatz 1 Satz 2
+                                  </akn:ref> wird
+                                      die Angabe <akn:quotedText
+                                              eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-1"
+                                              GUID="694459c4-ef66-4f87-bb78-a332054a2216"
+                                              startQuote="„"
+                                              endQuote="“">§ 9 Abs. 1 Satz 2, Abs. 2
+                                      </akn:quotedText> durch die
+                                      Wörter
+                                      <akn:quotedText
+                                              eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2"
+                                              GUID="dd25bdb6-4ef4-4ef5-808c-27579b6ae196"
+                                              startQuote="„"
+                                              endQuote="“">§ 9 Absatz 1 Satz 2, Absatz 2 oder 3
+                                      </akn:quotedText>
+                                      ersetzt.
+                                  </akn:mod>
+                              </akn:p>
+                          </akn:content>
+                      </akn:point>
+                  </akn:list>
+              </akn:paragraph>
+          </akn:article>
+          """;
 
     var article = new Article(toNode(articleString));
     var expectedModEId =
-        "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1";
+      "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1";
 
     // when
     var mods = article.getMods();

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/CharacterRangeTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/CharacterRangeTest.java
@@ -11,6 +11,7 @@ public class CharacterRangeTest {
 
   @Nested
   class isEndGreaterEqualsStart {
+
     @Test
     void itShouldDetectStartIsGreaterThanEnd() {
       // given
@@ -32,6 +33,7 @@ public class CharacterRangeTest {
 
   @Nested
   class getStart {
+
     @Test
     void itShouldReturnStart() {
       // given //when
@@ -53,6 +55,7 @@ public class CharacterRangeTest {
 
   @Nested
   class getEnd {
+
     @Test
     void itShouldReturnEnd() {
       // given //when
@@ -92,16 +95,18 @@ public class CharacterRangeTest {
 
   @Nested
   class findTextInNode {
+
     @Test
     void itShouldReturnTextOfASimpleTextNode() {
       // given //when
-      var textInRange =
-          new CharacterRange("9-13")
-              .findTextInNode(
-                  XmlMapper.toNode(
-                      """
-                          <akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="text-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2">A simple text of which we want to find a part.</akn:p>
-                          """));
+      var textInRange = new CharacterRange("9-13")
+        .findTextInNode(
+          XmlMapper.toNode(
+            """
+            <akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="text-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2">A simple text of which we want to find a part.</akn:p>
+            """
+          )
+        );
 
       // then
       assertThat(textInRange).isEqualTo("text");
@@ -110,13 +115,14 @@ public class CharacterRangeTest {
     @Test
     void itShouldReturnTextOfANestedNode() {
       // given //when
-      var textInRange =
-          new CharacterRange("9-13")
-              .findTextInNode(
-                  XmlMapper.toNode(
-                      """
-                          <akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="text-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2">A simple <akn:ref eId="text-1_ref-1">text</akn:ref> of which we want to find a part.</akn:p>
-                          """));
+      var textInRange = new CharacterRange("9-13")
+        .findTextInNode(
+          XmlMapper.toNode(
+            """
+            <akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="text-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2">A simple <akn:ref eId="text-1_ref-1">text</akn:ref> of which we want to find a part.</akn:p>
+            """
+          )
+        );
 
       // then
       assertThat(textInRange).isEqualTo("text");
@@ -125,13 +131,14 @@ public class CharacterRangeTest {
     @Test
     void itShouldReturnTextSpanningMultipleNodes() {
       // given //when
-      var textInRange =
-          new CharacterRange("2-16")
-              .findTextInNode(
-                  XmlMapper.toNode(
-                      """
-                          <akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="text-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2">A simple <akn:ref eId="text-1_ref-1">text</akn:ref> of which we want to find a part.</akn:p>
-                          """));
+      var textInRange = new CharacterRange("2-16")
+        .findTextInNode(
+          XmlMapper.toNode(
+            """
+            <akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="text-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2">A simple <akn:ref eId="text-1_ref-1">text</akn:ref> of which we want to find a part.</akn:p>
+            """
+          )
+        );
 
       // then
       assertThat(textInRange).isEqualTo("simple text of");
@@ -140,14 +147,15 @@ public class CharacterRangeTest {
 
   @Nested
   class getNodesInRange {
+
     @Test
     void itShouldFindRangeInAText() {
       // given //when
-      var node =
-          XmlMapper.toNode(
-              """
-                  <akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="text-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179">A simple text of which we want to find a part.</akn:p>
-                  """);
+      var node = XmlMapper.toNode(
+        """
+        <akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="text-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179">A simple text of which we want to find a part.</akn:p>
+        """
+      );
       var nodesInRange = new CharacterRange("9-13").getNodesInRange(node);
 
       // then
@@ -157,10 +165,11 @@ public class CharacterRangeTest {
       nodesInRange.getFirst().setTextContent("foo");
 
       assertThat(XmlMapper.toString(node))
-          .isEqualToIgnoringWhitespace(
-              """
-                  <?xml version="1.0" encoding="UTF-8"?><akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" eId="text-1">A simple foo of which we want to find a part.</akn:p>
-                  """);
+        .isEqualToIgnoringWhitespace(
+          """
+          <?xml version="1.0" encoding="UTF-8"?><akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" eId="text-1">A simple foo of which we want to find a part.</akn:p>
+          """
+        );
     }
 
     @Test
@@ -168,10 +177,10 @@ public class CharacterRangeTest {
       // given //when
       var norm = NormFixtures.loadFromDisk("NormWithPassiveModifications.xml", true);
 
-      var n2 =
-          NodeParser.getNodeFromExpression(
-              "//*[@eId='hauptteil-1_para-20_abs-1_untergl-1_listenelem-1_inhalt-1']",
-              norm.getDocument());
+      var n2 = NodeParser.getNodeFromExpression(
+        "//*[@eId='hauptteil-1_para-20_abs-1_untergl-1_listenelem-1_inhalt-1']",
+        norm.getDocument()
+      );
 
       var nodesInRange = new CharacterRange("101-118").getNodesInRange(n2.get());
 
@@ -185,11 +194,11 @@ public class CharacterRangeTest {
     @Test
     void itShouldFindRangeInANestedNode() {
       // given //when
-      var node =
-          XmlMapper.toNode(
-              """
-                  <akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="text-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179">A simple <akn:ref eId="text-1_ref-1">text</akn:ref> of which we want to find a part.</akn:p>
-                  """);
+      var node = XmlMapper.toNode(
+        """
+        <akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="text-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179">A simple <akn:ref eId="text-1_ref-1">text</akn:ref> of which we want to find a part.</akn:p>
+        """
+      );
       var nodesInRange = new CharacterRange("9-13").getNodesInRange(node);
 
       // then
@@ -198,24 +207,25 @@ public class CharacterRangeTest {
 
       assertThat(firstNode.getTextContent()).isEqualTo("text");
       firstNode
-          .getParentNode()
-          .replaceChild(firstNode.getOwnerDocument().createTextNode("foo"), firstNode);
+        .getParentNode()
+        .replaceChild(firstNode.getOwnerDocument().createTextNode("foo"), firstNode);
 
       assertThat(XmlMapper.toString(node))
-          .isEqualToIgnoringWhitespace(
-              """
-                  <?xml version="1.0" encoding="UTF-8"?><akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" eId="text-1">A simple foo of which we want to find a part.</akn:p>
-                  """);
+        .isEqualToIgnoringWhitespace(
+          """
+          <?xml version="1.0" encoding="UTF-8"?><akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" eId="text-1">A simple foo of which we want to find a part.</akn:p>
+          """
+        );
     }
 
     @Test
     void itShouldFindRangeSpanningMultipleNodes() {
       // given //when
-      var document =
-          XmlMapper.toNode(
-              """
-                  <akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="text-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179">A simple <akn:ref eId="text-1_ref-1">text</akn:ref> of which we want to find a part.</akn:p>
-                  """);
+      var document = XmlMapper.toNode(
+        """
+        <akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="text-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179">A simple <akn:ref eId="text-1_ref-1">text</akn:ref> of which we want to find a part.</akn:p>
+        """
+      );
       var nodesInRange = new CharacterRange("2-16").getNodesInRange(document);
 
       // then
@@ -226,20 +236,22 @@ public class CharacterRangeTest {
 
       var firstNode = nodesInRange.getFirst();
       firstNode
-          .getParentNode()
-          .insertBefore(firstNode.getOwnerDocument().createTextNode("new text"), firstNode);
+        .getParentNode()
+        .insertBefore(firstNode.getOwnerDocument().createTextNode("new text"), firstNode);
       nodesInRange.forEach(node -> node.getParentNode().removeChild(node));
 
       assertThat(XmlMapper.toString(document))
-          .isEqualToIgnoringWhitespace(
-              """
-                  <?xml version="1.0" encoding="UTF-8"?><akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" eId="text-1">A new text which we want to find a part.</akn:p>
-                  """);
+        .isEqualToIgnoringWhitespace(
+          """
+          <?xml version="1.0" encoding="UTF-8"?><akn:p xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" eId="text-1">A new text which we want to find a part.</akn:p>
+          """
+        );
     }
   }
 
   @Nested
   class Builder {
+
     @Test
     void itShouldCreateCharacterCount() {
       // given // when

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/EIdPartTypeTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/EIdPartTypeTest.java
@@ -11,101 +11,108 @@ class EIdPartTypeTest {
 
   @ParameterizedTest
   @CsvSource(
-      """
-          <akn:mod xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" />,ändbefehl
-          <akn:list xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" />,untergl
-          <akn:li xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" />,listenelem
-          <akn:point xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" />,listenelem
-          <akn:passiveModifications xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" />,pasmod
-          """)
+    """
+    <akn:mod xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" />,ändbefehl
+    <akn:list xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" />,untergl
+    <akn:li xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" />,listenelem
+    <akn:point xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" />,listenelem
+    <akn:passiveModifications xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" />,pasmod
+    """
+  )
   void itShouldGetTheCorrectEIdPartTypeForAknElements(String xml, String eIdPartName) {
     var node = XmlMapper.toNode(xml);
     // when
     var partType = EIdPartType.forAknElement(node);
     // then
     assertThat(partType)
-        .hasValueSatisfying(part -> assertThat(part.getName()).isEqualTo(eIdPartName));
+      .hasValueSatisfying(part -> assertThat(part.getName()).isEqualTo(eIdPartName));
   }
 
   @ParameterizedTest
   @CsvSource(
-      """
-          stammform,para
-          mantelform,para
-          eingebundene-stammform,para
-          geltungszeitregel,para
-          vertragsgesetz,art
-          vertragsverordnung,art
-          hauptaenderung,para
-          folgeaenderung,para
-          """)
+    """
+    stammform,para
+    mantelform,para
+    eingebundene-stammform,para
+    geltungszeitregel,para
+    vertragsgesetz,art
+    vertragsverordnung,art
+    hauptaenderung,para
+    folgeaenderung,para
+    """
+  )
   void itShouldGetTheCorrectEIdPartTypeForArticleInQuotedStructure(
-      String refersTo, String eIdPartName) {
-    var node =
-        XmlMapper.toNode(
-            """
-        <akn:quotedStructure xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"><akn:article refersTo="%s" /></akn:quotedStructure>
-        """
-                .formatted(refersTo));
+    String refersTo,
+    String eIdPartName
+  ) {
+    var node = XmlMapper.toNode(
+      """
+      <akn:quotedStructure xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"><akn:article refersTo="%s" /></akn:quotedStructure>
+      """.formatted(refersTo)
+    );
     // when
     var partType = EIdPartType.forAknElement(node.getFirstChild());
     // then
     assertThat(partType)
-        .hasValueSatisfying(part -> assertThat(part.getName()).isEqualTo(eIdPartName));
+      .hasValueSatisfying(part -> assertThat(part.getName()).isEqualTo(eIdPartName));
   }
 
   @ParameterizedTest
   @CsvSource(
-      """
-          stammform,stammform,para
-          stammform,mantelform,para
-          stammform,eingebundene-stammform,para
-          stammform,geltungszeitregel,para
-          stammform,vertragsgesetz,art
-          stammform,vertragsverordnung,art
-          stammform,hauptaenderung,para
-          stammform,folgeaenderung,para
-          eingebundene-stammform,stammform,para
-          eingebundene-stammform,mantelform,para
-          eingebundene-stammform,eingebundene-stammform,para
-          eingebundene-stammform,geltungszeitregel,para
-          eingebundene-stammform,vertragsgesetz,para
-          eingebundene-stammform,vertragsverordnung,para
-          eingebundene-stammform,hauptaenderung,para
-          eingebundene-stammform,folgeaenderung,para
-          mantelform,stammform,art
-          mantelform,mantelform,art
-          mantelform,eingebundene-stammform,art
-          mantelform,geltungszeitregel,art
-          mantelform,vertragsgesetz,art
-          mantelform,vertragsverordnung,art
-          mantelform,hauptaenderung,art
-          mantelform,folgeaenderung,art
-          """)
+    """
+    stammform,stammform,para
+    stammform,mantelform,para
+    stammform,eingebundene-stammform,para
+    stammform,geltungszeitregel,para
+    stammform,vertragsgesetz,art
+    stammform,vertragsverordnung,art
+    stammform,hauptaenderung,para
+    stammform,folgeaenderung,para
+    eingebundene-stammform,stammform,para
+    eingebundene-stammform,mantelform,para
+    eingebundene-stammform,eingebundene-stammform,para
+    eingebundene-stammform,geltungszeitregel,para
+    eingebundene-stammform,vertragsgesetz,para
+    eingebundene-stammform,vertragsverordnung,para
+    eingebundene-stammform,hauptaenderung,para
+    eingebundene-stammform,folgeaenderung,para
+    mantelform,stammform,art
+    mantelform,mantelform,art
+    mantelform,eingebundene-stammform,art
+    mantelform,geltungszeitregel,art
+    mantelform,vertragsgesetz,art
+    mantelform,vertragsverordnung,art
+    mantelform,hauptaenderung,art
+    mantelform,folgeaenderung,art
+    """
+  )
   void itShouldGetTheCorrectEIdPartTypeForArticleOutsideQuotedStructure(
-      String form, String refersTo, String eIdPartName) {
-    var node =
-        XmlMapper.toNode(
-            """
-          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/">
-            <akn:act name="regelungstext">
-              <akn:meta eId="meta-1" GUID="7e5837c8-b967-45be-924b-c95956c4aa94">
-                <akn:proprietary eId="meta-1_proprietary-1" GUID="fe419055-3201-41b1-b096-402eabcbe6a1" source="attributsemantik-noch-undefiniert">
-                  <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
-                    <meta:form>%s</meta:form>
-                  </meta:legalDocML.de_metadaten>
-                </akn:proprietary>
-              </akn:meta>
-              <akn:article refersTo="%s" />
-            </akn:act>
-          </akn:akomaNtoso>
-        """
-                .formatted(form, refersTo));
+    String form,
+    String refersTo,
+    String eIdPartName
+  ) {
+    var node = XmlMapper.toNode(
+      """
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/">
+          <akn:act name="regelungstext">
+            <akn:meta eId="meta-1" GUID="7e5837c8-b967-45be-924b-c95956c4aa94">
+              <akn:proprietary eId="meta-1_proprietary-1" GUID="fe419055-3201-41b1-b096-402eabcbe6a1" source="attributsemantik-noch-undefiniert">
+                <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+                  <meta:form>%s</meta:form>
+                </meta:legalDocML.de_metadaten>
+              </akn:proprietary>
+            </akn:meta>
+            <akn:article refersTo="%s" />
+          </akn:act>
+        </akn:akomaNtoso>
+      """.formatted(form, refersTo)
+    );
     // when
-    var partType =
-        EIdPartType.forAknElement(NodeParser.getMandatoryNodeFromExpression("//*/article", node));
+    var partType = EIdPartType.forAknElement(
+      NodeParser.getMandatoryNodeFromExpression("//*/article", node)
+    );
     // then
     assertThat(partType)
-        .hasValueSatisfying(part -> assertThat(part.getName()).isEqualTo(eIdPartName));
+      .hasValueSatisfying(part -> assertThat(part.getName()).isEqualTo(eIdPartName));
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/EIdTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/EIdTest.java
@@ -20,9 +20,9 @@ class EIdTest {
     var parts = eid.getParts();
     // then
     assertThat(parts)
-        .hasSize(6)
-        .contains(new EIdPart("hauptteil-1"))
-        .contains(new EIdPart("text-1"));
+      .hasSize(6)
+      .contains(new EIdPart("hauptteil-1"))
+      .contains(new EIdPart("text-1"));
   }
 
   @Test
@@ -47,9 +47,9 @@ class EIdTest {
   @Test
   void fromNode() {
     // given
-    var node =
-        XmlMapper.toNode(
-            "<akn:mod xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\" eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3\" />");
+    var node = XmlMapper.toNode(
+      "<akn:mod xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\" eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3\" />"
+    );
     // when
     var eId = EId.fromNode(node);
     // then
@@ -60,9 +60,9 @@ class EIdTest {
   @Test
   void fromMandatoryNode() {
     // given
-    var node =
-        XmlMapper.toNode(
-            "<akn:mod xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\" eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3\" />");
+    var node = XmlMapper.toNode(
+      "<akn:mod xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\" eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3\" />"
+    );
     // when
     var eId = EId.fromMandatoryNode(node);
     // then
@@ -72,13 +72,13 @@ class EIdTest {
   @Test
   void fromMandatoryNodeThrowsMandatoryNodeNotFoundException() {
     // given
-    var node =
-        XmlMapper.toNode(
-            "<akn:mod xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\" eId=\"\" />");
+    var node = XmlMapper.toNode(
+      "<akn:mod xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\" eId=\"\" />"
+    );
 
     // when/then
     assertThatThrownBy(() -> EId.fromMandatoryNode(node))
-        .isInstanceOf(MandatoryNodeNotFoundException.class);
+      .isInstanceOf(MandatoryNodeNotFoundException.class);
   }
 
   @Nested
@@ -86,54 +86,52 @@ class EIdTest {
 
     @ParameterizedTest
     @CsvSource(
-        """
-            <akn:mod xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\" />,ändbefehl-1
-            <akn:article xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\" refersTo=\"stammform\"><akn:num><akn:marker>3a</akn:marker>§ 3a</akn:num></akn:article>,para-3a
-            <akn:article xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\" refersTo=\"stammform\"><akn:num><akn:marker name=\"3a\" />§ 3a</akn:num></akn:article>,para-3a
-            <akn:ol xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\"><akn:li value=\"3.\">Some text</akn:li></akn:ol>,listenelem-3
-            """)
+      """
+      <akn:mod xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\" />,ändbefehl-1
+      <akn:article xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\" refersTo=\"stammform\"><akn:num><akn:marker>3a</akn:marker>§ 3a</akn:num></akn:article>,para-3a
+      <akn:article xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\" refersTo=\"stammform\"><akn:num><akn:marker name=\"3a\" />§ 3a</akn:num></akn:article>,para-3a
+      <akn:ol xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\"><akn:li value=\"3.\">Some text</akn:li></akn:ol>,listenelem-3
+      """
+    )
     void itShouldProvideEIdForNode(String xml, String expectedEId) {
       var node = XmlMapper.toNode(xml);
       // when
       var optionalEId = EId.forNode(node);
       // then
       assertThat(optionalEId)
-          .hasValueSatisfying(
-              eId -> {
-                assertThat(eId.value()).isEqualTo(expectedEId);
-              });
+        .hasValueSatisfying(eId -> {
+          assertThat(eId.value()).isEqualTo(expectedEId);
+        });
     }
 
     @Test
     void itShouldProvideEIdForNodeWithParent() {
-      var node =
-          XmlMapper.toNode(
-              "<akn:mod xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\" eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3\"><akn:p>Some text</akn:p></akn:mod>");
+      var node = XmlMapper.toNode(
+        "<akn:mod xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\" eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3\"><akn:p>Some text</akn:p></akn:mod>"
+      );
       // when
       var optionalEId = EId.forNode(node.getFirstChild());
       // then
       assertThat(optionalEId)
-          .hasValueSatisfying(
-              eId -> {
-                assertThat(eId.value())
-                    .isEqualTo("hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3_text-1");
-              });
+        .hasValueSatisfying(eId -> {
+          assertThat(eId.value())
+            .isEqualTo("hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3_text-1");
+        });
     }
 
     @Test
     void itShouldProvideEIdForNodeWithSiblingsWithSameEIdTypeWithoutNestedNum() {
-      var node =
-          XmlMapper.toNode(
-              "<akn:mod xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\" eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3\"><akn:p eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3_text-1\">Some text 1</akn:p><akn:ref eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3_ref-1\">Some other element</akn:ref><akn:p eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3_text-1\">Some text 2</akn:p><akn:p eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3_text-2\">Some text 3</akn:p></akn:mod>");
+      var node = XmlMapper.toNode(
+        "<akn:mod xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\" eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3\"><akn:p eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3_text-1\">Some text 1</akn:p><akn:ref eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3_ref-1\">Some other element</akn:ref><akn:p eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3_text-1\">Some text 2</akn:p><akn:p eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3_text-2\">Some text 3</akn:p></akn:mod>"
+      );
       // when
       var optionalEId = EId.forNode(node.getChildNodes().item(2));
       // then
       assertThat(optionalEId)
-          .hasValueSatisfying(
-              eId -> {
-                assertThat(eId.value())
-                    .isEqualTo("hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3_text-2");
-              });
+        .hasValueSatisfying(eId -> {
+          assertThat(eId.value())
+            .isEqualTo("hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3_text-2");
+        });
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/EinzelelementTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/EinzelelementTest.java
@@ -11,60 +11,63 @@ class EinzelelementTest {
 
   @Nested
   class getMetadatum {
+
     @Test
     void getArtDerNormAtDate() {
-      final Einzelelement e =
-          Einzelelement.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                <meta:einzelelement href="#hauptteil-1_abschnitt-0_para-1">
-                                    <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN</meta:artDerNorm>
-                                    <meta:artDerNorm start="1995-01-01" end="2000-12-31">ÄN</meta:artDerNorm>
-                                    <meta:artDerNorm start="2001-01-01">ÜN</meta:artDerNorm>
-                                </meta:einzelelement>
-                                """))
-              .build();
+      final Einzelelement e = Einzelelement
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+            <meta:einzelelement href="#hauptteil-1_abschnitt-0_para-1">
+                <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN</meta:artDerNorm>
+                <meta:artDerNorm start="1995-01-01" end="2000-12-31">ÄN</meta:artDerNorm>
+                <meta:artDerNorm start="2001-01-01">ÜN</meta:artDerNorm>
+            </meta:einzelelement>
+            """
+          )
+        )
+        .build();
 
       assertThat(
-              e.getSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, LocalDate.parse("1980-01-01")))
-          .isEmpty();
+        e.getSimpleMetadatum(Einzelelement.Metadata.ART_DER_NORM, LocalDate.parse("1980-01-01"))
+      )
+        .isEmpty();
 
       assertThat(
-              e.getSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, LocalDate.parse("1990-01-01")))
-          .contains("SN");
+        e.getSimpleMetadatum(Einzelelement.Metadata.ART_DER_NORM, LocalDate.parse("1990-01-01"))
+      )
+        .contains("SN");
       assertThat(
-              e.getSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, LocalDate.parse("1992-01-01")))
-          .contains("SN");
+        e.getSimpleMetadatum(Einzelelement.Metadata.ART_DER_NORM, LocalDate.parse("1992-01-01"))
+      )
+        .contains("SN");
       assertThat(
-              e.getSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, LocalDate.parse("1994-12-31")))
-          .contains("SN");
+        e.getSimpleMetadatum(Einzelelement.Metadata.ART_DER_NORM, LocalDate.parse("1994-12-31"))
+      )
+        .contains("SN");
 
       assertThat(
-              e.getSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, LocalDate.parse("1995-01-01")))
-          .contains("ÄN");
+        e.getSimpleMetadatum(Einzelelement.Metadata.ART_DER_NORM, LocalDate.parse("1995-01-01"))
+      )
+        .contains("ÄN");
       assertThat(
-              e.getSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, LocalDate.parse("1998-01-01")))
-          .contains("ÄN");
+        e.getSimpleMetadatum(Einzelelement.Metadata.ART_DER_NORM, LocalDate.parse("1998-01-01"))
+      )
+        .contains("ÄN");
       assertThat(
-              e.getSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, LocalDate.parse("2000-12-31")))
-          .contains("ÄN");
+        e.getSimpleMetadatum(Einzelelement.Metadata.ART_DER_NORM, LocalDate.parse("2000-12-31"))
+      )
+        .contains("ÄN");
 
       assertThat(
-              e.getSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, LocalDate.parse("2001-01-01")))
-          .contains("ÜN");
+        e.getSimpleMetadatum(Einzelelement.Metadata.ART_DER_NORM, LocalDate.parse("2001-01-01"))
+      )
+        .contains("ÜN");
       assertThat(
-              e.getSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, LocalDate.parse("2024-01-01")))
-          .contains("ÜN");
+        e.getSimpleMetadatum(Einzelelement.Metadata.ART_DER_NORM, LocalDate.parse("2024-01-01"))
+      )
+        .contains("ÜN");
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/EliTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/EliTest.java
@@ -7,12 +7,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 class EliTest {
+
   @ParameterizedTest
   @CsvSource(
-      """
-      eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1,eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1
-      eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1.xml,eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1
-      """)
+    """
+    eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1,eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1
+    eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1.xml,eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1
+    """
+  )
   void itShouldCreateEliFromString(String eli, String expectedEli) {
     assertThat(new Eli(eli).getValue()).isEqualTo(expectedEli);
   }
@@ -24,6 +26,6 @@ class EliTest {
 
     // Then
     assertThat(eli.getValue())
-        .isEqualTo("eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1");
+      .isEqualTo("eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1");
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/EventRefTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/EventRefTest.java
@@ -10,14 +10,16 @@ class EventRefTest {
 
   @Test
   void getDate() {
-    final EventRef eventRef =
-        EventRef.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:eventRef xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2017-03-15" source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                           """))
-            .build();
+    final EventRef eventRef = EventRef
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:eventRef xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2017-03-15" source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+             """
+        )
+      )
+      .build();
 
     // then
     assertThat(eventRef.getDate()).contains(LocalDate.parse("2017-03-15"));
@@ -25,14 +27,16 @@ class EventRefTest {
 
   @Test
   void getDateEmpty() {
-    final EventRef eventRef =
-        EventRef.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:eventRef xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                           """))
-            .build();
+    final EventRef eventRef = EventRef
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:eventRef xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                             """
+        )
+      )
+      .build();
 
     // then
     assertThat(eventRef.getDate()).isEmpty();

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/FRBRExpressionTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/FRBRExpressionTest.java
@@ -12,57 +12,63 @@ class FRBRExpressionTest {
 
   @Test
   void getFRBRaliasPreviousVersionId() {
-    final FRBRExpression frbrExpression =
-        FRBRExpression.builder()
-            .node(
-                XmlMapper.toNode(
+    final FRBRExpression frbrExpression = FRBRExpression
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                    </akn:FRBRExpression>
                     """
-                        <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                     <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                  </akn:FRBRExpression>
-                                  """))
-            .build();
+        )
+      )
+      .build();
 
     assertThat(frbrExpression.getFRBRaliasPreviousVersionId().map(UUID::toString))
-        .contains("123577e5-66ba-48f5-a6eb-db40bcfd6b87");
+      .contains("123577e5-66ba-48f5-a6eb-db40bcfd6b87");
   }
 
   @Test
   void getFRBRaliasPreviousVersionIdEmpty() {
-    final FRBRExpression frbrExpression =
-        FRBRExpression.builder()
-            .node(
-                XmlMapper.toNode(
+    final FRBRExpression frbrExpression = FRBRExpression
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                    </akn:FRBRExpression>
                     """
-                        <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                     <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                  </akn:FRBRExpression>
-                                  """))
-            .build();
+        )
+      )
+      .build();
 
     assertThat(frbrExpression.getFRBRaliasPreviousVersionId()).isEmpty();
   }
 
   @Test
   void setFRBRaliasPreviousVersionIdByReplacing() {
-    final FRBRExpression frbrExpression =
-        FRBRExpression.builder()
-            .node(
-                XmlMapper.toNode(
+    final FRBRExpression frbrExpression = FRBRExpression
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                    </akn:FRBRExpression>
                     """
-                        <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                     <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                  </akn:FRBRExpression>
-                                  """))
-            .build();
+        )
+      )
+      .build();
 
     final UUID newPreviousVersion = UUID.randomUUID();
     frbrExpression.setFRBRaliasPreviousVersionId(newPreviousVersion);
@@ -72,18 +78,20 @@ class FRBRExpressionTest {
 
   @Test
   void setFRBRaliasPreviousVersionIdByAdding() {
-    final FRBRExpression frbrExpression =
-        FRBRExpression.builder()
-            .node(
-                XmlMapper.toNode(
+    final FRBRExpression frbrExpression = FRBRExpression
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                    </akn:FRBRExpression>
                     """
-                        <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                     <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                  </akn:FRBRExpression>
-                                  """))
-            .build();
+        )
+      )
+      .build();
 
     final UUID newPreviousVersion = UUID.randomUUID();
     frbrExpression.setFRBRaliasPreviousVersionId(newPreviousVersion);
@@ -93,58 +101,66 @@ class FRBRExpressionTest {
 
   @Test
   void getFRBRaliasCurrentVersionId() {
-    final FRBRExpression frbrExpression =
-        FRBRExpression.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                 <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                              </akn:FRBRExpression>
-                              """))
-            .build();
+    final FRBRExpression frbrExpression = FRBRExpression
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                   <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                   <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                   <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                   <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                </akn:FRBRExpression>
+                """
+        )
+      )
+      .build();
 
     assertThat(frbrExpression.getFRBRaliasCurrentVersionId().toString())
-        .hasToString("ba44d2ae-0e73-44ba-850a-932ab2fa553f");
+      .hasToString("ba44d2ae-0e73-44ba-850a-932ab2fa553f");
   }
 
   @Test
   void getFRBRaliasCurrentVersionIdNotFound() {
-    final FRBRExpression frbrExpression =
-        FRBRExpression.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                              </akn:FRBRExpression>
-                              """))
-            .build();
+    final FRBRExpression frbrExpression = FRBRExpression
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                  <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                  <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                  <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                </akn:FRBRExpression>
+                """
+        )
+      )
+      .build();
 
     assertThrows(
-        MandatoryNodeNotFoundException.class, frbrExpression::getFRBRaliasCurrentVersionId);
+      MandatoryNodeNotFoundException.class,
+      frbrExpression::getFRBRaliasCurrentVersionId
+    );
   }
 
   @Test
   void setFRBRaliasCurrentVersionId() {
-    final FRBRExpression frbrExpression =
-        FRBRExpression.builder()
-            .node(
-                XmlMapper.toNode(
+    final FRBRExpression frbrExpression = FRBRExpression
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                    </akn:FRBRExpression>
                     """
-                        <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                     <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                  </akn:FRBRExpression>
-                                  """))
-            .build();
+        )
+      )
+      .build();
 
     final UUID newCurrentVersion = UUID.randomUUID();
     frbrExpression.setFRBRaliasCurrentVersionId(newCurrentVersion);
@@ -154,57 +170,63 @@ class FRBRExpressionTest {
 
   @Test
   void getFRBRaliasNextVersionId() {
-    final FRBRExpression frbrExpression =
-        FRBRExpression.builder()
-            .node(
-                XmlMapper.toNode(
+    final FRBRExpression frbrExpression = FRBRExpression
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                    </akn:FRBRExpression>
                     """
-                        <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                     <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                  </akn:FRBRExpression>
-                                  """))
-            .build();
+        )
+      )
+      .build();
 
     assertThat(frbrExpression.getFRBRaliasNextVersionId().toString())
-        .hasToString("931577e5-66ba-48f5-a6eb-db40bcfd6b87");
+      .hasToString("931577e5-66ba-48f5-a6eb-db40bcfd6b87");
   }
 
   @Test
   void getFRBRaliasNextVersionIdNotFound() {
-    final FRBRExpression frbrExpression =
-        FRBRExpression.builder()
-            .node(
-                XmlMapper.toNode(
+    final FRBRExpression frbrExpression = FRBRExpression
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                      <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                      <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                      <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                    </akn:FRBRExpression>
                     """
-                        <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                    <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                  </akn:FRBRExpression>
-                                  """))
-            .build();
+        )
+      )
+      .build();
 
     assertThrows(MandatoryNodeNotFoundException.class, frbrExpression::getFRBRaliasNextVersionId);
   }
 
   @Test
   void setFRBRaliasNextVersionId() {
-    final FRBRExpression frbrExpression =
-        FRBRExpression.builder()
-            .node(
-                XmlMapper.toNode(
+    final FRBRExpression frbrExpression = FRBRExpression
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                    </akn:FRBRExpression>
                     """
-                        <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                     <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                  </akn:FRBRExpression>
-                                  """))
-            .build();
+        )
+      )
+      .build();
 
     final UUID newNextVersion = UUID.randomUUID();
     frbrExpression.setFRBRaliasNextVersionId(newNextVersion);
@@ -214,39 +236,43 @@ class FRBRExpressionTest {
 
   @Test
   void getFRBRthisEli() {
-    final FRBRExpression frbrExpression =
-        FRBRExpression.builder()
-            .node(
-                XmlMapper.toNode(
+    final FRBRExpression frbrExpression = FRBRExpression
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                        </akn:FRBRExpression>
                     """
-                        <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                      </akn:FRBRExpression>
-                                  """))
-            .build();
+        )
+      )
+      .build();
 
     assertThat(frbrExpression.getEli())
-        .isEqualTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1");
+      .isEqualTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1");
   }
 
   @Test
   void setFRBRthisEli() {
-    final FRBRExpression frbrExpression =
-        FRBRExpression.builder()
-            .node(
-                XmlMapper.toNode(
+    final FRBRExpression frbrExpression = FRBRExpression
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                        </akn:FRBRExpression>
                     """
-                        <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                      </akn:FRBRExpression>
-                                  """))
-            .build();
+        )
+      )
+      .build();
 
     frbrExpression.setEli("new eli");
 
@@ -255,58 +281,64 @@ class FRBRExpressionTest {
 
   @Test
   void getFBRDate() {
-    final FRBRExpression frbrExpression =
-        FRBRExpression.builder()
-            .node(
-                XmlMapper.toNode(
+    final FRBRExpression frbrExpression = FRBRExpression
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                            <akn:FRBRdate eId="meta-1_ident-1_frbrexpression-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                        </akn:FRBRExpression>
                     """
-                        <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                          <akn:FRBRdate eId="meta-1_ident-1_frbrexpression-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
-                                      </akn:FRBRExpression>
-                                  """))
-            .build();
+        )
+      )
+      .build();
 
     assertThat(frbrExpression.getFBRDate()).isEqualTo("1964-08-05");
   }
 
   @Test
   void getFBRDateNotFound() {
-    final FRBRExpression frbrExpression =
-        FRBRExpression.builder()
-            .node(
-                XmlMapper.toNode(
+    final FRBRExpression frbrExpression = FRBRExpression
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                          <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                          <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                          <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                        </akn:FRBRExpression>
                     """
-                        <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                      </akn:FRBRExpression>
-                                  """))
-            .build();
+        )
+      )
+      .build();
 
     assertThrows(MandatoryNodeNotFoundException.class, frbrExpression::getFBRDate);
   }
 
   @Test
   void setFBRDate() {
-    final FRBRExpression frbrExpression =
-        FRBRExpression.builder()
-            .node(
-                XmlMapper.toNode(
+    final FRBRExpression frbrExpression = FRBRExpression
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                           <akn:FRBRdate eId="meta-1_ident-1_frbrexpression-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                        </akn:FRBRExpression>
                     """
-                        <akn:FRBRExpression xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                         <akn:FRBRdate eId="meta-1_ident-1_frbrexpression-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
-                                      </akn:FRBRExpression>
-                                  """))
-            .build();
+        )
+      )
+      .build();
 
     frbrExpression.setFBRDate("2002-02-02", "test");
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/FRBRManifestationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/FRBRManifestationTest.java
@@ -11,39 +11,43 @@ class FRBRManifestationTest {
 
   @Test
   void getFRBRthisEli() {
-    final FRBRManifestation frbrManifestation =
-        FRBRManifestation.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:FRBRManifestation xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                  <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"/>
-                                  <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                                  <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                                  <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                              </akn:FRBRManifestation>
-                           """))
-            .build();
+    final FRBRManifestation frbrManifestation = FRBRManifestation
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRManifestation xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                    <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"/>
+                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                </akn:FRBRManifestation>
+             """
+        )
+      )
+      .build();
 
     assertThat(frbrManifestation.getEli())
-        .isEqualTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1");
+      .isEqualTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1");
   }
 
   @Test
   void setFRBRthisEli() {
-    final FRBRManifestation frbrManifestation =
-        FRBRManifestation.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:FRBRManifestation xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                      </akn:FRBRManifestation>
-                                      """))
-            .build();
+    final FRBRManifestation frbrManifestation = FRBRManifestation
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRManifestation xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                        </akn:FRBRManifestation>
+                        """
+        )
+      )
+      .build();
 
     frbrManifestation.setEli("new eli");
 
@@ -52,58 +56,64 @@ class FRBRManifestationTest {
 
   @Test
   void getFBRDate() {
-    final FRBRManifestation frbrManifestation =
-        FRBRManifestation.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:FRBRManifestation xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                          <akn:FRBRdate eId="meta-1_ident-1_frbrexpression-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
-                                      </akn:FRBRManifestation>
-                                      """))
-            .build();
+    final FRBRManifestation frbrManifestation = FRBRManifestation
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRManifestation xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                            <akn:FRBRdate eId="meta-1_ident-1_frbrexpression-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                        </akn:FRBRManifestation>
+                        """
+        )
+      )
+      .build();
 
     assertThat(frbrManifestation.getFBRDate()).isEqualTo("1964-08-05");
   }
 
   @Test
   void getFBRDateNotFound() {
-    final FRBRManifestation frbrManifestation =
-        FRBRManifestation.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:FRBRManifestation xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                      </akn:FRBRManifestation>
-                                      """))
-            .build();
+    final FRBRManifestation frbrManifestation = FRBRManifestation
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRManifestation xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                          <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                          <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                          <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                        </akn:FRBRManifestation>
+                        """
+        )
+      )
+      .build();
 
     assertThrows(MandatoryNodeNotFoundException.class, frbrManifestation::getFBRDate);
   }
 
   @Test
   void setFBRDate() {
-    final FRBRManifestation frbrManifestation =
-        FRBRManifestation.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:FRBRManifestation xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                         <akn:FRBRdate eId="meta-1_ident-1_frbrexpression-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
-                                      </akn:FRBRManifestation>
-                                      """))
-            .build();
+    final FRBRManifestation frbrManifestation = FRBRManifestation
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRManifestation xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                           <akn:FRBRdate eId="meta-1_ident-1_frbrexpression-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                        </akn:FRBRManifestation>
+                        """
+        )
+      )
+      .build();
 
     frbrManifestation.setFBRDate("2002-02-02", "test");
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/FRBRWorkTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/FRBRWorkTest.java
@@ -11,39 +11,43 @@ class FRBRWorkTest {
 
   @Test
   void getFRBRthisEli() {
-    final FRBRWork frbrWork =
-        FRBRWork.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:FRBRWork xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                  <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"/>
-                                  <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                                  <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                                  <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                              </akn:FRBRWork>
-                           """))
-            .build();
+    final FRBRWork frbrWork = FRBRWork
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRWork xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                    <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"/>
+                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                </akn:FRBRWork>
+             """
+        )
+      )
+      .build();
 
     assertThat(frbrWork.getEli())
-        .isEqualTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1");
+      .isEqualTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1");
   }
 
   @Test
   void setFRBRthisEli() {
-    final FRBRWork frbrWork =
-        FRBRWork.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:FRBRWork xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                      </akn:FRBRWork>
-                                      """))
-            .build();
+    final FRBRWork frbrWork = FRBRWork
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRWork xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                        </akn:FRBRWork>
+                        """
+        )
+      )
+      .build();
 
     frbrWork.setEli("new eli");
 
@@ -52,58 +56,64 @@ class FRBRWorkTest {
 
   @Test
   void getFBRDate() {
-    final FRBRWork frbrWork =
-        FRBRWork.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:FRBRWork xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                          <akn:FRBRdate eId="meta-1_ident-1_frbrexpression-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
-                                      </akn:FRBRWork>
-                                      """))
-            .build();
+    final FRBRWork frbrWork = FRBRWork
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRWork xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                            <akn:FRBRdate eId="meta-1_ident-1_frbrexpression-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                        </akn:FRBRWork>
+                        """
+        )
+      )
+      .build();
 
     assertThat(frbrWork.getFBRDate()).isEqualTo("1964-08-05");
   }
 
   @Test
   void getFBRDateNotFound() {
-    final FRBRWork frbrWork =
-        FRBRWork.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:FRBRWork xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                      </akn:FRBRWork>
-                                      """))
-            .build();
+    final FRBRWork frbrWork = FRBRWork
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRWork xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                          <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                          <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                          <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                        </akn:FRBRWork>
+                        """
+        )
+      )
+      .build();
 
     assertThrows(MandatoryNodeNotFoundException.class, frbrWork::getFBRDate);
   }
 
   @Test
   void setFBRDate() {
-    final FRBRWork frbrWork =
-        FRBRWork.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:FRBRWork xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                         <akn:FRBRdate eId="meta-1_ident-1_frbrexpression-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
-                                      </akn:FRBRWork>
-                                      """))
-            .build();
+    final FRBRWork frbrWork = FRBRWork
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRWork xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                           <akn:FRBRdate eId="meta-1_ident-1_frbrexpression-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                        </akn:FRBRWork>
+                        """
+        )
+      )
+      .build();
 
     frbrWork.setFBRDate("2002-02-02", "test");
 
@@ -112,70 +122,78 @@ class FRBRWorkTest {
 
   @Test
   void getFRBRname() {
-    final FRBRWork frbrWork =
-        FRBRWork.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:FRBRWork xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                            <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593"/>
-                                            <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I"/>
-                                            <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung"/>
-                                        </akn:FRBRWork>
-                                           """))
-            .build();
+    final FRBRWork frbrWork = FRBRWork
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRWork xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                              <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593"/>
+                              <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I"/>
+                              <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung"/>
+                          </akn:FRBRWork>
+                             """
+        )
+      )
+      .build();
 
     assertThat(frbrWork.getFRBRname()).contains("BGBl. I");
   }
 
   @Test
   void getFRBRnameEmpty() {
-    final FRBRWork frbrWork =
-        FRBRWork.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:FRBRWork xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                            <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593"/>
-                                            <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung"/>
-                                        </akn:FRBRWork>
-                                           """))
-            .build();
+    final FRBRWork frbrWork = FRBRWork
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRWork xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                              <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593"/>
+                              <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung"/>
+                          </akn:FRBRWork>
+                             """
+        )
+      )
+      .build();
 
     assertThat(frbrWork.getFRBRname()).isEmpty();
   }
 
   @Test
   void getFRBRnumber() {
-    final FRBRWork frbrWork =
-        FRBRWork.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:FRBRWork xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                            <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593"/>
-                                            <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I"/>
-                                            <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung"/>
-                                        </akn:FRBRWork>
-                                           """))
-            .build();
+    final FRBRWork frbrWork = FRBRWork
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRWork xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                              <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593"/>
+                              <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I"/>
+                              <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung"/>
+                          </akn:FRBRWork>
+                             """
+        )
+      )
+      .build();
 
     assertThat(frbrWork.getFRBRnumber()).contains("s593");
   }
 
   @Test
   void getFRBRnumberEmpty() {
-    final FRBRWork frbrWork =
-        FRBRWork.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:FRBRWork xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                            <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I"/>
-                                            <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung"/>
-                                        </akn:FRBRWork>
-                                           """))
-            .build();
+    final FRBRWork frbrWork = FRBRWork
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:FRBRWork xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                              <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I"/>
+                              <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung"/>
+                          </akn:FRBRWork>
+                             """
+        )
+      )
+      .build();
 
     assertThat(frbrWork.getFRBRnumber()).isEmpty();
   }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/HrefTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/HrefTest.java
@@ -9,8 +9,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class HrefTest {
+
   @Nested
   class isRelative {
+
     @Test
     void itShouldDetectRelativeHrefs() {
       // given
@@ -23,9 +25,9 @@ class HrefTest {
     @Test
     void itShouldDetectAbsoluteHrefs() {
       // given
-      var href =
-          new Href(
-              "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml");
+      var href = new Href(
+        "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"
+      );
 
       // when // then
       assertThat(href.isRelative()).isFalse();
@@ -34,6 +36,7 @@ class HrefTest {
 
   @Nested
   class getEli {
+
     @Test
     void itShouldBeEmptyForRelativeHrefs() {
       // given
@@ -49,9 +52,9 @@ class HrefTest {
     @Test
     void itShouldProvideTheEli() {
       // given // when
-      var href =
-          new Href(
-              "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml");
+      var href = new Href(
+        "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"
+      );
 
       // when
       var eli = href.getEli();
@@ -63,14 +66,16 @@ class HrefTest {
 
   @Nested
   class getEId {
+
     @ParameterizedTest
     @ValueSource(
-        strings = {
-          "#para-20_abs-1/100-126",
-          "#para-20_abs-1",
-          "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml",
-          "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1.xml"
-        })
+      strings = {
+        "#para-20_abs-1/100-126",
+        "#para-20_abs-1",
+        "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml",
+        "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1.xml",
+      }
+    )
     void itShouldProvideTheEId(String hrefString) {
       // given
       var href = new Href(hrefString);
@@ -85,14 +90,16 @@ class HrefTest {
 
   @Nested
   class getParentEId {
+
     @ParameterizedTest
     @ValueSource(
-        strings = {
-          "#hauptteil-1_para-20_abs-1/100-126",
-          "#hauptteil-1_para-20_abs-1",
-          "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1/100-126.xml",
-          "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1.xml"
-        })
+      strings = {
+        "#hauptteil-1_para-20_abs-1/100-126",
+        "#hauptteil-1_para-20_abs-1",
+        "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1/100-126.xml",
+        "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1.xml",
+      }
+    )
     void itShouldProvideTheParentEId(String hrefString) {
       // given
       var href = new Href(hrefString);
@@ -107,6 +114,7 @@ class HrefTest {
 
   @Nested
   class getCharacterRange {
+
     @Test
     void itShouldProvideTheCharacterRangeForRelativeHrefs() {
       // given
@@ -135,9 +143,9 @@ class HrefTest {
     @Test
     void itShouldProvideTheCharacterRangeForAbsoluteHrefs() {
       // given
-      var href =
-          new Href(
-              "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml");
+      var href = new Href(
+        "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"
+      );
 
       // when
       Optional<CharacterRange> characterRange = href.getCharacterRange();
@@ -150,8 +158,9 @@ class HrefTest {
     @Test
     void itShouldBeEmptyForAbsoluteHrefsWithoutCharacterRange() {
       // given
-      var href =
-          new Href("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1.xml");
+      var href = new Href(
+        "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1.xml"
+      );
 
       // when
       var characterRange = href.getCharacterRange();
@@ -163,16 +172,16 @@ class HrefTest {
 
   @Nested
   class Builder {
+
     @Test
     void itShouldCreateRelativeHrefWithCharacterCount() {
       // given // when
-      var href =
-          new Href.Builder()
-              .setEli("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
-              .setEId("para-20_abs-1")
-              .setCharacterRange(new CharacterRange.Builder().start(100).end(126).build())
-              .setFileExtension("xml")
-              .buildInternalReference();
+      var href = new Href.Builder()
+        .setEli("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+        .setEId("para-20_abs-1")
+        .setCharacterRange(new CharacterRange.Builder().start(100).end(126).build())
+        .setFileExtension("xml")
+        .buildInternalReference();
 
       // then
       assertThat(href).hasToString("#para-20_abs-1/100-126");
@@ -181,12 +190,11 @@ class HrefTest {
     @Test
     void itShouldCreateRelativeHrefWithoutCharacterCount() {
       // given // when
-      var href =
-          new Href.Builder()
-              .setEli("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
-              .setEId("para-20_abs-1")
-              .setFileExtension("xml")
-              .buildInternalReference();
+      var href = new Href.Builder()
+        .setEli("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+        .setEId("para-20_abs-1")
+        .setFileExtension("xml")
+        .buildInternalReference();
 
       // then
       assertThat(href).hasToString("#para-20_abs-1");
@@ -195,34 +203,34 @@ class HrefTest {
     @Test
     void itShouldCreateAbsoluteHrefWithCharacterCount() {
       // given // when
-      var href =
-          new Href.Builder()
-              .setEli("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
-              .setEId("para-20_abs-1")
-              .setCharacterRange(new CharacterRange.Builder().start(100).end(126).build())
-              .setFileExtension("xml")
-              .buildAbsolute();
+      var href = new Href.Builder()
+        .setEli("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+        .setEId("para-20_abs-1")
+        .setCharacterRange(new CharacterRange.Builder().start(100).end(126).build())
+        .setFileExtension("xml")
+        .buildAbsolute();
 
       // then
       assertThat(href)
-          .hasToString(
-              "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml");
+        .hasToString(
+          "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"
+        );
     }
 
     @Test
     void itShouldCreateAbsoluteHrefWithoutCharacterCount() {
       // given // when
-      var href =
-          new Href.Builder()
-              .setEli("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
-              .setEId("para-20_abs-1")
-              .setFileExtension("xml")
-              .buildAbsolute();
+      var href = new Href.Builder()
+        .setEli("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+        .setEId("para-20_abs-1")
+        .setFileExtension("xml")
+        .buildAbsolute();
 
       // then
       assertThat(href)
-          .hasToString(
-              "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1.xml");
+        .hasToString(
+          "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1.xml"
+        );
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/LifecycleTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/LifecycleTest.java
@@ -10,17 +10,19 @@ class LifecycleTest {
   @Test
   void getEventRefEId() {
     // given
-    final Lifecycle lifecycle =
-        Lifecycle.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:lifecycle xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2017-03-15" source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2017-03-16" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                             </akn:lifecycle>
-                           """))
-            .build();
+    final Lifecycle lifecycle = Lifecycle
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:lifecycle xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2017-03-15" source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2017-03-16" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+               </akn:lifecycle>
+             """
+        )
+      )
+      .build();
 
     // when
     var eventRefs = lifecycle.getEventRefs();
@@ -32,15 +34,17 @@ class LifecycleTest {
   @Test
   void getEventRefEIdEmpty() {
     // given
-    final Lifecycle lifecycle =
-        Lifecycle.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:lifecycle xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                              </akn:lifecycle>
-                                           """))
-            .build();
+    final Lifecycle lifecycle = Lifecycle
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:lifecycle xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                                </akn:lifecycle>
+                             """
+        )
+      )
+      .build();
 
     // when
     var eventRefs = lifecycle.getEventRefs();

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/MetaTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/MetaTest.java
@@ -12,209 +12,227 @@ class MetaTest {
 
   @Test
   void getFRBRExpression() {
-    final Meta meta =
-        Meta.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                         <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                           <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                              <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                 <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                              </akn:FRBRExpression>
-                          </akn:identification>
-                        </akn:meta>
-                       """))
-            .build();
+    final Meta meta = Meta
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+            <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+              <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                 <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                    <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                 </akn:FRBRExpression>
+             </akn:identification>
+           </akn:meta>
+          """
+        )
+      )
+      .build();
 
     assertThat(meta.getFRBRExpression()).isNotNull();
   }
 
   @Test
   void getFRBRExpressionNotFound() {
-    final Meta meta =
-        Meta.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                         <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                           <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                              <akn:FRBRManifestation eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                 <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                              </akn:FRBRManifestation>
-                          </akn:identification>
-                        </akn:meta>
-                       """))
-            .build();
+    final Meta meta = Meta
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+            <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+              <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                 <akn:FRBRManifestation eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                    <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                 </akn:FRBRManifestation>
+             </akn:identification>
+           </akn:meta>
+          """
+        )
+      )
+      .build();
 
     assertThrows(MandatoryNodeNotFoundException.class, meta::getFRBRExpression);
   }
 
   @Test
   void getFRBRManifestation() {
-    final Meta meta =
-        Meta.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                         <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                           <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                              <akn:FRBRManifestation eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                 <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                              </akn:FRBRManifestation>
-                          </akn:identification>
-                        </akn:meta>
-                       """))
-            .build();
+    final Meta meta = Meta
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+            <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+              <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                 <akn:FRBRManifestation eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                    <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                 </akn:FRBRManifestation>
+             </akn:identification>
+           </akn:meta>
+          """
+        )
+      )
+      .build();
 
     assertThat(meta.getFRBRManifestation()).isNotNull();
   }
 
   @Test
   void getFRBRManifestationNotFound() {
-    final Meta meta =
-        Meta.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                         <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                           <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                              <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                 <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                              </akn:FRBRExpression>
-                          </akn:identification>
-                        </akn:meta>
-                       """))
-            .build();
+    final Meta meta = Meta
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+            <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+              <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                 <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                    <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                    <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                 </akn:FRBRExpression>
+             </akn:identification>
+           </akn:meta>
+          """
+        )
+      )
+      .build();
 
     assertThrows(MandatoryNodeNotFoundException.class, meta::getFRBRManifestation);
   }
 
   @Test
   void getFRBRWork() {
-    final Meta meta =
-        Meta.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                         <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                           <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                  <akn:FRBRWork eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                     <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                  </akn:FRBRWork>
-                          </akn:identification>
-                        </akn:meta>
-                       """))
-            .build();
+    final Meta meta = Meta
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+            <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+              <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                     <akn:FRBRWork eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                     </akn:FRBRWork>
+             </akn:identification>
+           </akn:meta>
+          """
+        )
+      )
+      .build();
 
     assertThat(meta.getFRBRWork()).isNotNull();
   }
 
   @Test
   void getFRBRWorkNotFound() {
-    final Meta meta =
-        Meta.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                         <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                           <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                  <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                     <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                  </akn:FRBRExpression>
-                          </akn:identification>
-                        </akn:meta>
-                       """))
-            .build();
+    final Meta meta = Meta
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+            <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+              <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                     <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                     </akn:FRBRExpression>
+             </akn:identification>
+           </akn:meta>
+          """
+        )
+      )
+      .build();
 
     assertThrows(MandatoryNodeNotFoundException.class, meta::getFRBRWork);
   }
 
   @Test
   void getTemporalData() {
-    final Meta meta =
-        Meta.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                         <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                <akn:temporalData eId="meta-1_geltzeiten-1" GUID="58a31120-e277-4a33-a093-6a3637fd603d" source="attributsemantik-noch-undefiniert">
-                                    <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ee45119b-2485-4115-b587-da54b95e3ebd">
-                                       <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="a43d0287-920d-4fbb-91d1-42fd7e03fe16"
-                                                         start="#meta-1_lebzykl-1_ereignis-2" refersTo="geltungszeit"/>
-                                    </akn:temporalGroup>
-                                    <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="0477223f-0f4e-4f79-9656-5ff7d2afd9c4">
-                                       <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="ebd52dd5-7122-4000-93e8-b6e96d0ac75f"
-                                                         start="#meta-1_lebzykl-1_ereignis-4" refersTo="geltungszeit"/>
-                                    </akn:temporalGroup>
-                                </akn:temporalData>
-                        </akn:meta>
-                       """))
-            .build();
+    final Meta meta = Meta
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+            <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                   <akn:temporalData eId="meta-1_geltzeiten-1" GUID="58a31120-e277-4a33-a093-6a3637fd603d" source="attributsemantik-noch-undefiniert">
+                       <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ee45119b-2485-4115-b587-da54b95e3ebd">
+                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="a43d0287-920d-4fbb-91d1-42fd7e03fe16"
+                                            start="#meta-1_lebzykl-1_ereignis-2" refersTo="geltungszeit"/>
+                       </akn:temporalGroup>
+                       <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="0477223f-0f4e-4f79-9656-5ff7d2afd9c4">
+                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="ebd52dd5-7122-4000-93e8-b6e96d0ac75f"
+                                            start="#meta-1_lebzykl-1_ereignis-4" refersTo="geltungszeit"/>
+                       </akn:temporalGroup>
+                   </akn:temporalData>
+           </akn:meta>
+          """
+        )
+      )
+      .build();
 
     assertThat(meta.getTemporalData()).isNotNull();
   }
 
   @Test
   void getTemporalDataNotFound() {
-    final Meta meta =
-        Meta.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                         <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                  <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                     <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                  </akn:FRBRExpression>
-                              </akn:identification>
-                        </akn:meta>
-                       """))
-            .build();
+    final Meta meta = Meta
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+            <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                  <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                     <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                     </akn:FRBRExpression>
+                 </akn:identification>
+           </akn:meta>
+          """
+        )
+      )
+      .build();
 
     assertThrows(MandatoryNodeNotFoundException.class, meta::getTemporalData);
   }
 
   @Test
   void getTemporalDataCreate() {
-    final Meta meta =
-        Meta.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                         <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                  <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                     <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                  </akn:FRBRExpression>
-                              </akn:identification>
-                        </akn:meta>
-                       """))
-            .build();
+    final Meta meta = Meta
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+            <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                  <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                     <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                     </akn:FRBRExpression>
+                 </akn:identification>
+           </akn:meta>
+          """
+        )
+      )
+      .build();
 
     assertThat(meta.getOrCreateTemporalDataNode()).isNotNull();
     assertThat(meta.getTemporalData()).isNotNull();
@@ -222,24 +240,26 @@ class MetaTest {
 
   @Test
   void getAnalysis() {
-    final Meta meta =
-        Meta.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                          <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                          <akn:analysis eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
-                              <akn:activeModifications eId="meta-1_analysis-1_activemod-1" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3ac">
-                                  <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-2" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
-                                      <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-2_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
-                                      <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-2_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
-                                      <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-2_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
-                                  </akn:textualMod>
-                              </akn:activeModifications>
-                          </akn:analysis>
-                      </akn:meta>
-                      """))
-            .build();
+    final Meta meta = Meta
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+              <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+              <akn:analysis eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
+                  <akn:activeModifications eId="meta-1_analysis-1_activemod-1" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3ac">
+                      <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-2" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
+                          <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-2_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
+                          <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-2_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
+                          <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-2_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
+                      </akn:textualMod>
+                  </akn:activeModifications>
+              </akn:analysis>
+          </akn:meta>
+          """
+        )
+      )
+      .build();
 
     final Optional<Analysis> analysis = meta.getAnalysis();
 
@@ -248,24 +268,25 @@ class MetaTest {
 
   @Test
   void getAnalysisEmpty() {
-
-    final Meta meta =
-        Meta.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                          <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                      </akn:FRBRExpression>
-                                  </akn:identification>
-                      </akn:meta>
-                      """))
-            .build();
+    final Meta meta = Meta
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+              <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+          </akn:meta>
+          """
+        )
+      )
+      .build();
 
     final Optional<Analysis> analysis = meta.getAnalysis();
 
@@ -274,23 +295,25 @@ class MetaTest {
 
   @Test
   void getAnalysisCreate() {
-    final Meta meta =
-        Meta.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                          <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                      </akn:FRBRExpression>
-                                  </akn:identification>
-                      </akn:meta>
-                      """))
-            .build();
+    final Meta meta = Meta
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+              <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+          </akn:meta>
+          """
+        )
+      )
+      .build();
 
     final Analysis analysis = meta.getOrCreateAnalysis();
 
@@ -300,68 +323,74 @@ class MetaTest {
 
   @Test
   void getLifecycle() {
-    final Meta meta =
-        Meta.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                         <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                             <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                   source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                                   source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                             </akn:lifecycle>
-                        </akn:meta>
-                       """))
-            .build();
+    final Meta meta = Meta
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+            <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                   <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                   <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                </akn:lifecycle>
+           </akn:meta>
+          """
+        )
+      )
+      .build();
 
     assertThat(meta.getLifecycle()).isNotNull();
   }
 
   @Test
   void getLifecycleNotFound() {
-    final Meta meta =
-        Meta.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                         <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                  <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                     <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                  </akn:FRBRExpression>
-                              </akn:identification>
-                        </akn:meta>
-                       """))
-            .build();
+    final Meta meta = Meta
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+            <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                  <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                     <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                     </akn:FRBRExpression>
+                 </akn:identification>
+           </akn:meta>
+          """
+        )
+      )
+      .build();
 
     assertThrows(MandatoryNodeNotFoundException.class, meta::getLifecycle);
   }
 
   @Test
   void getOrCreateProprietary() {
-    final Meta meta =
-        Meta.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                            <akn:proprietary eId="meta-1_proprietary-1"
-                                                             GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                                                             source="attributsemantik-noch-undefiniert">
-                                                <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
-                                                    <meta:typ>gesetz</meta:typ>
-                                                    <meta:fna>754-28-1</meta:fna>
-                                                    <meta:fassung>verkuendungsfassung</meta:fassung>
-                                                </meta:legalDocML.de_metadaten>
-                                            </akn:proprietary>
-                                          </akn:meta>
-                                         """))
-            .build();
+    final Meta meta = Meta
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                              <akn:proprietary eId="meta-1_proprietary-1"
+                                               GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+                                               source="attributsemantik-noch-undefiniert">
+                                  <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+                                      <meta:typ>gesetz</meta:typ>
+                                      <meta:fna>754-28-1</meta:fna>
+                                      <meta:fassung>verkuendungsfassung</meta:fassung>
+                                  </meta:legalDocML.de_metadaten>
+                              </akn:proprietary>
+                            </akn:meta>
+                           """
+        )
+      )
+      .build();
 
     assertThat(meta.getOrCreateProprietary()).isNotNull();
   }
@@ -370,19 +399,19 @@ class MetaTest {
   void returnsProprietaryEvenIfDoesNotExistInNorm() {
     // Given
     var normXml =
-        """
-                  <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                  <akn:akomaNtoso
-                    xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                    xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd">
-                    <akn:act name="regelungstext">
-                      <!-- Metadaten -->
-                      <akn:meta eId="meta-1" GUID="000">
-                      </akn:meta>
-                    </akn:act>
-                  </akn:akomaNtoso>
-                  """;
+      """
+      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+      <akn:akomaNtoso
+        xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd">
+        <akn:act name="regelungstext">
+          <!-- Metadaten -->
+          <akn:meta eId="meta-1" GUID="000">
+          </akn:meta>
+        </akn:act>
+      </akn:akomaNtoso>
+      """;
 
     var norm = new Norm(XmlMapper.toDocument(normXml));
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/MetadatenDeTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/MetadatenDeTest.java
@@ -10,190 +10,210 @@ class MetadatenDeTest {
 
   @Test
   void getFna() {
-    final MetadatenDe metadatenDe =
-        MetadatenDe.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                                <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
-                                    <meta:fna>111-11-1</meta:fna>
-                                </meta:legalDocML.de_metadaten>
-                            """))
-            .build();
+    final MetadatenDe metadatenDe = MetadatenDe
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+              <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+                  <meta:fna>111-11-1</meta:fna>
+              </meta:legalDocML.de_metadaten>
+          """
+        )
+      )
+      .build();
 
     assertThat(metadatenDe.getFna()).contains("111-11-1");
   }
 
   @Test
   void getFnaEmpty() {
-    final MetadatenDe metadatenDe =
-        MetadatenDe.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                                                <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
-                                                </meta:legalDocML.de_metadaten>
-                                            """))
-            .build();
+    final MetadatenDe metadatenDe = MetadatenDe
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+              <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+              </meta:legalDocML.de_metadaten>
+          """
+        )
+      )
+      .build();
 
     assertThat(metadatenDe.getFna()).isEmpty();
   }
 
   @Test
   void getArt() {
-    final MetadatenDe metadatenDe =
-        MetadatenDe.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                                                <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
-                                                    <meta:art>test art</meta:art>
-                                                </meta:legalDocML.de_metadaten>
-                                            """))
-            .build();
+    final MetadatenDe metadatenDe = MetadatenDe
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+              <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+                  <meta:art>test art</meta:art>
+              </meta:legalDocML.de_metadaten>
+          """
+        )
+      )
+      .build();
 
     assertThat(metadatenDe.getArt()).contains("test art");
   }
 
   @Test
   void getArtEmpty() {
-    final MetadatenDe metadatenDe =
-        MetadatenDe.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                                                <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
-                                                </meta:legalDocML.de_metadaten>
-                                            """))
-            .build();
+    final MetadatenDe metadatenDe = MetadatenDe
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+              <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+              </meta:legalDocML.de_metadaten>
+          """
+        )
+      )
+      .build();
 
     assertThat(metadatenDe.getArt()).isEmpty();
   }
 
   @Test
   void getTyp() {
-    final MetadatenDe metadatenDe =
-        MetadatenDe.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                                                <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
-                                                    <meta:typ>typi1</meta:typ>
-                                                </meta:legalDocML.de_metadaten>
-                                            """))
-            .build();
+    final MetadatenDe metadatenDe = MetadatenDe
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+              <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+                  <meta:typ>typi1</meta:typ>
+              </meta:legalDocML.de_metadaten>
+          """
+        )
+      )
+      .build();
 
     assertThat(metadatenDe.getTyp()).contains("typi1");
   }
 
   @Test
   void getTypEmpty() {
-    final MetadatenDe metadatenDe =
-        MetadatenDe.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                                                                <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
-                                                                </meta:legalDocML.de_metadaten>
-                                                            """))
-            .build();
+    final MetadatenDe metadatenDe = MetadatenDe
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+              <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+              </meta:legalDocML.de_metadaten>
+          """
+        )
+      )
+      .build();
 
     assertThat(metadatenDe.getTyp()).isEmpty();
   }
 
   @Test
   void getRessort() {
-    final MetadatenDe metadatenDe =
-        MetadatenDe.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                                        <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
-                                            <meta:federfuehrung>
-                                                <meta:federfuehrend ab="2022-12-01" bis="unbestimmt">Bundesministerium des Innern und für Heimat</meta:federfuehrend>
-                                                <meta:federfuehrend ab="2002-10-01" bis="2022-11-30">Bundesministerium der Justiz</meta:federfuehrend>
-                                            </meta:federfuehrung>
-                                        </meta:legalDocML.de_metadaten>
-                                        """))
-            .build();
+    final MetadatenDe metadatenDe = MetadatenDe
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+              <meta:federfuehrung>
+                  <meta:federfuehrend ab="2022-12-01" bis="unbestimmt">Bundesministerium des Innern und für Heimat</meta:federfuehrend>
+                  <meta:federfuehrend ab="2002-10-01" bis="2022-11-30">Bundesministerium der Justiz</meta:federfuehrend>
+              </meta:federfuehrung>
+          </meta:legalDocML.de_metadaten>
+          """
+        )
+      )
+      .build();
 
     assertThat(
-            metadatenDe.getSimpleMetadatum(
-                MetadatenDe.Metadata.RESSORT, LocalDate.parse("1990-01-01")))
-        .isEmpty();
+      metadatenDe.getSimpleMetadatum(MetadatenDe.Metadata.RESSORT, LocalDate.parse("1990-01-01"))
+    )
+      .isEmpty();
     assertThat(
-            metadatenDe.getSimpleMetadatum(
-                MetadatenDe.Metadata.RESSORT, LocalDate.parse("2002-10-01")))
-        .contains("Bundesministerium der Justiz");
+      metadatenDe.getSimpleMetadatum(MetadatenDe.Metadata.RESSORT, LocalDate.parse("2002-10-01"))
+    )
+      .contains("Bundesministerium der Justiz");
     assertThat(
-            metadatenDe.getSimpleMetadatum(
-                MetadatenDe.Metadata.RESSORT, LocalDate.parse("2022-12-01")))
-        .contains("Bundesministerium des Innern und für Heimat");
+      metadatenDe.getSimpleMetadatum(MetadatenDe.Metadata.RESSORT, LocalDate.parse("2022-12-01"))
+    )
+      .contains("Bundesministerium des Innern und für Heimat");
     assertThat(
-            metadatenDe.getSimpleMetadatum(
-                MetadatenDe.Metadata.RESSORT, LocalDate.parse("2024-06-18")))
-        .contains("Bundesministerium des Innern und für Heimat");
+      metadatenDe.getSimpleMetadatum(MetadatenDe.Metadata.RESSORT, LocalDate.parse("2024-06-18"))
+    )
+      .contains("Bundesministerium des Innern und für Heimat");
   }
 
   @Test
   void getRessortNotPresent() {
-    final MetadatenDe metadatenDe =
-        MetadatenDe.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                                                                <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
-                                                                </meta:legalDocML.de_metadaten>
-                                                            """))
-            .build();
+    final MetadatenDe metadatenDe = MetadatenDe
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+              <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+              </meta:legalDocML.de_metadaten>
+          """
+        )
+      )
+      .build();
 
     assertThat(metadatenDe.getSimpleMetadatum(MetadatenDe.Metadata.RESSORT, LocalDate.MAX))
-        .isEmpty();
+      .isEmpty();
   }
 
   @Test
   void setRessortUpdate() {
-    final MetadatenDe metadatenDe =
-        MetadatenDe.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                                                                        <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
-                                                                            <meta:federfuehrung>
-                                                                                <meta:federfuehrend ab="2022-12-01" bis="unbestimmt">Bundesministerium des Innern und für Heimat</meta:federfuehrend>
-                                                                                <meta:federfuehrend ab="2002-10-01" bis="2022-11-30">Bundesministerium der Justiz</meta:federfuehrend>
-                                                                            </meta:federfuehrung>
-                                                                        </meta:legalDocML.de_metadaten>
-                                                                        """))
-            .build();
+    final MetadatenDe metadatenDe = MetadatenDe
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+              <meta:federfuehrung>
+                  <meta:federfuehrend ab="2022-12-01" bis="unbestimmt">Bundesministerium des Innern und für Heimat</meta:federfuehrend>
+                  <meta:federfuehrend ab="2002-10-01" bis="2022-11-30">Bundesministerium der Justiz</meta:federfuehrend>
+              </meta:federfuehrung>
+          </meta:legalDocML.de_metadaten>
+          """
+        )
+      )
+      .build();
 
     final LocalDate atDate = LocalDate.parse("2002-10-01");
     assertThat(metadatenDe.getSimpleMetadatum(MetadatenDe.Metadata.RESSORT, atDate))
-        .contains("Bundesministerium der Justiz");
+      .contains("Bundesministerium der Justiz");
     assertThat(metadatenDe.getNodes(MetadatenDe.Metadata.RESSORT.getXpath())).hasSize(2);
 
     metadatenDe.updateSimpleMetadatum(MetadatenDe.Metadata.RESSORT, atDate, "test ressort");
 
     assertThat(metadatenDe.getSimpleMetadatum(MetadatenDe.Metadata.RESSORT, atDate))
-        .contains("test ressort");
+      .contains("test ressort");
     assertThat(metadatenDe.getNodes(MetadatenDe.Metadata.RESSORT.getXpath())).hasSize(2);
   }
 
   @Test
   void setRessortCreate() {
-    final MetadatenDe metadatenDe =
-        MetadatenDe.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                                                        <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
-                                                            <meta:federfuehrung>
-                                                                <meta:federfuehrend ab="2022-12-01" bis="unbestimmt">Bundesministerium des Innern und für Heimat</meta:federfuehrend>
-                                                                <meta:federfuehrend ab="2002-10-01" bis="2022-11-30">Bundesministerium der Justiz</meta:federfuehrend>
-                                                            </meta:federfuehrung>
-                                                        </meta:legalDocML.de_metadaten>
-                                                        """))
-            .build();
+    final MetadatenDe metadatenDe = MetadatenDe
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+              <meta:federfuehrung>
+                  <meta:federfuehrend ab="2022-12-01" bis="unbestimmt">Bundesministerium des Innern und für Heimat</meta:federfuehrend>
+                  <meta:federfuehrend ab="2002-10-01" bis="2022-11-30">Bundesministerium der Justiz</meta:federfuehrend>
+              </meta:federfuehrung>
+          </meta:legalDocML.de_metadaten>
+          """
+        )
+      )
+      .build();
 
     final LocalDate atDate = LocalDate.parse("1990-01-01");
     assertThat(metadatenDe.getSimpleMetadatum(MetadatenDe.Metadata.RESSORT, atDate)).isEmpty();
@@ -202,7 +222,7 @@ class MetadatenDeTest {
     metadatenDe.updateSimpleMetadatum(MetadatenDe.Metadata.RESSORT, atDate, "test ressort");
 
     assertThat(metadatenDe.getSimpleMetadatum(MetadatenDe.Metadata.RESSORT, atDate))
-        .contains("test ressort");
+      .contains("test ressort");
     assertThat(metadatenDe.getNodes(MetadatenDe.Metadata.RESSORT.getXpath())).hasSize(3);
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/MetadatenDsTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/MetadatenDsTest.java
@@ -13,60 +13,63 @@ class MetadatenDsTest {
 
   @Nested
   class getMetadatum {
+
     @Test
     void getFnaAtDate() {
-      final MetadatenDs metadatenDs =
-          MetadatenDs.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                  <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                                      <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
-                                                      <meta:fna start="1995-01-01" end="2000-12-31">222-22-2</meta:fna>
-                                                      <meta:fna start="2001-01-01" end="unbestimmt">333-33-3</meta:fna>
-                                                  </meta:legalDocML.de_metadaten_ds>
-                                              """))
-              .build();
+      final MetadatenDs metadatenDs = MetadatenDs
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                    <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
+                    <meta:fna start="1995-01-01" end="2000-12-31">222-22-2</meta:fna>
+                    <meta:fna start="2001-01-01" end="unbestimmt">333-33-3</meta:fna>
+                </meta:legalDocML.de_metadaten_ds>
+            """
+          )
+        )
+        .build();
 
       assertThat(
-              metadatenDs.getSimpleMetadatum(
-                  MetadatenDs.Metadata.FNA, LocalDate.parse("1980-01-01")))
-          .isEmpty();
+        metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, LocalDate.parse("1980-01-01"))
+      )
+        .isEmpty();
 
       assertThat(
-              metadatenDs.getSimpleMetadatum(
-                  MetadatenDs.Metadata.FNA, LocalDate.parse("1990-01-01")))
-          .contains("111-11-1");
+        metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, LocalDate.parse("1990-01-01"))
+      )
+        .contains("111-11-1");
       assertThat(
-              metadatenDs.getSimpleMetadatum(
-                  MetadatenDs.Metadata.FNA, LocalDate.parse("1992-01-01")))
-          .contains("111-11-1");
+        metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, LocalDate.parse("1992-01-01"))
+      )
+        .contains("111-11-1");
       assertThat(
-              metadatenDs.getSimpleMetadatum(
-                  MetadatenDs.Metadata.FNA, LocalDate.parse("1994-12-31")))
-          .contains("111-11-1");
+        metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, LocalDate.parse("1994-12-31"))
+      )
+        .contains("111-11-1");
 
       assertThat(
-              metadatenDs.getSimpleMetadatum(
-                  MetadatenDs.Metadata.FNA, LocalDate.parse("1995-01-01")))
-          .contains("222-22-2");
+        metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, LocalDate.parse("1995-01-01"))
+      )
+        .contains("222-22-2");
       assertThat(
-              metadatenDs.getSimpleMetadatum(
-                  MetadatenDs.Metadata.FNA, LocalDate.parse("1998-01-01")))
-          .contains("222-22-2");
+        metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, LocalDate.parse("1998-01-01"))
+      )
+        .contains("222-22-2");
       assertThat(
-              metadatenDs.getSimpleMetadatum(
-                  MetadatenDs.Metadata.FNA, LocalDate.parse("2000-12-31")))
-          .contains("222-22-2");
+        metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, LocalDate.parse("2000-12-31"))
+      )
+        .contains("222-22-2");
 
       assertThat(
-              metadatenDs.getSimpleMetadatum(
-                  MetadatenDs.Metadata.FNA, LocalDate.parse("2001-01-01")))
-          .contains("333-33-3");
+        metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, LocalDate.parse("2001-01-01"))
+      )
+        .contains("333-33-3");
       assertThat(
-              metadatenDs.getSimpleMetadatum(
-                  MetadatenDs.Metadata.FNA, LocalDate.parse("2024-01-01")))
-          .contains("333-33-3");
+        metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, LocalDate.parse("2024-01-01"))
+      )
+        .contains("333-33-3");
     }
   }
 
@@ -75,43 +78,46 @@ class MetadatenDsTest {
 
     @Test
     void setFnaAtDateUpdate() {
-      final MetadatenDs metadatenDs =
-          MetadatenDs.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                                                    <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
-                                                                    <meta:fna start="1995-01-01" end="2000-12-31">222-22-2</meta:fna>
-                                                                    <meta:fna start="2001-01-01" end="unbestimmt">333-33-3</meta:fna>
-                                                                </meta:legalDocML.de_metadaten_ds>
-                                                            """))
-              .build();
+      final MetadatenDs metadatenDs = MetadatenDs
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                    <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
+                    <meta:fna start="1995-01-01" end="2000-12-31">222-22-2</meta:fna>
+                    <meta:fna start="2001-01-01" end="unbestimmt">333-33-3</meta:fna>
+                </meta:legalDocML.de_metadaten_ds>
+            """
+          )
+        )
+        .build();
 
       final LocalDate newDate = LocalDate.parse("1990-01-01");
       assertThat(metadatenDs.getNodes(MetadatenDs.Metadata.FNA.getXpath())).hasSize(3);
       assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate))
-          .contains("111-11-1");
+        .contains("111-11-1");
 
       metadatenDs.updateSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate, "000-00-0");
 
       assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate))
-          .contains("000-00-0");
+        .contains("000-00-0");
       assertThat(metadatenDs.getNodes(MetadatenDs.Metadata.FNA.getXpath())).hasSize(3);
     }
 
     @Test
     void setFnaAtDateCreateWithUnbestimmtEnd() {
-
-      final MetadatenDs metadatenDs =
-          MetadatenDs.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                                                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                                                                </meta:legalDocML.de_metadaten_ds>
-                                                                            """))
-              .build();
+      final MetadatenDs metadatenDs = MetadatenDs
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                </meta:legalDocML.de_metadaten_ds>
+            """
+          )
+        )
+        .build();
 
       final LocalDate newDate = LocalDate.parse("1980-01-01");
 
@@ -121,29 +127,33 @@ class MetadatenDsTest {
       metadatenDs.updateSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate, "000-00-0");
 
       assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate))
-          .contains("000-00-0");
+        .contains("000-00-0");
       assertThat(metadatenDs.getNodes(MetadatenDs.Metadata.FNA.getXpath())).hasSize(1);
 
-      metadatenDs.getNodes(MetadatenDs.Metadata.FNA.getXpath()).stream()
-          .filter(f -> f.getStart().isPresent() && f.getStart().get().isEqual(newDate))
-          .findFirst()
-          .map(m -> assertThat(m.getEnd()).contains(LocalDate.MAX));
+      metadatenDs
+        .getNodes(MetadatenDs.Metadata.FNA.getXpath())
+        .stream()
+        .filter(f -> f.getStart().isPresent() && f.getStart().get().isEqual(newDate))
+        .findFirst()
+        .map(m -> assertThat(m.getEnd()).contains(LocalDate.MAX));
     }
 
     @Test
     void setFnaAtDateCreateWithEnd() {
-      final MetadatenDs metadatenDs =
-          MetadatenDs.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                                                    <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
-                                                                    <meta:fna start="1995-01-01" end="2000-12-31">222-22-2</meta:fna>
-                                                                    <meta:fna start="2001-01-01" end="unbestimmt">333-33-3</meta:fna>
-                                                                </meta:legalDocML.de_metadaten_ds>
-                                                            """))
-              .build();
+      final MetadatenDs metadatenDs = MetadatenDs
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                    <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
+                    <meta:fna start="1995-01-01" end="2000-12-31">222-22-2</meta:fna>
+                    <meta:fna start="2001-01-01" end="unbestimmt">333-33-3</meta:fna>
+                </meta:legalDocML.de_metadaten_ds>
+            """
+          )
+        )
+        .build();
 
       final LocalDate newDate = LocalDate.parse("1980-01-01");
       assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate)).isEmpty();
@@ -152,109 +162,120 @@ class MetadatenDsTest {
       metadatenDs.updateSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate, "000-00-0");
 
       assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate))
-          .contains("000-00-0");
+        .contains("000-00-0");
       assertThat(metadatenDs.getNodes(MetadatenDs.Metadata.FNA.getXpath())).hasSize(4);
 
-      metadatenDs.getNodes(MetadatenDs.Metadata.FNA.getXpath()).stream()
-          .filter(f -> f.getStart().isPresent() && f.getStart().get().isEqual(newDate))
-          .findFirst()
-          .map(m -> assertThat(m.getEnd()).contains(LocalDate.parse("1989-12-31")));
+      metadatenDs
+        .getNodes(MetadatenDs.Metadata.FNA.getXpath())
+        .stream()
+        .filter(f -> f.getStart().isPresent() && f.getStart().get().isEqual(newDate))
+        .findFirst()
+        .map(m -> assertThat(m.getEnd()).contains(LocalDate.parse("1989-12-31")));
     }
 
     @Test
     void setFnaAtDateCreateAndUpdatePreviousUnbestimmtEnd() {
-      final MetadatenDs metadatenDs =
-          MetadatenDs.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                                                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                                                                    <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
-                                                                                    <meta:fna start="1995-01-01" end="2000-12-31">222-22-2</meta:fna>
-                                                                                    <meta:fna start="2001-01-01" end="unbestimmt">333-33-3</meta:fna>
-                                                                                </meta:legalDocML.de_metadaten_ds>
-                                                                            """))
-              .build();
+      final MetadatenDs metadatenDs = MetadatenDs
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                    <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
+                    <meta:fna start="1995-01-01" end="2000-12-31">222-22-2</meta:fna>
+                    <meta:fna start="2001-01-01" end="unbestimmt">333-33-3</meta:fna>
+                </meta:legalDocML.de_metadaten_ds>
+            """
+          )
+        )
+        .build();
 
       final LocalDate newDate = LocalDate.parse("2005-01-01");
       assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate))
-          .contains("333-33-3");
+        .contains("333-33-3");
       assertThat(metadatenDs.getNodes(MetadatenDs.Metadata.FNA.getXpath())).hasSize(3);
 
       metadatenDs.updateSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate, "000-00-0");
 
       assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate))
-          .contains("000-00-0");
-      final List<SimpleProprietary> fnaValues =
-          metadatenDs.getNodes(MetadatenDs.Metadata.FNA.getXpath());
+        .contains("000-00-0");
+      final List<SimpleProprietary> fnaValues = metadatenDs.getNodes(
+        MetadatenDs.Metadata.FNA.getXpath()
+      );
       assertThat(fnaValues).hasSize(4);
 
-      fnaValues.stream()
-          .filter(f -> f.getStart().isPresent() && f.getStart().get().isEqual(newDate))
-          .findFirst()
-          .map(m -> assertThat(m.getEnd()).contains(LocalDate.MAX));
+      fnaValues
+        .stream()
+        .filter(f -> f.getStart().isPresent() && f.getStart().get().isEqual(newDate))
+        .findFirst()
+        .map(m -> assertThat(m.getEnd()).contains(LocalDate.MAX));
 
-      fnaValues.stream()
-          .filter(
-              f ->
-                  f.getStart().isPresent()
-                      && f.getStart().get().isEqual(LocalDate.parse("2001-01-01")))
-          .findFirst()
-          .map(m -> assertThat(m.getEnd()).contains(newDate.minusDays(1)));
+      fnaValues
+        .stream()
+        .filter(f ->
+          f.getStart().isPresent() && f.getStart().get().isEqual(LocalDate.parse("2001-01-01"))
+        )
+        .findFirst()
+        .map(m -> assertThat(m.getEnd()).contains(newDate.minusDays(1)));
     }
 
     @Test
     void setSubtypAtDateCreateAndSetDefaultWithEnd() {
-      final MetadatenDs metadatenDs =
-          MetadatenDs.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                              <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                                                  <meta:subtyp>subtyp0</meta:subtyp>
-                                                              </meta:legalDocML.de_metadaten_ds>
-                                                              """))
-              .build();
+      final MetadatenDs metadatenDs = MetadatenDs
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+            <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                <meta:subtyp>subtyp0</meta:subtyp>
+            </meta:legalDocML.de_metadaten_ds>
+            """
+          )
+        )
+        .build();
 
       final LocalDate newDate = LocalDate.parse("2005-01-01");
       assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.SUBTYP, newDate))
-          .contains("subtyp0");
+        .contains("subtyp0");
       assertThat(metadatenDs.getNodes("./subtyp")).hasSize(1);
 
       metadatenDs.updateSimpleMetadatum(MetadatenDs.Metadata.SUBTYP, newDate, "subtyp1");
 
       assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.SUBTYP, newDate))
-          .contains("subtyp1");
+        .contains("subtyp1");
       final List<SimpleProprietary> subtypValues = metadatenDs.getNodes("./subtyp");
       assertThat(subtypValues).hasSize(2);
 
-      subtypValues.stream()
-          .filter(f -> f.getStart().isPresent() && f.getStart().get().isEqual(newDate))
-          .findFirst()
-          .map(m -> assertThat(m.getEnd()).contains(LocalDate.MAX));
+      subtypValues
+        .stream()
+        .filter(f -> f.getStart().isPresent() && f.getStart().get().isEqual(newDate))
+        .findFirst()
+        .map(m -> assertThat(m.getEnd()).contains(LocalDate.MAX));
 
       assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.SUBTYP, newDate.minusDays(1)))
-          .contains("subtyp0");
+        .contains("subtyp0");
     }
 
     @Test
     void removeNodeIfSetWithNull() {
-      final MetadatenDs metadatenDs =
-          MetadatenDs.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                                                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                                                                    <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
-                                                                                    <meta:fna start="1995-01-01" end="2000-12-31">222-22-2</meta:fna>
-                                                                                    <meta:fna start="2001-01-01" end="unbestimmt">333-33-3</meta:fna>
-                                                                                </meta:legalDocML.de_metadaten_ds>
-                                                                            """))
-              .build();
+      final MetadatenDs metadatenDs = MetadatenDs
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                    <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
+                    <meta:fna start="1995-01-01" end="2000-12-31">222-22-2</meta:fna>
+                    <meta:fna start="2001-01-01" end="unbestimmt">333-33-3</meta:fna>
+                </meta:legalDocML.de_metadaten_ds>
+            """
+          )
+        )
+        .build();
 
       final LocalDate newDate = LocalDate.parse("1995-01-01");
       assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate))
-          .contains("222-22-2");
+        .contains("222-22-2");
       assertThat(metadatenDs.getNodes(MetadatenDs.Metadata.FNA.getXpath())).hasSize(3);
 
       metadatenDs.updateSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate, null);
@@ -265,17 +286,19 @@ class MetadatenDsTest {
 
     @Test
     void removeNothingIfNodeNotPresent() {
-      final MetadatenDs metadatenDs =
-          MetadatenDs.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                                                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                                                                    <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
-                                                                                    <meta:fna start="2001-01-01" end="unbestimmt">333-33-3</meta:fna>
-                                                                                </meta:legalDocML.de_metadaten_ds>
-                                                                            """))
-              .build();
+      final MetadatenDs metadatenDs = MetadatenDs
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                    <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
+                    <meta:fna start="2001-01-01" end="unbestimmt">333-33-3</meta:fna>
+                </meta:legalDocML.de_metadaten_ds>
+            """
+          )
+        )
+        .build();
 
       final LocalDate newDate = LocalDate.parse("1995-01-01");
       assertThat(metadatenDs.getSimpleMetadatum(MetadatenDs.Metadata.FNA, newDate)).isEmpty();
@@ -293,372 +316,538 @@ class MetadatenDsTest {
 
     @Test
     void getAttributeAtDate() {
-      final MetadatenDs metadatenDs =
-          MetadatenDs.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                  <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                                      <meta:beschliessendesOrgan qualifizierteMehrheit="true" start="1990-01-01" end="1994-12-31">organ 1</meta:beschliessendesOrgan>
-                                                      <meta:beschliessendesOrgan qualifizierteMehrheit="false" start="1995-01-01" end="2000-12-31">organ 2</meta:beschliessendesOrgan>
-                                                      <meta:beschliessendesOrgan qualifizierteMehrheit="true" start="2001-01-01" end="unbestimmt">organ 3</meta:beschliessendesOrgan>
-                                                  </meta:legalDocML.de_metadaten_ds>
-                                              """))
-              .build();
+      final MetadatenDs metadatenDs = MetadatenDs
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                    <meta:beschliessendesOrgan qualifizierteMehrheit="true" start="1990-01-01" end="1994-12-31">organ 1</meta:beschliessendesOrgan>
+                    <meta:beschliessendesOrgan qualifizierteMehrheit="false" start="1995-01-01" end="2000-12-31">organ 2</meta:beschliessendesOrgan>
+                    <meta:beschliessendesOrgan qualifizierteMehrheit="true" start="2001-01-01" end="unbestimmt">organ 3</meta:beschliessendesOrgan>
+                </meta:legalDocML.de_metadaten_ds>
+            """
+          )
+        )
+        .build();
 
       assertThat(
-              metadatenDs.getAttributeOfSimpleMetadatumAt(
-                  MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, LocalDate.parse("1980-01-01")))
-          .isEmpty();
+        metadatenDs.getAttributeOfSimpleMetadatumAt(
+          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+          LocalDate.parse("1980-01-01")
+        )
+      )
+        .isEmpty();
 
       assertThat(
-              metadatenDs.getAttributeOfSimpleMetadatumAt(
-                  MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, LocalDate.parse("1990-01-01")))
-          .contains("true");
+        metadatenDs.getAttributeOfSimpleMetadatumAt(
+          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+          LocalDate.parse("1990-01-01")
+        )
+      )
+        .contains("true");
       assertThat(
-              metadatenDs.getAttributeOfSimpleMetadatumAt(
-                  MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, LocalDate.parse("1992-01-01")))
-          .contains("true");
+        metadatenDs.getAttributeOfSimpleMetadatumAt(
+          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+          LocalDate.parse("1992-01-01")
+        )
+      )
+        .contains("true");
       assertThat(
-              metadatenDs.getAttributeOfSimpleMetadatumAt(
-                  MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, LocalDate.parse("1994-12-31")))
-          .contains("true");
+        metadatenDs.getAttributeOfSimpleMetadatumAt(
+          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+          LocalDate.parse("1994-12-31")
+        )
+      )
+        .contains("true");
 
       assertThat(
-              metadatenDs.getAttributeOfSimpleMetadatumAt(
-                  MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, LocalDate.parse("1995-01-01")))
-          .contains("false");
+        metadatenDs.getAttributeOfSimpleMetadatumAt(
+          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+          LocalDate.parse("1995-01-01")
+        )
+      )
+        .contains("false");
       assertThat(
-              metadatenDs.getAttributeOfSimpleMetadatumAt(
-                  MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, LocalDate.parse("1998-01-01")))
-          .contains("false");
+        metadatenDs.getAttributeOfSimpleMetadatumAt(
+          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+          LocalDate.parse("1998-01-01")
+        )
+      )
+        .contains("false");
       assertThat(
-              metadatenDs.getAttributeOfSimpleMetadatumAt(
-                  MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, LocalDate.parse("2000-12-31")))
-          .contains("false");
+        metadatenDs.getAttributeOfSimpleMetadatumAt(
+          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+          LocalDate.parse("2000-12-31")
+        )
+      )
+        .contains("false");
 
       assertThat(
-              metadatenDs.getAttributeOfSimpleMetadatumAt(
-                  MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, LocalDate.parse("2001-01-01")))
-          .contains("true");
+        metadatenDs.getAttributeOfSimpleMetadatumAt(
+          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+          LocalDate.parse("2001-01-01")
+        )
+      )
+        .contains("true");
       assertThat(
-              metadatenDs.getAttributeOfSimpleMetadatumAt(
-                  MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, LocalDate.parse("2024-01-01")))
-          .contains("true");
+        metadatenDs.getAttributeOfSimpleMetadatumAt(
+          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+          LocalDate.parse("2024-01-01")
+        )
+      )
+        .contains("true");
     }
 
     @Test
     void setAttributeAtDateUpdate() {
-      final MetadatenDs metadatenDs =
-          MetadatenDs.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                  <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                                      <meta:beschliessendesOrgan qualifizierteMehrheit="true" start="1990-01-01" end="1994-12-31">organ 1</meta:beschliessendesOrgan>
-                                                  </meta:legalDocML.de_metadaten_ds>
-                                              """))
-              .build();
+      final MetadatenDs metadatenDs = MetadatenDs
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                    <meta:beschliessendesOrgan qualifizierteMehrheit="true" start="1990-01-01" end="1994-12-31">organ 1</meta:beschliessendesOrgan>
+                </meta:legalDocML.de_metadaten_ds>
+            """
+          )
+        )
+        .build();
 
       final LocalDate newDate = LocalDate.parse("1990-01-01");
       assertThat(
-              metadatenDs.getAttributeOfSimpleMetadatumAt(
-                  MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, newDate))
-          .contains("true");
+        metadatenDs.getAttributeOfSimpleMetadatumAt(
+          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+          newDate
+        )
+      )
+        .contains("true");
 
       metadatenDs.setAttributeOfSimpleMetadatum(
-          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, newDate, "false");
+        MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+        newDate,
+        "false"
+      );
 
       assertThat(
-              metadatenDs.getAttributeOfSimpleMetadatumAt(
-                  MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, newDate))
-          .contains("false");
+        metadatenDs.getAttributeOfSimpleMetadatumAt(
+          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+          newDate
+        )
+      )
+        .contains("false");
     }
 
     @Test
     void setAttributeAtDateCreate() {
-      final MetadatenDs metadatenDs =
-          MetadatenDs.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                  <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                                      <meta:beschliessendesOrgan start="1990-01-01" end="1994-12-31">organ 1</meta:beschliessendesOrgan>
-                                                  </meta:legalDocML.de_metadaten_ds>
-                                              """))
-              .build();
+      final MetadatenDs metadatenDs = MetadatenDs
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                    <meta:beschliessendesOrgan start="1990-01-01" end="1994-12-31">organ 1</meta:beschliessendesOrgan>
+                </meta:legalDocML.de_metadaten_ds>
+            """
+          )
+        )
+        .build();
 
       final LocalDate newDate = LocalDate.parse("1990-01-01");
       assertThat(
-              metadatenDs.getAttributeOfSimpleMetadatumAt(
-                  MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, newDate))
-          .isEmpty();
+        metadatenDs.getAttributeOfSimpleMetadatumAt(
+          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+          newDate
+        )
+      )
+        .isEmpty();
 
       metadatenDs.setAttributeOfSimpleMetadatum(
-          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, newDate, "false");
+        MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+        newDate,
+        "false"
+      );
 
       assertThat(
-              metadatenDs.getAttributeOfSimpleMetadatumAt(
-                  MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, newDate))
-          .contains("false");
+        metadatenDs.getAttributeOfSimpleMetadatumAt(
+          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+          newDate
+        )
+      )
+        .contains("false");
     }
 
     @Test
     void setAttributeAtDateParentNotPresent() {
-      final MetadatenDs metadatenDs =
-          MetadatenDs.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                  <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                                      <meta:beschliessendesOrgan qualifizierteMehrheit="false" start="1995-01-01" end="2000-12-31">organ 2</meta:beschliessendesOrgan>
-                                                      <meta:beschliessendesOrgan qualifizierteMehrheit="true" start="2001-01-01" end="unbestimmt">organ 3</meta:beschliessendesOrgan>
-                                                  </meta:legalDocML.de_metadaten_ds>
-                                              """))
-              .build();
+      final MetadatenDs metadatenDs = MetadatenDs
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                    <meta:beschliessendesOrgan qualifizierteMehrheit="false" start="1995-01-01" end="2000-12-31">organ 2</meta:beschliessendesOrgan>
+                    <meta:beschliessendesOrgan qualifizierteMehrheit="true" start="2001-01-01" end="unbestimmt">organ 3</meta:beschliessendesOrgan>
+                </meta:legalDocML.de_metadaten_ds>
+            """
+          )
+        )
+        .build();
 
       final LocalDate newDate = LocalDate.parse("1990-01-01");
       assertThat(
-              metadatenDs.getAttributeOfSimpleMetadatumAt(
-                  MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, newDate))
-          .isEmpty();
+        metadatenDs.getAttributeOfSimpleMetadatumAt(
+          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+          newDate
+        )
+      )
+        .isEmpty();
 
       metadatenDs.setAttributeOfSimpleMetadatum(
-          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, newDate, "true");
+        MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+        newDate,
+        "true"
+      );
 
       assertThat(
-              metadatenDs.getAttributeOfSimpleMetadatumAt(
-                  MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, newDate))
-          .isEmpty();
+        metadatenDs.getAttributeOfSimpleMetadatumAt(
+          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+          newDate
+        )
+      )
+        .isEmpty();
     }
 
     @Test
     void removeAttributeAtValueNull() {
-      final MetadatenDs metadatenDs =
-          MetadatenDs.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                  <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                                      <meta:beschliessendesOrgan qualifizierteMehrheit="false" start="1995-01-01" end="2000-12-31">organ 2</meta:beschliessendesOrgan>
-                                                      <meta:beschliessendesOrgan qualifizierteMehrheit="true" start="2001-01-01" end="unbestimmt"></meta:beschliessendesOrgan>
-                                                  </meta:legalDocML.de_metadaten_ds>
-                                              """))
-              .build();
+      final MetadatenDs metadatenDs = MetadatenDs
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                    <meta:beschliessendesOrgan qualifizierteMehrheit="false" start="1995-01-01" end="2000-12-31">organ 2</meta:beschliessendesOrgan>
+                    <meta:beschliessendesOrgan qualifizierteMehrheit="true" start="2001-01-01" end="unbestimmt"></meta:beschliessendesOrgan>
+                </meta:legalDocML.de_metadaten_ds>
+            """
+          )
+        )
+        .build();
 
       final LocalDate newDate = LocalDate.parse("2002-01-01");
       assertThat(
-              metadatenDs.getAttributeOfSimpleMetadatumAt(
-                  MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, newDate))
-          .contains("true");
+        metadatenDs.getAttributeOfSimpleMetadatumAt(
+          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+          newDate
+        )
+      )
+        .contains("true");
 
       // the 3rd parameter actually doesn't matter. It will remove the attribute because content of
       // beschliessendesOrgan is empty
       metadatenDs.setAttributeOfSimpleMetadatum(
-          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, newDate, null);
+        MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+        newDate,
+        null
+      );
 
       assertThat(
-              metadatenDs.getAttributeOfSimpleMetadatumAt(
-                  MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT, newDate))
-          .isEmpty();
+        metadatenDs.getAttributeOfSimpleMetadatumAt(
+          MetadatenDs.Attribute.QUALIFIZIERTE_MEHRHEIT,
+          newDate
+        )
+      )
+        .isEmpty();
     }
   }
 
   @Nested
   class getMetadatenDsEinzelelement {
+
     @Test
     void getEinzelelementArtDerNormAtDate() {
       var eid = "hauptteil-1_abschnitt-0_para-1";
-      final MetadatenDs metadatenDs =
-          MetadatenDs.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                    <meta:einzelelement href="#hauptteil-1_abschnitt-0_para-1">
-                                        <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN</meta:artDerNorm>
-                                        <meta:artDerNorm start="1995-01-01" end="2000-12-31">ÄN</meta:artDerNorm>
-                                        <meta:artDerNorm start="2001-01-01">ÜN</meta:artDerNorm>
-                                    </meta:einzelelement>
-                                </meta:legalDocML.de_metadaten_ds>
-                            """))
-              .build();
+      final MetadatenDs metadatenDs = MetadatenDs
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                    <meta:einzelelement href="#hauptteil-1_abschnitt-0_para-1">
+                        <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN</meta:artDerNorm>
+                        <meta:artDerNorm start="1995-01-01" end="2000-12-31">ÄN</meta:artDerNorm>
+                        <meta:artDerNorm start="2001-01-01">ÜN</meta:artDerNorm>
+                    </meta:einzelelement>
+                </meta:legalDocML.de_metadaten_ds>
+            """
+          )
+        )
+        .build();
 
       assertThat(
-              metadatenDs.getSingleElementSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, eid, LocalDate.parse("1980-01-01")))
-          .isEmpty();
+        metadatenDs.getSingleElementSimpleMetadatum(
+          Einzelelement.Metadata.ART_DER_NORM,
+          eid,
+          LocalDate.parse("1980-01-01")
+        )
+      )
+        .isEmpty();
 
       assertThat(
-              metadatenDs.getSingleElementSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, eid, LocalDate.parse("1990-01-01")))
-          .contains("SN");
+        metadatenDs.getSingleElementSimpleMetadatum(
+          Einzelelement.Metadata.ART_DER_NORM,
+          eid,
+          LocalDate.parse("1990-01-01")
+        )
+      )
+        .contains("SN");
       assertThat(
-              metadatenDs.getSingleElementSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, eid, LocalDate.parse("1992-01-01")))
-          .contains("SN");
+        metadatenDs.getSingleElementSimpleMetadatum(
+          Einzelelement.Metadata.ART_DER_NORM,
+          eid,
+          LocalDate.parse("1992-01-01")
+        )
+      )
+        .contains("SN");
       assertThat(
-              metadatenDs.getSingleElementSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, eid, LocalDate.parse("1994-12-31")))
-          .contains("SN");
+        metadatenDs.getSingleElementSimpleMetadatum(
+          Einzelelement.Metadata.ART_DER_NORM,
+          eid,
+          LocalDate.parse("1994-12-31")
+        )
+      )
+        .contains("SN");
 
       assertThat(
-              metadatenDs.getSingleElementSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, eid, LocalDate.parse("1995-01-01")))
-          .contains("ÄN");
+        metadatenDs.getSingleElementSimpleMetadatum(
+          Einzelelement.Metadata.ART_DER_NORM,
+          eid,
+          LocalDate.parse("1995-01-01")
+        )
+      )
+        .contains("ÄN");
       assertThat(
-              metadatenDs.getSingleElementSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, eid, LocalDate.parse("1998-01-01")))
-          .contains("ÄN");
+        metadatenDs.getSingleElementSimpleMetadatum(
+          Einzelelement.Metadata.ART_DER_NORM,
+          eid,
+          LocalDate.parse("1998-01-01")
+        )
+      )
+        .contains("ÄN");
       assertThat(
-              metadatenDs.getSingleElementSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, eid, LocalDate.parse("2000-12-31")))
-          .contains("ÄN");
+        metadatenDs.getSingleElementSimpleMetadatum(
+          Einzelelement.Metadata.ART_DER_NORM,
+          eid,
+          LocalDate.parse("2000-12-31")
+        )
+      )
+        .contains("ÄN");
 
       assertThat(
-              metadatenDs.getSingleElementSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, eid, LocalDate.parse("2001-01-01")))
-          .contains("ÜN");
+        metadatenDs.getSingleElementSimpleMetadatum(
+          Einzelelement.Metadata.ART_DER_NORM,
+          eid,
+          LocalDate.parse("2001-01-01")
+        )
+      )
+        .contains("ÜN");
       assertThat(
-              metadatenDs.getSingleElementSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, eid, LocalDate.parse("2024-01-01")))
-          .contains("ÜN");
+        metadatenDs.getSingleElementSimpleMetadatum(
+          Einzelelement.Metadata.ART_DER_NORM,
+          eid,
+          LocalDate.parse("2024-01-01")
+        )
+      )
+        .contains("ÜN");
     }
   }
 
   @Nested
   class updateMetadatenDsEinzelelement {
+
     @Test
     void createEinzelelementNode() {
       var eid = "hauptteil-1_abschnitt-0_para-1";
-      final MetadatenDs metadatenDs =
-          MetadatenDs.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                </meta:legalDocML.de_metadaten_ds>
-                            """))
-              .build();
+      final MetadatenDs metadatenDs = MetadatenDs
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                </meta:legalDocML.de_metadaten_ds>
+            """
+          )
+        )
+        .build();
 
       metadatenDs.updateSingleElementSimpleMetadatum(
-          Einzelelement.Metadata.ART_DER_NORM, eid, LocalDate.parse("1980-01-01"), "SN");
+        Einzelelement.Metadata.ART_DER_NORM,
+        eid,
+        LocalDate.parse("1980-01-01"),
+        "SN"
+      );
 
       assertThat(
-              metadatenDs.getSingleElementSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, eid, LocalDate.parse("1980-01-01")))
-          .contains("SN");
+        metadatenDs.getSingleElementSimpleMetadatum(
+          Einzelelement.Metadata.ART_DER_NORM,
+          eid,
+          LocalDate.parse("1980-01-01")
+        )
+      )
+        .contains("SN");
     }
 
     @Test
     void updateEinzelelementBetweenDates() {
       var eid = "hauptteil-1_abschnitt-0_para-1";
-      final MetadatenDs metadatenDs =
-          MetadatenDs.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                  <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                    <meta:einzelelement href="#hauptteil-1_abschnitt-0_para-1">
-                                        <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN</meta:artDerNorm>
-                                        <meta:artDerNorm start="1995-01-01" end="2000-12-31">ÄN</meta:artDerNorm>
-                                        <meta:artDerNorm start="2001-01-01">ÜN</meta:artDerNorm>
-                                    </meta:einzelelement>
-                                  </meta:legalDocML.de_metadaten_ds>
-                              """))
-              .build();
+      final MetadatenDs metadatenDs = MetadatenDs
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                  <meta:einzelelement href="#hauptteil-1_abschnitt-0_para-1">
+                      <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN</meta:artDerNorm>
+                      <meta:artDerNorm start="1995-01-01" end="2000-12-31">ÄN</meta:artDerNorm>
+                      <meta:artDerNorm start="2001-01-01">ÜN</meta:artDerNorm>
+                  </meta:einzelelement>
+                </meta:legalDocML.de_metadaten_ds>
+            """
+          )
+        )
+        .build();
 
       metadatenDs.updateSingleElementSimpleMetadatum(
-          Einzelelement.Metadata.ART_DER_NORM, eid, LocalDate.parse("1992-01-01"), "ÄN");
+        Einzelelement.Metadata.ART_DER_NORM,
+        eid,
+        LocalDate.parse("1992-01-01"),
+        "ÄN"
+      );
 
       assertThat(
-              metadatenDs.getSingleElementSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, eid, LocalDate.parse("1992-01-01")))
-          .contains("ÄN");
+        metadatenDs.getSingleElementSimpleMetadatum(
+          Einzelelement.Metadata.ART_DER_NORM,
+          eid,
+          LocalDate.parse("1992-01-01")
+        )
+      )
+        .contains("ÄN");
     }
 
     @Test
     void updateEinzelelementAtStartDate() {
       var eid = "hauptteil-1_abschnitt-0_para-1";
-      final MetadatenDs metadatenDs =
-          MetadatenDs.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                  <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                    <meta:einzelelement href="#hauptteil-1_abschnitt-0_para-1">
-                                        <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN</meta:artDerNorm>
-                                        <meta:artDerNorm start="1995-01-01" end="2000-12-31">ÄN</meta:artDerNorm>
-                                        <meta:artDerNorm start="2001-01-01">ÜN</meta:artDerNorm>
-                                    </meta:einzelelement>
-                                  </meta:legalDocML.de_metadaten_ds>
-                              """))
-              .build();
+      final MetadatenDs metadatenDs = MetadatenDs
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                  <meta:einzelelement href="#hauptteil-1_abschnitt-0_para-1">
+                      <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN</meta:artDerNorm>
+                      <meta:artDerNorm start="1995-01-01" end="2000-12-31">ÄN</meta:artDerNorm>
+                      <meta:artDerNorm start="2001-01-01">ÜN</meta:artDerNorm>
+                  </meta:einzelelement>
+                </meta:legalDocML.de_metadaten_ds>
+            """
+          )
+        )
+        .build();
 
       metadatenDs.updateSingleElementSimpleMetadatum(
-          Einzelelement.Metadata.ART_DER_NORM, eid, LocalDate.parse("1990-01-01"), "ÜN");
+        Einzelelement.Metadata.ART_DER_NORM,
+        eid,
+        LocalDate.parse("1990-01-01"),
+        "ÜN"
+      );
 
       assertThat(
-              metadatenDs.getSingleElementSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, eid, LocalDate.parse("1990-01-01")))
-          .contains("ÜN");
+        metadatenDs.getSingleElementSimpleMetadatum(
+          Einzelelement.Metadata.ART_DER_NORM,
+          eid,
+          LocalDate.parse("1990-01-01")
+        )
+      )
+        .contains("ÜN");
     }
 
     @Test
     void resetEinzelelementAtDate() {
       var eid = "hauptteil-1_abschnitt-0_para-1";
-      final MetadatenDs metadatenDs =
-          MetadatenDs.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                  <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                    <meta:einzelelement href="#hauptteil-1_abschnitt-0_para-1">
-                                        <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN</meta:artDerNorm>
-                                        <meta:artDerNorm start="1995-01-01" end="2000-12-31">ÄN</meta:artDerNorm>
-                                        <meta:artDerNorm start="2001-01-01">ÜN</meta:artDerNorm>
-                                    </meta:einzelelement>
-                                  </meta:legalDocML.de_metadaten_ds>
-                              """))
-              .build();
+      final MetadatenDs metadatenDs = MetadatenDs
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                  <meta:einzelelement href="#hauptteil-1_abschnitt-0_para-1">
+                      <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN</meta:artDerNorm>
+                      <meta:artDerNorm start="1995-01-01" end="2000-12-31">ÄN</meta:artDerNorm>
+                      <meta:artDerNorm start="2001-01-01">ÜN</meta:artDerNorm>
+                  </meta:einzelelement>
+                </meta:legalDocML.de_metadaten_ds>
+            """
+          )
+        )
+        .build();
 
       metadatenDs.updateSingleElementSimpleMetadatum(
-          Einzelelement.Metadata.ART_DER_NORM, eid, LocalDate.parse("1990-01-01"), null);
+        Einzelelement.Metadata.ART_DER_NORM,
+        eid,
+        LocalDate.parse("1990-01-01"),
+        null
+      );
 
       assertThat(
-              metadatenDs.getSingleElementSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, eid, LocalDate.parse("1990-01-01")))
-          .isEmpty();
+        metadatenDs.getSingleElementSimpleMetadatum(
+          Einzelelement.Metadata.ART_DER_NORM,
+          eid,
+          LocalDate.parse("1990-01-01")
+        )
+      )
+        .isEmpty();
     }
 
     @Test
     void resetLastEinzelelementAtDate() {
       var eid = "hauptteil-1_abschnitt-0_para-1";
-      final MetadatenDs metadatenDs =
-          MetadatenDs.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                  <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                    <meta:einzelelement href="#hauptteil-1_abschnitt-0_para-1">
-                                        <meta:artDerNorm end="unbestimmt" start="1980-01-01">SN</meta:artDerNorm>
-                                    </meta:einzelelement>
-                                  </meta:legalDocML.de_metadaten_ds>
-                              """))
-              .build();
+      final MetadatenDs metadatenDs = MetadatenDs
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                  <meta:einzelelement href="#hauptteil-1_abschnitt-0_para-1">
+                      <meta:artDerNorm end="unbestimmt" start="1980-01-01">SN</meta:artDerNorm>
+                  </meta:einzelelement>
+                </meta:legalDocML.de_metadaten_ds>
+            """
+          )
+        )
+        .build();
 
       metadatenDs.updateSingleElementSimpleMetadatum(
-          Einzelelement.Metadata.ART_DER_NORM, eid, LocalDate.parse("1980-01-01"), null);
+        Einzelelement.Metadata.ART_DER_NORM,
+        eid,
+        LocalDate.parse("1980-01-01"),
+        null
+      );
 
       assertThat(
-              metadatenDs.getSingleElementSimpleMetadatum(
-                  Einzelelement.Metadata.ART_DER_NORM, eid, LocalDate.parse("1980-01-01")))
-          .isEmpty();
+        metadatenDs.getSingleElementSimpleMetadatum(
+          Einzelelement.Metadata.ART_DER_NORM,
+          eid,
+          LocalDate.parse("1980-01-01")
+        )
+      )
+        .isEmpty();
 
       assertThat(
-              NodeParser.getNodeFromExpression(
-                  "./einzelelement[@href='#%s']".formatted(eid), metadatenDs.getNode()))
-          .isEmpty();
+        NodeParser.getNodeFromExpression(
+          "./einzelelement[@href='#%s']".formatted(eid),
+          metadatenDs.getNode()
+        )
+      )
+        .isEmpty();
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/ModTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/ModTest.java
@@ -11,52 +11,52 @@ import org.w3c.dom.Node;
 class ModTest {
 
   private static final String QUOTED_TEXT_MOD =
-      """
-          <akn:mod eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"
-                GUID="148c2f06-6e33-4af8-9f4a-3da67c888510"
-                refersTo="aenderungsbefehl-ersetzen">In <akn:ref eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1"
-                   GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206"
-                   href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml">§ 20 Absatz 1 Satz 2</akn:ref> wird
-          die Angabe <akn:quotedText eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-1"
-                          GUID="694459c4-ef66-4f87-bb78-a332054a2216"
-                          startQuote="„"
-                          endQuote="“">§ 9 Abs. 1 Satz 2, Abs. 2</akn:quotedText> durch die
-          Wörter <akn:quotedText eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2"
-                          GUID="dd25bdb6-4ef4-4ef5-808c-27579b6ae196"
-                          startQuote="„"
-                          endQuote="“">§ 9 Absatz 1 Satz 2, Absatz 2 oder 3</akn:quotedText>
-          ersetzt.</akn:mod>
-          """;
+    """
+    <akn:mod eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"
+          GUID="148c2f06-6e33-4af8-9f4a-3da67c888510"
+          refersTo="aenderungsbefehl-ersetzen">In <akn:ref eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1"
+             GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206"
+             href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml">§ 20 Absatz 1 Satz 2</akn:ref> wird
+    die Angabe <akn:quotedText eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-1"
+                    GUID="694459c4-ef66-4f87-bb78-a332054a2216"
+                    startQuote="„"
+                    endQuote="“">§ 9 Abs. 1 Satz 2, Abs. 2</akn:quotedText> durch die
+    Wörter <akn:quotedText eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2"
+                    GUID="dd25bdb6-4ef4-4ef5-808c-27579b6ae196"
+                    startQuote="„"
+                    endQuote="“">§ 9 Absatz 1 Satz 2, Absatz 2 oder 3</akn:quotedText>
+    ersetzt.</akn:mod>
+    """;
 
   private static final String QUOTED_STRUCTURE_REF_MOD =
-      """
-              <akn:mod GUID="5597b2ca-bc99-42d7-a362-faced3cad1c1" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1" refersTo="aenderungsbefehl-ersetzen"> Der
-                <akn:ref GUID="4400b9ef-c992-49fe-9bb5-30bfd4519e5d" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_ref-1" href="eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/einleitung-1_doktitel-1.xml">Titel</akn:ref> des Gesetzes wird ersetzt durch:
-                <akn:quotedStructure GUID="9cb0572a-2933-473e-823f-5541ab360561" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1" endQuote="“" startQuote="„">
-                  <akn:longTitle GUID="0505f7b3-54c8-4c9d-b456-cd84adfb98f1" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1">
-                    <akn:p GUID="6ad3f708-b3be-4dbf-b149-a61e72678105" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1_text-1">
-                      <akn:docTitle GUID="ab481c1a-db58-4b6a-886c-1e9301952c34" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1_text-1_doctitel-1">Fiktives Beispielgesetz für das Ersetzen von Strukturen und Gliederungseinheiten mit Änderungsbefehlen</akn:docTitle>
-                      <akn:shortTitle GUID="820e7af3-fd8c-4409-949a-1e40ec2cc8e6" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1_text-1_kurztitel-1"> (Strukturänderungsgesetz) </akn:shortTitle>
-                    </akn:p>
-                  </akn:longTitle>
-                </akn:quotedStructure>
-              </akn:mod>
-        """;
+    """
+          <akn:mod GUID="5597b2ca-bc99-42d7-a362-faced3cad1c1" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1" refersTo="aenderungsbefehl-ersetzen"> Der
+            <akn:ref GUID="4400b9ef-c992-49fe-9bb5-30bfd4519e5d" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_ref-1" href="eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/einleitung-1_doktitel-1.xml">Titel</akn:ref> des Gesetzes wird ersetzt durch:
+            <akn:quotedStructure GUID="9cb0572a-2933-473e-823f-5541ab360561" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1" endQuote="“" startQuote="„">
+              <akn:longTitle GUID="0505f7b3-54c8-4c9d-b456-cd84adfb98f1" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1">
+                <akn:p GUID="6ad3f708-b3be-4dbf-b149-a61e72678105" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1_text-1">
+                  <akn:docTitle GUID="ab481c1a-db58-4b6a-886c-1e9301952c34" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1_text-1_doctitel-1">Fiktives Beispielgesetz für das Ersetzen von Strukturen und Gliederungseinheiten mit Änderungsbefehlen</akn:docTitle>
+                  <akn:shortTitle GUID="820e7af3-fd8c-4409-949a-1e40ec2cc8e6" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1_text-1_kurztitel-1"> (Strukturänderungsgesetz) </akn:shortTitle>
+                </akn:p>
+              </akn:longTitle>
+            </akn:quotedStructure>
+          </akn:mod>
+    """;
 
   private static final String QUOTED_STRUCTURE_RREF_MOD =
-      """
-                  <akn:mod GUID="5597b2ca-bc99-42d7-a362-faced3cad1c1" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1" refersTo="aenderungsbefehl-ersetzen"> Der
-                    <akn:rref GUID="4400b9ef-c992-49fe-9bb5-30bfd4519e5d" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_ref-1" from="eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/einleitung-1_doktitel-1.xml" upTo="eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/einleitung-1_doktitel-3.xml">Titel</akn:rref> des Gesetzes wird ersetzt durch:
-                    <akn:quotedStructure GUID="9cb0572a-2933-473e-823f-5541ab360561" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1" endQuote="“" startQuote="„">
-                      <akn:longTitle GUID="0505f7b3-54c8-4c9d-b456-cd84adfb98f1" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1">
-                        <akn:p GUID="6ad3f708-b3be-4dbf-b149-a61e72678105" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1_text-1">
-                          <akn:docTitle GUID="ab481c1a-db58-4b6a-886c-1e9301952c34" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1_text-1_doctitel-1">Fiktives Beispielgesetz für das Ersetzen von Strukturen und Gliederungseinheiten mit Änderungsbefehlen</akn:docTitle>
-                          <akn:shortTitle GUID="820e7af3-fd8c-4409-949a-1e40ec2cc8e6" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1_text-1_kurztitel-1"> (Strukturänderungsgesetz) </akn:shortTitle>
-                        </akn:p>
-                      </akn:longTitle>
-                    </akn:quotedStructure>
-                  </akn:mod>
-            """;
+    """
+          <akn:mod GUID="5597b2ca-bc99-42d7-a362-faced3cad1c1" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1" refersTo="aenderungsbefehl-ersetzen"> Der
+            <akn:rref GUID="4400b9ef-c992-49fe-9bb5-30bfd4519e5d" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_ref-1" from="eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/einleitung-1_doktitel-1.xml" upTo="eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/einleitung-1_doktitel-3.xml">Titel</akn:rref> des Gesetzes wird ersetzt durch:
+            <akn:quotedStructure GUID="9cb0572a-2933-473e-823f-5541ab360561" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1" endQuote="“" startQuote="„">
+              <akn:longTitle GUID="0505f7b3-54c8-4c9d-b456-cd84adfb98f1" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1">
+                <akn:p GUID="6ad3f708-b3be-4dbf-b149-a61e72678105" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1_text-1">
+                  <akn:docTitle GUID="ab481c1a-db58-4b6a-886c-1e9301952c34" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1_text-1_doctitel-1">Fiktives Beispielgesetz für das Ersetzen von Strukturen und Gliederungseinheiten mit Änderungsbefehlen</akn:docTitle>
+                  <akn:shortTitle GUID="820e7af3-fd8c-4409-949a-1e40ec2cc8e6" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1_text-1_kurztitel-1"> (Strukturänderungsgesetz) </akn:shortTitle>
+                </akn:p>
+              </akn:longTitle>
+            </akn:quotedStructure>
+          </akn:mod>
+    """;
 
   private Mod quotedTextMod;
   private Mod quotedStructureRefMod;
@@ -67,18 +67,17 @@ class ModTest {
     quotedTextMod = Mod.builder().node(XmlMapper.toNode(QUOTED_TEXT_MOD)).build();
     quotedStructureRefMod = Mod.builder().node(XmlMapper.toNode(QUOTED_STRUCTURE_REF_MOD)).build();
     quotedStructureRrefMod =
-        Mod.builder().node(XmlMapper.toNode(QUOTED_STRUCTURE_RREF_MOD)).build();
+    Mod.builder().node(XmlMapper.toNode(QUOTED_STRUCTURE_RREF_MOD)).build();
   }
 
   @Test
   void getEid() {
-
     // when
     var eid = quotedTextMod.getEid();
 
     // then
     assertThat(eid)
-        .contains("hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1");
+      .contains("hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1");
   }
 
   @Test
@@ -117,8 +116,9 @@ class ModTest {
     // then
     assertThat(eid).isPresent();
     assertThat(eid.get().value())
-        .contains(
-            "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml");
+      .contains(
+        "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"
+      );
   }
 
   @Test
@@ -140,8 +140,9 @@ class ModTest {
     // then
     assertThat(eid).isPresent();
     assertThat(eid.get().value())
-        .contains(
-            "eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/einleitung-1_doktitel-1.xml");
+      .contains(
+        "eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/einleitung-1_doktitel-1.xml"
+      );
   }
 
   @Test
@@ -163,8 +164,9 @@ class ModTest {
     // then
     assertThat(eid).isPresent();
     assertThat(eid.get().value())
-        .contains(
-            "eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/einleitung-1_doktitel-3.xml");
+      .contains(
+        "eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/einleitung-1_doktitel-3.xml"
+      );
   }
 
   @Test
@@ -195,12 +197,13 @@ class ModTest {
     // then
     assertThat(secondQuotedText).isPresent();
     assertThat(secondQuotedText.get().getAttributes().getNamedItem("GUID").getNodeValue())
-        .isEqualTo("dd25bdb6-4ef4-4ef5-808c-27579b6ae196");
+      .isEqualTo("dd25bdb6-4ef4-4ef5-808c-27579b6ae196");
     assertThat(secondQuotedText.get().getAttributes().getNamedItem("eId").getNodeValue())
-        .isEqualTo(
-            "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2");
+      .isEqualTo(
+        "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2"
+      );
     assertThat(secondQuotedText.get().getTextContent())
-        .isEqualTo("§ 9 Absatz 1 Satz 2, Absatz 2 oder 3");
+      .isEqualTo("§ 9 Absatz 1 Satz 2, Absatz 2 oder 3");
   }
 
   @Test
@@ -220,10 +223,11 @@ class ModTest {
     // then
     assertThat(quotedStructure).isPresent();
     assertThat(quotedStructure.get().getAttributes().getNamedItem("GUID").getNodeValue())
-        .isEqualTo("9cb0572a-2933-473e-823f-5541ab360561");
+      .isEqualTo("9cb0572a-2933-473e-823f-5541ab360561");
     assertThat(quotedStructure.get().getAttributes().getNamedItem("eId").getNodeValue())
-        .isEqualTo(
-            "hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1");
+      .isEqualTo(
+        "hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1"
+      );
     assertThat(quotedStructure.get().getChildNodes().getLength()).isGreaterThan(1);
   }
 
@@ -234,12 +238,11 @@ class ModTest {
 
   @Test
   void quotedTextContainsRef() {
-
-    final Mod mod =
-        Mod.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
+    final Mod mod = Mod
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
            <akn:mod eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"
                 GUID="148c2f06-6e33-4af8-9f4a-3da67c888510"
                 refersTo="aenderungsbefehl-ersetzen">In <akn:ref eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1"
@@ -254,8 +257,10 @@ class ModTest {
                           startQuote="„"
                           endQuote="“"><akn:ref>§ 9 Absatz 1 Satz 2, Absatz 2 oder 3</akn:ref></akn:quotedText>
           ersetzt.</akn:mod>
-          """))
-            .build();
+          """
+        )
+      )
+      .build();
 
     assertThat(mod.containsRef()).isTrue();
   }
@@ -267,25 +272,26 @@ class ModTest {
 
   @Test
   void quotedStructureContainsRef() {
-
-    final Mod mod =
-        Mod.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-              <akn:mod GUID="5597b2ca-bc99-42d7-a362-faced3cad1c1" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1" refersTo="aenderungsbefehl-ersetzen"> Der
-                <akn:ref GUID="4400b9ef-c992-49fe-9bb5-30bfd4519e5d" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_ref-1" href="eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/einleitung-1_doktitel-1.xml">Titel</akn:ref> des Gesetzes wird ersetzt durch:
-                <akn:quotedStructure GUID="9cb0572a-2933-473e-823f-5541ab360561" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1" endQuote="“" startQuote="„">
-                  <akn:longTitle GUID="0505f7b3-54c8-4c9d-b456-cd84adfb98f1" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1">
-                    <akn:p GUID="6ad3f708-b3be-4dbf-b149-a61e72678105" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1_text-1">
-                      <akn:docTitle GUID="ab481c1a-db58-4b6a-886c-1e9301952c34" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1_text-1_doctitel-1">Fiktives <akn:ref>Beispielgesetz</akn:ref> für das Ersetzen von Strukturen und Gliederungseinheiten mit Änderungsbefehlen</akn:docTitle>
-                      <akn:shortTitle GUID="820e7af3-fd8c-4409-949a-1e40ec2cc8e6" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1_text-1_kurztitel-1"> (Strukturänderungsgesetz) </akn:shortTitle>
-                    </akn:p>
-                  </akn:longTitle>
-                </akn:quotedStructure>
-              </akn:mod>
-              """))
-            .build();
+    final Mod mod = Mod
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:mod GUID="5597b2ca-bc99-42d7-a362-faced3cad1c1" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1" refersTo="aenderungsbefehl-ersetzen"> Der
+            <akn:ref GUID="4400b9ef-c992-49fe-9bb5-30bfd4519e5d" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_ref-1" href="eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/einleitung-1_doktitel-1.xml">Titel</akn:ref> des Gesetzes wird ersetzt durch:
+            <akn:quotedStructure GUID="9cb0572a-2933-473e-823f-5541ab360561" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1" endQuote="“" startQuote="„">
+              <akn:longTitle GUID="0505f7b3-54c8-4c9d-b456-cd84adfb98f1" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1">
+                <akn:p GUID="6ad3f708-b3be-4dbf-b149-a61e72678105" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1_text-1">
+                  <akn:docTitle GUID="ab481c1a-db58-4b6a-886c-1e9301952c34" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1_text-1_doctitel-1">Fiktives <akn:ref>Beispielgesetz</akn:ref> für das Ersetzen von Strukturen und Gliederungseinheiten mit Änderungsbefehlen</akn:docTitle>
+                  <akn:shortTitle GUID="820e7af3-fd8c-4409-949a-1e40ec2cc8e6" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quotstruct-1_doktitel-1_text-1_kurztitel-1"> (Strukturänderungsgesetz) </akn:shortTitle>
+                </akn:p>
+              </akn:longTitle>
+            </akn:quotedStructure>
+          </akn:mod>
+          """
+        )
+      )
+      .build();
 
     assertThat(mod.containsRef()).isTrue();
   }
@@ -293,11 +299,11 @@ class ModTest {
   @Test
   void hasRref() {
     String rangeRefString =
-        """
-                      <akn:mod xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="5597b2ca-bc99-42d7-a362-faced3cad1c1" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1" refersTo="aenderungsbefehl-ersetzen"> Der
-                <akn:rref from="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-9_abs-1.xml" upTo="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-9_abs-4.xml">§ 9 Absatz 1 bis 4</akn:rref> des Gesetzes wird ersetzt durch:
-              </akn:mod>
-        """;
+      """
+                    <akn:mod xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="5597b2ca-bc99-42d7-a362-faced3cad1c1" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1" refersTo="aenderungsbefehl-ersetzen"> Der
+              <akn:rref from="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-9_abs-1.xml" upTo="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-9_abs-4.xml">§ 9 Absatz 1 bis 4</akn:rref> des Gesetzes wird ersetzt durch:
+            </akn:mod>
+      """;
     quotedStructureRefMod = Mod.builder().node(XmlMapper.toNode(rangeRefString)).build();
 
     // when
@@ -310,11 +316,11 @@ class ModTest {
   @Test
   void hasRrefFalse() {
     String rangeRefString =
-        """
-                    <akn:mod xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="5597b2ca-bc99-42d7-a362-faced3cad1c1" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1" refersTo="aenderungsbefehl-ersetzen"> Der
-              <akn:ref GUID="4400b9ef-c992-49fe-9bb5-30bfd4519e5d" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_ref-1" href="eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/einleitung-1_doktitel-1.xml">Titel</akn:ref> des Gesetzes wird ersetzt
-            </akn:mod>
-        """;
+      """
+                  <akn:mod xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" GUID="5597b2ca-bc99-42d7-a362-faced3cad1c1" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1" refersTo="aenderungsbefehl-ersetzen"> Der
+            <akn:ref GUID="4400b9ef-c992-49fe-9bb5-30bfd4519e5d" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_ref-1" href="eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/einleitung-1_doktitel-1.xml">Titel</akn:ref> des Gesetzes wird ersetzt
+          </akn:mod>
+      """;
     quotedStructureRefMod = Mod.builder().node(XmlMapper.toNode(rangeRefString)).build();
 
     // when

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormFixtures.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormFixtures.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import org.apache.commons.io.IOUtils;
 
 public class NormFixtures {
+
   public static Norm loadFromDisk(final String fileName) {
     return loadFromDisk(fileName, false);
   }
@@ -18,8 +19,9 @@ public class NormFixtures {
   private static String loadNormFile(final String fileName) {
     try {
       return IOUtils.toString(
-          Objects.requireNonNull(NormFixtures.class.getResourceAsStream(fileName)),
-          StandardCharsets.UTF_8);
+        Objects.requireNonNull(NormFixtures.class.getResourceAsStream(fileName)),
+        StandardCharsets.UTF_8
+      );
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.w3c.dom.Node;
 
 class NormTest {
+
   @Test
   void getEli() {
     // given
@@ -35,16 +36,15 @@ class NormTest {
   void getErrorWhenEliItDoesntExist() {
     // given
     String normString =
-        """
-                        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                    <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                       xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                           http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                       <akn:act name="regelungstext">
-                       </akn:act>
-                    </akn:akomaNtoso>
-                      """
-            .strip();
+      """
+          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+         <akn:act name="regelungstext">
+         </akn:act>
+      </akn:akomaNtoso>
+        """.strip();
 
     Norm norm = new Norm(toDocument(normString));
 
@@ -55,26 +55,26 @@ class NormTest {
   void getGuid() {
     // given
     String normString =
-        """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                  <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                     <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                  </akn:FRBRExpression>
-                              </akn:identification>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                    </akn:FRBRExpression>
+                </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
 
     Norm norm = new Norm(toDocument(normString));
 
@@ -89,31 +89,31 @@ class NormTest {
   void getTitle() {
     // given
     String normString =
-        """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Dokumentenkopf Regelungstext -->
-                            <akn:preface eId="einleitung-1" GUID="fc10e89f-fde4-44bf-aa98-b6bdea01f0ea">
-                               <akn:longTitle eId="einleitung-1_doktitel-1" GUID="abbb08de-e7e2-40ab-aba0-079ce786e6d6">
-                                  <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="3e7c2134-d82c-44ba-b50d-bad9790375a0">
-                                     <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="3b355cab-ce10-45b5-9cde-cc618fbf491f" />
-                                     <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="c83abe1e-5fde-4e4e-a9b5-7293505ffeff" />
-                                     <akn:docTitle
-                                        eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="8c4eabab-9893-455e-b83b-c46f2453f2fb">Gesetz zur Regelung des öffentlichen Vereinsrechts</akn:docTitle>
-                                     <akn:shortTitle eId="einleitung-1_doktitel-1_text-1_kurztitel-1" GUID="fdb8ed28-2e1f-4d81-b780-846fd9ecb716">( <akn:inline
-                                           eId="einleitung-1_doktitel-1_text-1_kurztitel-1_inline-1" GUID="bdff7240-266e-4ff3-b311-60342bd1afa2" refersTo="amtliche-abkuerzung" name="attributsemantik-noch-undefiniert">Vereinsgesetz</akn:inline>)</akn:shortTitle>
-                                  </akn:p>
-                               </akn:longTitle>
-                               <akn:block eId="einleitung-1_block-1" GUID="010d9df0-817a-49b6-a121-d0a1d412a3e3" name="attributsemantik-noch-undefiniert">
-                                  <akn:date eId="einleitung-1_block-1_datum-1" GUID="28fafbe4-403d-4436-8d0d-7241cbbdade0" refersTo="ausfertigung-datum" date="1964-08-05">Vom 5. August 1964 </akn:date>
-                               </akn:block>
-                            </akn:preface>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Dokumentenkopf Regelungstext -->
+              <akn:preface eId="einleitung-1" GUID="fc10e89f-fde4-44bf-aa98-b6bdea01f0ea">
+                 <akn:longTitle eId="einleitung-1_doktitel-1" GUID="abbb08de-e7e2-40ab-aba0-079ce786e6d6">
+                    <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="3e7c2134-d82c-44ba-b50d-bad9790375a0">
+                       <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="3b355cab-ce10-45b5-9cde-cc618fbf491f" />
+                       <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="c83abe1e-5fde-4e4e-a9b5-7293505ffeff" />
+                       <akn:docTitle
+                          eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="8c4eabab-9893-455e-b83b-c46f2453f2fb">Gesetz zur Regelung des öffentlichen Vereinsrechts</akn:docTitle>
+                       <akn:shortTitle eId="einleitung-1_doktitel-1_text-1_kurztitel-1" GUID="fdb8ed28-2e1f-4d81-b780-846fd9ecb716">( <akn:inline
+                             eId="einleitung-1_doktitel-1_text-1_kurztitel-1_inline-1" GUID="bdff7240-266e-4ff3-b311-60342bd1afa2" refersTo="amtliche-abkuerzung" name="attributsemantik-noch-undefiniert">Vereinsgesetz</akn:inline>)</akn:shortTitle>
+                    </akn:p>
+                 </akn:longTitle>
+                 <akn:block eId="einleitung-1_block-1" GUID="010d9df0-817a-49b6-a121-d0a1d412a3e3" name="attributsemantik-noch-undefiniert">
+                    <akn:date eId="einleitung-1_block-1_datum-1" GUID="28fafbe4-403d-4436-8d0d-7241cbbdade0" refersTo="ausfertigung-datum" date="1964-08-05">Vom 5. August 1964 </akn:date>
+                 </akn:block>
+              </akn:preface>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
 
     Norm norm = new Norm(toDocument(normString));
     String expectedTitle = "Gesetz zur Regelung des öffentlichen Vereinsrechts";
@@ -129,23 +129,23 @@ class NormTest {
   void getShortTitle() {
     // given
     String normString =
-        """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Dokumentenkopf Regelungstext -->
-                            <akn:preface eId="einleitung-1" GUID="fc10e89f-fde4-44bf-aa98-b6bdea01f0ea">
-                               <akn:longTitle eId="einleitung-1_doktitel-1" GUID="abbb08de-e7e2-40ab-aba0-079ce786e6d6">
-                                  <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="3e7c2134-d82c-44ba-b50d-bad9790375a0">
-                                     <akn:shortTitle eId="einleitung-1_doktitel-1_text-1_kurztitel-1" GUID="fdb8ed28-2e1f-4d81-b780-846fd9ecb716">Vereinsgesetz</akn:shortTitle>
-                                  </akn:p>
-                               </akn:longTitle>
-                            </akn:preface>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Dokumentenkopf Regelungstext -->
+              <akn:preface eId="einleitung-1" GUID="fc10e89f-fde4-44bf-aa98-b6bdea01f0ea">
+                 <akn:longTitle eId="einleitung-1_doktitel-1" GUID="abbb08de-e7e2-40ab-aba0-079ce786e6d6">
+                    <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="3e7c2134-d82c-44ba-b50d-bad9790375a0">
+                       <akn:shortTitle eId="einleitung-1_doktitel-1_text-1_kurztitel-1" GUID="fdb8ed28-2e1f-4d81-b780-846fd9ecb716">Vereinsgesetz</akn:shortTitle>
+                    </akn:p>
+                 </akn:longTitle>
+              </akn:preface>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
     Norm norm = new Norm(toDocument(normString));
 
     // when
@@ -159,24 +159,24 @@ class NormTest {
   void getShortTitleWithoutParenthesis() {
     // given
     String normString =
-        """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Dokumentenkopf Regelungstext -->
-                            <akn:preface eId="einleitung-1" GUID="fc10e89f-fde4-44bf-aa98-b6bdea01f0ea">
-                               <akn:longTitle eId="einleitung-1_doktitel-1" GUID="abbb08de-e7e2-40ab-aba0-079ce786e6d6">
-                                  <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="3e7c2134-d82c-44ba-b50d-bad9790375a0">
-                                     <akn:shortTitle eId="einleitung-1_doktitel-1_text-1_kurztitel-1" GUID="fdb8ed28-2e1f-4d81-b780-846fd9ecb716">( <akn:inline
-                                           eId="einleitung-1_doktitel-1_text-1_kurztitel-1_inline-1" GUID="bdff7240-266e-4ff3-b311-60342bd1afa2" refersTo="amtliche-abkuerzung" name="attributsemantik-noch-undefiniert">Vereinsgesetz</akn:inline>)</akn:shortTitle>
-                                  </akn:p>
-                               </akn:longTitle>
-                            </akn:preface>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Dokumentenkopf Regelungstext -->
+              <akn:preface eId="einleitung-1" GUID="fc10e89f-fde4-44bf-aa98-b6bdea01f0ea">
+                 <akn:longTitle eId="einleitung-1_doktitel-1" GUID="abbb08de-e7e2-40ab-aba0-079ce786e6d6">
+                    <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="3e7c2134-d82c-44ba-b50d-bad9790375a0">
+                       <akn:shortTitle eId="einleitung-1_doktitel-1_text-1_kurztitel-1" GUID="fdb8ed28-2e1f-4d81-b780-846fd9ecb716">( <akn:inline
+                             eId="einleitung-1_doktitel-1_text-1_kurztitel-1_inline-1" GUID="bdff7240-266e-4ff3-b311-60342bd1afa2" refersTo="amtliche-abkuerzung" name="attributsemantik-noch-undefiniert">Vereinsgesetz</akn:inline>)</akn:shortTitle>
+                    </akn:p>
+                 </akn:longTitle>
+              </akn:preface>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
     Norm norm = new Norm(toDocument(normString));
 
     // when
@@ -190,24 +190,24 @@ class NormTest {
   void getFRBRname() {
     // given
     String normString =
-        """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                  <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                      <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
-                                      <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="bgbl-1" />
-                                   </akn:FRBRWork>
-                              </akn:identification>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                        <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                        <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="bgbl-1" />
+                     </akn:FRBRWork>
+                </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
 
     Norm norm = new Norm(toDocument(normString));
     String expectedFRBRname = "BGBl. I";
@@ -223,24 +223,24 @@ class NormTest {
   void getFRBRnumber() {
     // given
     String normString =
-        """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                  <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                      <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
-                                      <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="bgbl-1" />
-                                   </akn:FRBRWork>
-                              </akn:identification>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                        <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                        <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="bgbl-1" />
+                     </akn:FRBRWork>
+                </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
 
     Norm norm = new Norm(toDocument(normString));
     String expectedFRBRname = "s593";
@@ -256,24 +256,24 @@ class NormTest {
   void getFRBRnameAlreadyProperlyFormatted() {
     // given
     String normString =
-        """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                  <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                      <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
-                                      <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
-                                   </akn:FRBRWork>
-                              </akn:identification>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                        <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                        <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                     </akn:FRBRWork>
+                </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
 
     Norm norm = new Norm(toDocument(normString));
     String expectedFRBRname = "BGBl. I";
@@ -289,25 +289,25 @@ class NormTest {
   void getPublishingDate() {
     // given
     String normString =
-        """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                  <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                      <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
-                                      <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
-                                      <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
-                                   </akn:FRBRWork>
-                              </akn:identification>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                        <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                        <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                        <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                     </akn:FRBRWork>
+                </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
 
     Norm norm = new Norm(toDocument(normString));
     // when
@@ -321,27 +321,27 @@ class NormTest {
   void getMeta() {
     // given
     String normString =
-        """
-                  <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                  <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                         http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                     <akn:act name="regelungstext">
-                        <!-- Metadaten -->
-                        <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                         <akn:FRBRdate eId="meta-1_ident-1_frbrexpression-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
-                                      </akn:FRBRExpression>
-                                  </akn:identification>
-                        </akn:meta>
-                     </akn:act>
-                  </akn:akomaNtoso>
-                """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                         <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                            <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                               <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                               <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorherige-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                               <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                               <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                               <akn:FRBRdate eId="meta-1_ident-1_frbrexpression-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                            </akn:FRBRExpression>
+                        </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
 
     Norm norm = new Norm(toDocument(normString));
 
@@ -356,16 +356,15 @@ class NormTest {
   void getMetaNotFound() {
     // given
     String normString =
-        """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-             <akn:act name="regelungstext">
-             </akn:act>
-          </akn:akomaNtoso>
-            """
-            .strip();
+      """
+          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+         <akn:act name="regelungstext">
+         </akn:act>
+      </akn:akomaNtoso>
+        """.strip();
 
     Norm norm = new Norm(toDocument(normString));
 
@@ -374,190 +373,194 @@ class NormTest {
 
   private static Stream<Arguments> provideParametersForGetArticles() {
     return Stream.of(
-        Arguments.of(
-            """
-                                                  <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                                                  <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                                     xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                                         http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                                                     <akn:act name="regelungstext">
-                                                        <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                                           <!-- Artikel 1 : Hauptänderung -->
-                                                           <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                                              <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                                                 <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                                                              <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                                                              <!-- Absatz (1) -->
-                                                              <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                                                                 <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                                                                    <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                                                                 </akn:num>
-                                                                 <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                                                    <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                                                       <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                                                             href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                                                    </akn:intro>
-                                                                 </akn:list>
-                                                              </akn:paragraph>
-                                                           </akn:article>
-                                                            <!-- Artikel 3: Geltungszeitregel-->
-                                                            <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                                               <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                                                  <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
-                                                               <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                                                               <!-- Absatz (1) -->
-                                                               <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                                                  <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-                                                                     <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
-                                                                  </akn:num>
-                                                                  <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                                                     <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                                                        nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                                                  </akn:content>
-                                                               </akn:paragraph>
-                                                            </akn:article>
-                                                        </akn:body>
-                                                     </akn:act>
-                                                  </akn:akomaNtoso>
-                            """,
-            "hauptteil-1_art-1",
-            "hauptteil-1_art-3"),
-        Arguments.of(
-            """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                              <akn:section GUID="851e76da-dea2-4d9b-a85a-a90c31358e6e" eId="hauptteil-1_abschnitt-erster">
-                                 <akn:num GUID="15376a15-dcf4-4c11-ad20-f09b134db7f9" eId="hauptteil-1_abschnitt-erster_bezeichnung-1">
-                                    <akn:marker GUID="f26cff1f-7bba-46a0-8c1b-f23bce5c35aa" eId="hauptteil-1_abschnitt-erster_bezeichnung-1_zaehlbez-1" name="erster"/>Erster
-                                    Abschnitt </akn:num>
-                                 <akn:heading GUID="a803190c-9626-421f-9fd4-a904f9e572dd" eId="hauptteil-1_abschnitt-erster_überschrift-1">
-                                    Zusammenarbeit, Aufgaben der Verfassungsschutzbehörden
-                                 </akn:heading>
-                                 <!-- Artikel 1 : Hauptänderung -->
-                                 <akn:article eId="hauptteil-1_abschnitt-erster_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                    <akn:num eId="hauptteil-1_abschnitt-erster_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                       <akn:marker eId="hauptteil-1_abschnitt-erster_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                                    <akn:heading eId="hauptteil-1_abschnitt-erster_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                                    <!-- Absatz (1) -->
-                                    <akn:paragraph eId="hauptteil-1_abschnitt-erster_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                                       <akn:num eId="hauptteil-1_abschnitt-erster_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                                          <akn:marker eId="hauptteil-1_abschnitt-erster_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                                       </akn:num>
-                                       <akn:list eId="hauptteil-1_abschnitt-erster_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                          <akn:intro eId="hauptteil-1_abschnitt-erster_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                             <akn:p eId="hauptteil-1_abschnitt-erster_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                                   href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                          </akn:intro>
-                                       </akn:list>
-                                    </akn:paragraph>
-                                 </akn:article>
-                                 <!-- Artikel 3: Geltungszeitregel-->
-                                 <akn:article eId="hauptteil-1_abschnitt-erster_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                    <akn:num eId="hauptteil-1_abschnitt-erster_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                       <akn:marker eId="hauptteil-1_abschnitt-erster_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
-                                    <akn:heading eId="hauptteil-1_abschnitt-erster_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                                    <!-- Absatz (1) -->
-                                    <akn:paragraph eId="hauptteil-1_abschnitt-erster_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                       <akn:num eId="hauptteil-1_abschnitt-erster_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-                                          <akn:marker eId="hauptteil-1_abschnitt-erster_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
-                                       </akn:num>
-                                       <akn:content eId="hauptteil-1_abschnitt-erster_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                          <akn:p eId="hauptteil-1_abschnitt-erster_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                             nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                       </akn:content>
-                                    </akn:paragraph>
-                                 </akn:article>
-                               </akn:section>
-                            </akn:body>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                      """,
-            "hauptteil-1_abschnitt-erster_art-1",
-            "hauptteil-1_abschnitt-erster_art-3"),
-        Arguments.of(
-            """
-                  <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                             <akn:act name="regelungstext">
-                                <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                  <akn:section GUID="851e76da-dea2-4d9b-a85a-a90c31358e6e" eId="hauptteil-1_abschnitt-erster">
-                                     <akn:num GUID="15376a15-dcf4-4c11-ad20-f09b134db7f9" eId="hauptteil-1_abschnitt-erster_bezeichnung-1">
-                                        <akn:marker GUID="f26cff1f-7bba-46a0-8c1b-f23bce5c35aa" eId="hauptteil-1_abschnitt-erster_bezeichnung-1_zaehlbez-1" name="erster"/>Erster
-                                        Abschnitt </akn:num>
-                                     <akn:heading GUID="a803190c-9626-421f-9fd4-a904f9e572dd" eId="hauptteil-1_abschnitt-erster_überschrift-1">
-                                        Zusammenarbeit, Aufgaben der Verfassungsschutzbehörden
-                                     </akn:heading>
-                                     <!-- Artikel 1 : Hauptänderung -->
-                                     <akn:article eId="hauptteil-1_abschnitt-erster_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                        <akn:num eId="hauptteil-1_abschnitt-erster_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                           <akn:marker eId="hauptteil-1_abschnitt-erster_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                                        <akn:heading eId="hauptteil-1_abschnitt-erster_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                                        <!-- Absatz (1) -->
-                                        <akn:paragraph eId="hauptteil-1_abschnitt-erster_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                                           <akn:num eId="hauptteil-1_abschnitt-erster_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                                              <akn:marker eId="hauptteil-1_abschnitt-erster_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                                           </akn:num>
-                                           <akn:list eId="hauptteil-1_abschnitt-erster_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                              <akn:intro eId="hauptteil-1_abschnitt-erster_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                                 <akn:p eId="hauptteil-1_abschnitt-erster_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                                       href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                              </akn:intro>
-                                              <akn:point GUID="db5af8b9-7a46-4b65-8cc3-b87e8e7674eb" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8">
-                                                                      <akn:num GUID="cc554b9a-e137-48cd-b735-0b6774e6779e" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_bezeichnung-1"><akn:marker GUID="4158a840-27d5-4eee-aa0e-6a5994768cf7" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_bezeichnung-1_zaehlbez-1" name="8"/>8.</akn:num>
-                                                                      <akn:content GUID="2fe9739e-c809-4139-91fa-e111a7674e5b" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1">
-                                                                          <akn:p GUID="5675e613-f44b-4383-a825-1da8673206ae" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1">
-                                                                              <akn:mod GUID="2cbbf69b-9fe9-4996-b989-c10481119472" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1" refersTo="aenderungsbefehl-ersetzen">Das <akn:ref GUID="908f56a9-218c-478f-8bf4-7f915bf6ea59" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_ref-1" href="eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/hauptteil-1_buch-3.xml">3. Buch</akn:ref> wird ersetzt durch: <akn:quotedStructure GUID="5287afa2-cdd1-4d8c-b027-8ca653aa8f19" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1" endQuote="“" startQuote="„">
-                                                                                  <akn:book GUID="bff63266-ee36-4d78-9110-675239af599f" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3">
-                                                                                      <akn:num GUID="ddec4bf9-36d3-4af4-a607-a0acb1ee1bea" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_bezeichnung-1"><akn:marker GUID="d24ffb96-8213-430b-b7d7-dba7fc6ab1f3" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_bezeichnung-1_zaehlbez-1" name="3"/>3. Buch</akn:num>
-                                                                                      <akn:heading GUID="0384394e-3c9f-4355-8580-70280688c64f" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_überschrift-1">Beispiele Teil I</akn:heading>
-                                                                                      <akn:article GUID="c31f4462-545e-4064-af55-d42bb34dacde" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_para-6" period="#meta-1_geltzeiten-1_geltungszeitgr-2">
-                                                                                          <akn:num GUID="6b1085ed-6ac5-4ff3-ac2c-79602af6446f" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_para-6_bezeichnung-1"><akn:marker GUID="ed9a1419-e55d-445b-a1ed-c3906c7cb4bc" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_para-6_bezeichnung-1_zaehlbez-1" name="6"/>§ 6</akn:num>
-                                                                                          <akn:heading GUID="e3f17909-13f5-47e0-8467-e4906b90be2b" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_para-6_überschrift-1">Beispielartikel (neu)</akn:heading>
-                                                                                          <akn:paragraph GUID="d4cfcdd1-d1fd-408a-bf51-0720c852f6b5" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_para-6_abs-1">
-                                                                                              <akn:num GUID="9819cc84-b783-43e7-8185-b00f73748bdd" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_para-6_abs-1_bezeichnung-1"><akn:marker GUID="6e7d886d-34fd-4009-bbe8-06c7ecb57edc" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_para-6_abs-1_bezeichnung-1_zaehlbez-1" name="1"/></akn:num>
-                                                                                              <akn:content GUID="debcb0c7-991d-4823-9397-d55544fb70b0" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_para-6_abs-1_inhalt-1">
-                                                                                                  <akn:p GUID="f6aa96b1-0d31-4b72-8651-5a6bc2b3b1c8" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_para-6_abs-1_inhalt-1_text-1">Im Rahmen des Gesetzes werden klare Regelungen für die Inanspruchnahme von Rechtsmitteln festgelegt.</akn:p>
-                                                                                              </akn:content>
-                                                                                          </akn:paragraph>
-                                                                                      </akn:article>
-                                                                                  </akn:book>
-                                                                              </akn:quotedStructure>
-                                                                              </akn:mod>
-                                                                          </akn:p>
-                                                                      </akn:content>
-                                                                  </akn:point>
-                                           </akn:list>
-                                        </akn:paragraph>
-                                     </akn:article>
-                                     <!-- Artikel 3: Geltungszeitregel-->
-                                     <akn:article eId="hauptteil-1_abschnitt-erster_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                        <akn:num eId="hauptteil-1_abschnitt-erster_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                           <akn:marker eId="hauptteil-1_abschnitt-erster_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
-                                        <akn:heading eId="hauptteil-1_abschnitt-erster_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                                        <!-- Absatz (1) -->
-                                        <akn:paragraph eId="hauptteil-1_abschnitt-erster_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                           <akn:num eId="hauptteil-1_abschnitt-erster_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-                                              <akn:marker eId="hauptteil-1_abschnitt-erster_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
-                                           </akn:num>
-                                           <akn:content eId="hauptteil-1_abschnitt-erster_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                              <akn:p eId="hauptteil-1_abschnitt-erster_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                                 nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                           </akn:content>
-                                        </akn:paragraph>
-                                     </akn:article>
-                                   </akn:section>
-                                </akn:body>
-                             </akn:act>
-                          </akn:akomaNtoso>
-                  """,
-            "hauptteil-1_abschnitt-erster_art-1",
-            "hauptteil-1_abschnitt-erster_art-3"));
+      Arguments.of(
+        """
+                              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+                              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                                 <akn:act name="regelungstext">
+                                    <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                                       <!-- Artikel 1 : Hauptänderung -->
+                                       <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                                          <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                                             <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                                          <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                                          <!-- Absatz (1) -->
+                                          <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                                             <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                                                <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                                             </akn:num>
+                                             <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                                                <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                                                   <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                                         href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                                                </akn:intro>
+                                             </akn:list>
+                                          </akn:paragraph>
+                                       </akn:article>
+                                        <!-- Artikel 3: Geltungszeitregel-->
+                                        <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                                           <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
+                                              <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
+                                           <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+                                           <!-- Absatz (1) -->
+                                           <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
+                                              <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
+                                                 <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
+                                              </akn:num>
+                                              <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
+                                                 <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
+                                                    nach der Verkündung</akn:date> in Kraft. </akn:p>
+                                              </akn:content>
+                                           </akn:paragraph>
+                                        </akn:article>
+                                    </akn:body>
+                                 </akn:act>
+                              </akn:akomaNtoso>
+        """,
+        "hauptteil-1_art-1",
+        "hauptteil-1_art-3"
+      ),
+      Arguments.of(
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                <akn:section GUID="851e76da-dea2-4d9b-a85a-a90c31358e6e" eId="hauptteil-1_abschnitt-erster">
+                   <akn:num GUID="15376a15-dcf4-4c11-ad20-f09b134db7f9" eId="hauptteil-1_abschnitt-erster_bezeichnung-1">
+                      <akn:marker GUID="f26cff1f-7bba-46a0-8c1b-f23bce5c35aa" eId="hauptteil-1_abschnitt-erster_bezeichnung-1_zaehlbez-1" name="erster"/>Erster
+                      Abschnitt </akn:num>
+                   <akn:heading GUID="a803190c-9626-421f-9fd4-a904f9e572dd" eId="hauptteil-1_abschnitt-erster_überschrift-1">
+                      Zusammenarbeit, Aufgaben der Verfassungsschutzbehörden
+                   </akn:heading>
+                   <!-- Artikel 1 : Hauptänderung -->
+                   <akn:article eId="hauptteil-1_abschnitt-erster_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                      <akn:num eId="hauptteil-1_abschnitt-erster_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                         <akn:marker eId="hauptteil-1_abschnitt-erster_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                      <akn:heading eId="hauptteil-1_abschnitt-erster_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                      <!-- Absatz (1) -->
+                      <akn:paragraph eId="hauptteil-1_abschnitt-erster_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                         <akn:num eId="hauptteil-1_abschnitt-erster_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                            <akn:marker eId="hauptteil-1_abschnitt-erster_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                         </akn:num>
+                         <akn:list eId="hauptteil-1_abschnitt-erster_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                            <akn:intro eId="hauptteil-1_abschnitt-erster_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                               <akn:p eId="hauptteil-1_abschnitt-erster_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                     href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                            </akn:intro>
+                         </akn:list>
+                      </akn:paragraph>
+                   </akn:article>
+                   <!-- Artikel 3: Geltungszeitregel-->
+                   <akn:article eId="hauptteil-1_abschnitt-erster_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                      <akn:num eId="hauptteil-1_abschnitt-erster_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
+                         <akn:marker eId="hauptteil-1_abschnitt-erster_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
+                      <akn:heading eId="hauptteil-1_abschnitt-erster_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+                      <!-- Absatz (1) -->
+                      <akn:paragraph eId="hauptteil-1_abschnitt-erster_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
+                         <akn:num eId="hauptteil-1_abschnitt-erster_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
+                            <akn:marker eId="hauptteil-1_abschnitt-erster_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
+                         </akn:num>
+                         <akn:content eId="hauptteil-1_abschnitt-erster_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
+                            <akn:p eId="hauptteil-1_abschnitt-erster_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
+                               nach der Verkündung</akn:date> in Kraft. </akn:p>
+                         </akn:content>
+                      </akn:paragraph>
+                   </akn:article>
+                 </akn:section>
+              </akn:body>
+           </akn:act>
+        </akn:akomaNtoso>
+        """,
+        "hauptteil-1_abschnitt-erster_art-1",
+        "hauptteil-1_abschnitt-erster_art-3"
+      ),
+      Arguments.of(
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+                <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                       http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                   <akn:act name="regelungstext">
+                      <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                        <akn:section GUID="851e76da-dea2-4d9b-a85a-a90c31358e6e" eId="hauptteil-1_abschnitt-erster">
+                           <akn:num GUID="15376a15-dcf4-4c11-ad20-f09b134db7f9" eId="hauptteil-1_abschnitt-erster_bezeichnung-1">
+                              <akn:marker GUID="f26cff1f-7bba-46a0-8c1b-f23bce5c35aa" eId="hauptteil-1_abschnitt-erster_bezeichnung-1_zaehlbez-1" name="erster"/>Erster
+                              Abschnitt </akn:num>
+                           <akn:heading GUID="a803190c-9626-421f-9fd4-a904f9e572dd" eId="hauptteil-1_abschnitt-erster_überschrift-1">
+                              Zusammenarbeit, Aufgaben der Verfassungsschutzbehörden
+                           </akn:heading>
+                           <!-- Artikel 1 : Hauptänderung -->
+                           <akn:article eId="hauptteil-1_abschnitt-erster_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                              <akn:num eId="hauptteil-1_abschnitt-erster_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                                 <akn:marker eId="hauptteil-1_abschnitt-erster_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                              <akn:heading eId="hauptteil-1_abschnitt-erster_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                              <!-- Absatz (1) -->
+                              <akn:paragraph eId="hauptteil-1_abschnitt-erster_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                                 <akn:num eId="hauptteil-1_abschnitt-erster_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                                    <akn:marker eId="hauptteil-1_abschnitt-erster_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                                 </akn:num>
+                                 <akn:list eId="hauptteil-1_abschnitt-erster_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                                    <akn:intro eId="hauptteil-1_abschnitt-erster_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                                       <akn:p eId="hauptteil-1_abschnitt-erster_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                             href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                                    </akn:intro>
+                                    <akn:point GUID="db5af8b9-7a46-4b65-8cc3-b87e8e7674eb" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8">
+                                                            <akn:num GUID="cc554b9a-e137-48cd-b735-0b6774e6779e" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_bezeichnung-1"><akn:marker GUID="4158a840-27d5-4eee-aa0e-6a5994768cf7" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_bezeichnung-1_zaehlbez-1" name="8"/>8.</akn:num>
+                                                            <akn:content GUID="2fe9739e-c809-4139-91fa-e111a7674e5b" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1">
+                                                                <akn:p GUID="5675e613-f44b-4383-a825-1da8673206ae" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1">
+                                                                    <akn:mod GUID="2cbbf69b-9fe9-4996-b989-c10481119472" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1" refersTo="aenderungsbefehl-ersetzen">Das <akn:ref GUID="908f56a9-218c-478f-8bf4-7f915bf6ea59" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_ref-1" href="eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1/hauptteil-1_buch-3.xml">3. Buch</akn:ref> wird ersetzt durch: <akn:quotedStructure GUID="5287afa2-cdd1-4d8c-b027-8ca653aa8f19" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1" endQuote="“" startQuote="„">
+                                                                        <akn:book GUID="bff63266-ee36-4d78-9110-675239af599f" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3">
+                                                                            <akn:num GUID="ddec4bf9-36d3-4af4-a607-a0acb1ee1bea" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_bezeichnung-1"><akn:marker GUID="d24ffb96-8213-430b-b7d7-dba7fc6ab1f3" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_bezeichnung-1_zaehlbez-1" name="3"/>3. Buch</akn:num>
+                                                                            <akn:heading GUID="0384394e-3c9f-4355-8580-70280688c64f" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_überschrift-1">Beispiele Teil I</akn:heading>
+                                                                            <akn:article GUID="c31f4462-545e-4064-af55-d42bb34dacde" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_para-6" period="#meta-1_geltzeiten-1_geltungszeitgr-2">
+                                                                                <akn:num GUID="6b1085ed-6ac5-4ff3-ac2c-79602af6446f" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_para-6_bezeichnung-1"><akn:marker GUID="ed9a1419-e55d-445b-a1ed-c3906c7cb4bc" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_para-6_bezeichnung-1_zaehlbez-1" name="6"/>§ 6</akn:num>
+                                                                                <akn:heading GUID="e3f17909-13f5-47e0-8467-e4906b90be2b" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_para-6_überschrift-1">Beispielartikel (neu)</akn:heading>
+                                                                                <akn:paragraph GUID="d4cfcdd1-d1fd-408a-bf51-0720c852f6b5" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_para-6_abs-1">
+                                                                                    <akn:num GUID="9819cc84-b783-43e7-8185-b00f73748bdd" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_para-6_abs-1_bezeichnung-1"><akn:marker GUID="6e7d886d-34fd-4009-bbe8-06c7ecb57edc" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_para-6_abs-1_bezeichnung-1_zaehlbez-1" name="1"/></akn:num>
+                                                                                    <akn:content GUID="debcb0c7-991d-4823-9397-d55544fb70b0" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_para-6_abs-1_inhalt-1">
+                                                                                        <akn:p GUID="f6aa96b1-0d31-4b72-8651-5a6bc2b3b1c8" eId="hauptteil-1_para-1_abs-1_untergl-1_listenelem-8_inhalt-1_text-1_ändbefehl-1_quotstruct-1_buch-3_para-6_abs-1_inhalt-1_text-1">Im Rahmen des Gesetzes werden klare Regelungen für die Inanspruchnahme von Rechtsmitteln festgelegt.</akn:p>
+                                                                                    </akn:content>
+                                                                                </akn:paragraph>
+                                                                            </akn:article>
+                                                                        </akn:book>
+                                                                    </akn:quotedStructure>
+                                                                    </akn:mod>
+                                                                </akn:p>
+                                                            </akn:content>
+                                                        </akn:point>
+                                 </akn:list>
+                              </akn:paragraph>
+                           </akn:article>
+                           <!-- Artikel 3: Geltungszeitregel-->
+                           <akn:article eId="hauptteil-1_abschnitt-erster_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                              <akn:num eId="hauptteil-1_abschnitt-erster_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
+                                 <akn:marker eId="hauptteil-1_abschnitt-erster_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
+                              <akn:heading eId="hauptteil-1_abschnitt-erster_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+                              <!-- Absatz (1) -->
+                              <akn:paragraph eId="hauptteil-1_abschnitt-erster_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
+                                 <akn:num eId="hauptteil-1_abschnitt-erster_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
+                                    <akn:marker eId="hauptteil-1_abschnitt-erster_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
+                                 </akn:num>
+                                 <akn:content eId="hauptteil-1_abschnitt-erster_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
+                                    <akn:p eId="hauptteil-1_abschnitt-erster_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
+                                       nach der Verkündung</akn:date> in Kraft. </akn:p>
+                                 </akn:content>
+                              </akn:paragraph>
+                           </akn:article>
+                         </akn:section>
+                      </akn:body>
+                   </akn:act>
+                </akn:akomaNtoso>
+        """,
+        "hauptteil-1_abschnitt-erster_art-1",
+        "hauptteil-1_abschnitt-erster_art-3"
+      )
+    );
   }
 
   @ParameterizedTest
@@ -578,7 +581,7 @@ class NormTest {
     assertThat(actualArticles.getFirst().getEnumeration()).contains("1");
     assertThat(actualArticles.get(0).getEid()).contains(firstArticleEid);
     assertThat(actualArticles.get(0).getAffectedDocumentEli())
-        .contains("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1");
+      .contains("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1");
 
     assertThat(actualArticles.get(1).getHeading()).contains(secondExpectedHeading);
     assertThat(actualArticles.get(1).getEnumeration()).contains("3");
@@ -590,17 +593,17 @@ class NormTest {
   void returnsEmptyListIfNoArticlesAreFound() {
     // given
     String normString =
-        """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                            </akn:body>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+              </akn:body>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
 
     Norm norm = new Norm(toDocument(normString));
 
@@ -615,25 +618,25 @@ class NormTest {
   void equalsShouldEqualWithSameXml() {
     // given
     String xml =
-        """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                  <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                      <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
-                                      <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
-                                      <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
-                                   </akn:FRBRWork>
-                              </akn:identification>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                        <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                        <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                        <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                     </akn:FRBRWork>
+                </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
 
     Norm norm1 = new Norm(toDocument(xml));
     Norm norm2 = new Norm(toDocument(xml));
@@ -646,46 +649,46 @@ class NormTest {
   void equalsShouldNotEqualWithDifferentXml() {
     // given
     String xml1 =
-        """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                  <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                      <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
-                                      <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
-                                      <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
-                                   </akn:FRBRWork>
-                              </akn:identification>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                        <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                        <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                        <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                     </akn:FRBRWork>
+                </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
 
     String xml2 =
-        """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                  <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                      <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
-                                      <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
-                                      <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-06" name="verkuendungsfassung" />
-                                   </akn:FRBRWork>
-                              </akn:identification>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                        <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                        <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                        <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-06" name="verkuendungsfassung" />
+                     </akn:FRBRWork>
+                </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
 
     Norm norm1 = new Norm(toDocument(xml1));
     Norm norm2 = new Norm(toDocument(xml2));
@@ -698,25 +701,25 @@ class NormTest {
   void hashCodeShouldBeTheSameWithSameXml() {
     // given
     String xml =
-        """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                  <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                      <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
-                                      <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
-                                      <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
-                                   </akn:FRBRWork>
-                              </akn:identification>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                        <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                        <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                        <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                     </akn:FRBRWork>
+                </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
 
     Norm norm1 = new Norm(toDocument(xml));
     Norm norm2 = new Norm(toDocument(xml));
@@ -729,46 +732,46 @@ class NormTest {
   void hashCodeShouldBeDifferentWithDifferentXml() {
     // given
     String xml1 =
-        """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                  <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                      <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
-                                      <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
-                                      <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
-                                   </akn:FRBRWork>
-                              </akn:identification>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                        <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                        <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                        <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                     </akn:FRBRWork>
+                </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
 
     String xml2 =
-        """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                  <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                      <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
-                                      <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
-                                      <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-06" name="verkuendungsfassung" />
-                                   </akn:FRBRWork>
-                              </akn:identification>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                        <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                        <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                        <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-06" name="verkuendungsfassung" />
+                     </akn:FRBRWork>
+                </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
 
     Norm norm1 = new Norm(toDocument(xml1));
     Norm norm2 = new Norm(toDocument(xml2));
@@ -780,102 +783,100 @@ class NormTest {
   @Test
   void extractTimeBoundariesFromXml() {
     String xml =
-        """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                               </akn:lifecycle>
-                               <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                           <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                              <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                           </akn:temporalGroup>
-                               </akn:temporalData>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """
-            .strip();
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                 </akn:lifecycle>
+                 <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                             <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                                <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                             </akn:temporalGroup>
+                 </akn:temporalData>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """.strip();
 
     Norm norm = new Norm(toDocument(xml));
 
     List<TimeBoundary> actualBoundaries = norm.getTimeBoundaries();
 
     assertThat(actualBoundaries.getFirst().getEventRef().getDate())
-        .contains(LocalDate.parse("2023-12-30"));
+      .contains(LocalDate.parse("2023-12-30"));
     assertThat(actualBoundaries.getFirst().getEventRefEid())
-        .contains("meta-1_lebzykl-1_ereignis-2");
+      .contains("meta-1_lebzykl-1_ereignis-2");
   }
 
   @Test
   void extractTimeBoundariesFromTemporalGroups() {
     String xml =
-        """
-                          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                             <akn:act name="regelungstext">
-                                <!-- Metadaten -->
-                                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                   <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                   </akn:lifecycle>
-                                   <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                               <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                                  <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                               </akn:temporalGroup>
-                                   </akn:temporalData>
-                                </akn:meta>
-                             </akn:act>
-                          </akn:akomaNtoso>
-                        """
-            .strip();
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                 </akn:lifecycle>
+                 <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                             <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                                <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                             </akn:temporalGroup>
+                 </akn:temporalData>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """.strip();
 
     Norm norm = new Norm(toDocument(xml));
 
-    List<TimeBoundary> actualBoundaries =
-        norm.getTimeBoundaries(norm.getMeta().getTemporalData().getTemporalGroups());
+    List<TimeBoundary> actualBoundaries = norm.getTimeBoundaries(
+      norm.getMeta().getTemporalData().getTemporalGroups()
+    );
 
     assertThat(actualBoundaries.getFirst().getEventRef().getDate())
-        .contains(LocalDate.parse("2023-12-30"));
+      .contains(LocalDate.parse("2023-12-30"));
     assertThat(actualBoundaries.getFirst().getEventRefEid())
-        .contains("meta-1_lebzykl-1_ereignis-2");
+      .contains("meta-1_lebzykl-1_ereignis-2");
   }
 
   @Test
   void getTimeBoundariesEmpty() {
     String xml =
-        """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                               </akn:lifecycle>
-                               <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                               </akn:temporalData>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """
-            .strip();
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                 </akn:lifecycle>
+                 <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                 </akn:temporalData>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """.strip();
 
     Norm norm = new Norm(toDocument(xml));
     List<TimeBoundary> timeBoundaries = norm.getTimeBoundaries();
@@ -885,30 +886,29 @@ class NormTest {
   @Test
   void addTimeBoundary() {
     String xml =
-        """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                               </akn:lifecycle>
-                               <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                           <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                              <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                           </akn:temporalGroup>
-                               </akn:temporalData>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """
-            .strip();
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                 </akn:lifecycle>
+                 <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                             <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                                <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                             </akn:temporalGroup>
+                 </akn:temporalData>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """.strip();
 
     Norm norm = new Norm(toDocument(xml));
     norm.addTimeBoundary(LocalDate.parse("2024-01-02"), EventRefType.GENERATION);
@@ -917,152 +917,163 @@ class NormTest {
 
     // old one still there
     assertThat(timeBoundaries.get(0).getEventRef().getDate())
-        .contains(LocalDate.parse("2023-12-30"));
+      .contains(LocalDate.parse("2023-12-30"));
     assertThat(timeBoundaries.get(0).getEventRefEid().get())
-        .contains("meta-1_lebzykl-1_ereignis-2");
+      .contains("meta-1_lebzykl-1_ereignis-2");
     assertThat(
-            timeBoundaries
-                .get(0)
-                .getTimeInterval()
-                .getNode()
-                .getParentNode()
-                .getAttributes()
-                .getNamedItem("eId")
-                .getNodeValue())
-        .contains("meta-1_geltzeiten-1_geltungszeitgr-1");
+      timeBoundaries
+        .get(0)
+        .getTimeInterval()
+        .getNode()
+        .getParentNode()
+        .getAttributes()
+        .getNamedItem("eId")
+        .getNodeValue()
+    )
+      .contains("meta-1_geltzeiten-1_geltungszeitgr-1");
     assertThat(
-            timeBoundaries
-                .get(0)
-                .getTimeInterval()
-                .getNode()
-                .getParentNode()
-                .getAttributes()
-                .getNamedItem("GUID")
-                .getNodeValue())
-        .contains("ac311ee1-33d3-4b9b-a974-776e55a88396");
+      timeBoundaries
+        .get(0)
+        .getTimeInterval()
+        .getNode()
+        .getParentNode()
+        .getAttributes()
+        .getNamedItem("GUID")
+        .getNodeValue()
+    )
+      .contains("ac311ee1-33d3-4b9b-a974-776e55a88396");
     assertThat(timeBoundaries.get(0).getTimeIntervalEid().get())
-        .contains("meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1");
+      .contains("meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1");
     assertThat(
-            timeBoundaries
-                .get(0)
-                .getTimeInterval()
-                .getNode()
-                .getAttributes()
-                .getNamedItem("GUID")
-                .getNodeValue())
-        .contains("ca9f53aa-d374-4bec-aca3-fff4e3485179");
+      timeBoundaries
+        .get(0)
+        .getTimeInterval()
+        .getNode()
+        .getAttributes()
+        .getNamedItem("GUID")
+        .getNodeValue()
+    )
+      .contains("ca9f53aa-d374-4bec-aca3-fff4e3485179");
     assertThat(
-            timeBoundaries
-                .get(0)
-                .getTimeInterval()
-                .getNode()
-                .getAttributes()
-                .getNamedItem("refersTo")
-                .getNodeValue())
-        .contains("geltungszeit");
+      timeBoundaries
+        .get(0)
+        .getTimeInterval()
+        .getNode()
+        .getAttributes()
+        .getNamedItem("refersTo")
+        .getNodeValue()
+    )
+      .contains("geltungszeit");
     assertThat(
-            timeBoundaries
-                .get(0)
-                .getTimeInterval()
-                .getNode()
-                .getAttributes()
-                .getNamedItem("start")
-                .getNodeValue())
-        .contains("#" + timeBoundaries.get(0).getEventRefEid().get());
+      timeBoundaries
+        .get(0)
+        .getTimeInterval()
+        .getNode()
+        .getAttributes()
+        .getNamedItem("start")
+        .getNodeValue()
+    )
+      .contains("#" + timeBoundaries.get(0).getEventRefEid().get());
 
     // new one added
     assertThat(timeBoundaries.get(1).getEventRef().getDate())
-        .contains(LocalDate.parse("2024-01-02"));
+      .contains(LocalDate.parse("2024-01-02"));
     assertThat(timeBoundaries.get(1).getEventRefEid().get())
-        .contains("meta-1_lebzykl-1_ereignis-3");
+      .contains("meta-1_lebzykl-1_ereignis-3");
     assertThat(
-            timeBoundaries
-                .get(1)
-                .getTimeInterval()
-                .getNode()
-                .getParentNode()
-                .getAttributes()
-                .getNamedItem("eId")
-                .getNodeValue())
-        .contains("meta-1_geltzeiten-1_geltungszeitgr-2");
+      timeBoundaries
+        .get(1)
+        .getTimeInterval()
+        .getNode()
+        .getParentNode()
+        .getAttributes()
+        .getNamedItem("eId")
+        .getNodeValue()
+    )
+      .contains("meta-1_geltzeiten-1_geltungszeitgr-2");
     assertThat(
-            timeBoundaries
-                .get(1)
-                .getTimeInterval()
-                .getNode()
-                .getParentNode()
-                .getAttributes()
-                .getNamedItem("GUID")
-                .getNodeValue())
-        .isNotEmpty();
+      timeBoundaries
+        .get(1)
+        .getTimeInterval()
+        .getNode()
+        .getParentNode()
+        .getAttributes()
+        .getNamedItem("GUID")
+        .getNodeValue()
+    )
+      .isNotEmpty();
     assertThat(timeBoundaries.get(1).getTimeIntervalEid().get())
-        .contains("meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1");
+      .contains("meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1");
     assertThat(
-            timeBoundaries
-                .get(1)
-                .getTimeInterval()
-                .getNode()
-                .getAttributes()
-                .getNamedItem("GUID")
-                .getNodeValue())
-        .isNotEmpty();
+      timeBoundaries
+        .get(1)
+        .getTimeInterval()
+        .getNode()
+        .getAttributes()
+        .getNamedItem("GUID")
+        .getNodeValue()
+    )
+      .isNotEmpty();
     assertThat(
-            timeBoundaries
-                .get(1)
-                .getTimeInterval()
-                .getNode()
-                .getAttributes()
-                .getNamedItem("refersTo")
-                .getNodeValue())
-        .contains("geltungszeit");
+      timeBoundaries
+        .get(1)
+        .getTimeInterval()
+        .getNode()
+        .getAttributes()
+        .getNamedItem("refersTo")
+        .getNodeValue()
+    )
+      .contains("geltungszeit");
     assertThat(
-            timeBoundaries
-                .get(1)
-                .getTimeInterval()
-                .getNode()
-                .getAttributes()
-                .getNamedItem("start")
-                .getNodeValue())
-        .contains("#" + timeBoundaries.get(1).getEventRefEid().get());
+      timeBoundaries
+        .get(1)
+        .getTimeInterval()
+        .getNode()
+        .getAttributes()
+        .getNamedItem("start")
+        .getNodeValue()
+    )
+      .contains("#" + timeBoundaries.get(1).getEventRefEid().get());
   }
 
   @Test
   void deleteTimeBoundary() {
     String xml =
-        """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2024-01-02"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                               </akn:lifecycle>
-                               <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                     <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                     </akn:temporalGroup>
-                                     <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
-                                     </akn:temporalGroup>
-                               </akn:temporalData>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """
-            .strip();
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2024-01-02"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                 </akn:lifecycle>
+                 <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                       <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                       </akn:temporalGroup>
+                       <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
+                       </akn:temporalGroup>
+                 </akn:temporalData>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """.strip();
 
     Norm norm = new Norm(toDocument(xml));
 
-    TimeBoundaryChangeData timeBoundaryToDelete =
-        new TimeBoundaryChangeData("meta-1_lebzykl-1_ereignis-3", LocalDate.parse("2024-01-02"));
+    TimeBoundaryChangeData timeBoundaryToDelete = new TimeBoundaryChangeData(
+      "meta-1_lebzykl-1_ereignis-3",
+      LocalDate.parse("2024-01-02")
+    );
     norm.deleteTimeBoundary(timeBoundaryToDelete);
 
     List<TimeBoundary> timeBoundaries = norm.getTimeBoundaries();
@@ -1070,58 +1081,63 @@ class NormTest {
     // old one still there
     assertThat(timeBoundaries).hasSize(1);
     assertThat(timeBoundaries.get(0).getEventRef().getDate())
-        .contains(LocalDate.parse("2023-12-30"));
+      .contains(LocalDate.parse("2023-12-30"));
     assertThat(timeBoundaries.get(0).getEventRefEid().get())
-        .contains("meta-1_lebzykl-1_ereignis-2");
+      .contains("meta-1_lebzykl-1_ereignis-2");
     assertThat(
-            timeBoundaries
-                .get(0)
-                .getTimeInterval()
-                .getNode()
-                .getParentNode()
-                .getAttributes()
-                .getNamedItem("eId")
-                .getNodeValue())
-        .contains("meta-1_geltzeiten-1_geltungszeitgr-1");
+      timeBoundaries
+        .get(0)
+        .getTimeInterval()
+        .getNode()
+        .getParentNode()
+        .getAttributes()
+        .getNamedItem("eId")
+        .getNodeValue()
+    )
+      .contains("meta-1_geltzeiten-1_geltungszeitgr-1");
     assertThat(
-            timeBoundaries
-                .get(0)
-                .getTimeInterval()
-                .getNode()
-                .getParentNode()
-                .getAttributes()
-                .getNamedItem("GUID")
-                .getNodeValue())
-        .contains("ac311ee1-33d3-4b9b-a974-776e55a88396");
+      timeBoundaries
+        .get(0)
+        .getTimeInterval()
+        .getNode()
+        .getParentNode()
+        .getAttributes()
+        .getNamedItem("GUID")
+        .getNodeValue()
+    )
+      .contains("ac311ee1-33d3-4b9b-a974-776e55a88396");
     assertThat(timeBoundaries.get(0).getTimeIntervalEid().get())
-        .contains("meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1");
+      .contains("meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1");
     assertThat(
-            timeBoundaries
-                .get(0)
-                .getTimeInterval()
-                .getNode()
-                .getAttributes()
-                .getNamedItem("GUID")
-                .getNodeValue())
-        .contains("ca9f53aa-d374-4bec-aca3-fff4e3485179");
+      timeBoundaries
+        .get(0)
+        .getTimeInterval()
+        .getNode()
+        .getAttributes()
+        .getNamedItem("GUID")
+        .getNodeValue()
+    )
+      .contains("ca9f53aa-d374-4bec-aca3-fff4e3485179");
     assertThat(
-            timeBoundaries
-                .get(0)
-                .getTimeInterval()
-                .getNode()
-                .getAttributes()
-                .getNamedItem("refersTo")
-                .getNodeValue())
-        .contains("geltungszeit");
+      timeBoundaries
+        .get(0)
+        .getTimeInterval()
+        .getNode()
+        .getAttributes()
+        .getNamedItem("refersTo")
+        .getNodeValue()
+    )
+      .contains("geltungszeit");
     assertThat(
-            timeBoundaries
-                .get(0)
-                .getTimeInterval()
-                .getNode()
-                .getAttributes()
-                .getNamedItem("start")
-                .getNodeValue())
-        .contains("#" + timeBoundaries.get(0).getEventRefEid().get());
+      timeBoundaries
+        .get(0)
+        .getTimeInterval()
+        .getNode()
+        .getAttributes()
+        .getNamedItem("start")
+        .getNodeValue()
+    )
+      .contains("#" + timeBoundaries.get(0).getEventRefEid().get());
   }
 
   @Test
@@ -1135,7 +1151,7 @@ class NormTest {
     // then
     assertThat(mods).hasSize(1);
     assertThat(mods.getFirst().getEid())
-        .contains("hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1");
+      .contains("hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1");
   }
 
   @Test
@@ -1176,26 +1192,29 @@ class NormTest {
 
   @Nested
   class createElementWithEidAndGuid {
+
     @Test
     void itShouldCreatesANewElement() {
       // given
       Norm norm = NormFixtures.loadFromDisk("SimpleNorm.xml");
-      Node parentNode =
-          NodeParser.getNodeFromExpression("//act/meta", norm.getDocument()).orElseThrow();
+      Node parentNode = NodeParser
+        .getNodeFromExpression("//act/meta", norm.getDocument())
+        .orElseThrow();
 
       // when
       final Node createdNode = NodeCreator.createElementWithEidAndGuid("akn:analysis", parentNode);
 
       // then
       assertThat(NodeParser.getNodeFromExpression("//act/meta/analysis", norm.getDocument()))
-          .contains(createdNode);
+        .contains(createdNode);
       assertThat(NodeParser.getValueFromExpression("@eId", createdNode))
-          .contains("meta-1_analysis-1");
+        .contains("meta-1_analysis-1");
     }
   }
 
   @Nested
   class getOrCreateAnalysisNode {
+
     @Test
     void itShouldCreatesTheAnalysisNodeIfItDoesNotExist() {
       // given
@@ -1207,12 +1226,13 @@ class NormTest {
       // then
       assertThat(analysis).isNotNull();
       assertThat(NodeParser.getNodeFromExpression("//act/meta/analysis", norm.getDocument()))
-          .contains(analysis.getNode());
+        .contains(analysis.getNode());
     }
   }
 
   @Nested
   class getOrCreateTemporalDataNode {
+
     @Test
     void itShouldCreatesTheTemporalDataNodeIfItDoesNotExist() {
       // given
@@ -1224,7 +1244,7 @@ class NormTest {
       // then
       assertThat(temporalData).isNotNull();
       assertThat(NodeParser.getNodeFromExpression("//act//temporalData", norm.getDocument()))
-          .contains(temporalData.getNode());
+        .contains(temporalData.getNode());
     }
 
     @Test
@@ -1238,12 +1258,13 @@ class NormTest {
       // then
       assertThat(temporalData).isNotNull();
       assertThat(NodeParser.getValueFromExpression("@GUID", temporalData.getNode()))
-          .contains("2fcdfa3e-1460-4ef4-b22b-5ff4a897538f");
+        .contains("2fcdfa3e-1460-4ef4-b22b-5ff4a897538f");
     }
   }
 
   @Nested
   class deleteByEId {
+
     @Test
     void itShouldDeleteTheNodeOfTheEId() {
       // given
@@ -1259,6 +1280,7 @@ class NormTest {
 
   @Nested
   class deleteTemporalGroupIfUnused {
+
     @Test
     void itShouldDeleteTemporalGroupIfUnused() {
       // given
@@ -1288,6 +1310,7 @@ class NormTest {
 
   @Nested
   class deleteEventRefIfUnused {
+
     @Test
     void itShouldDeleteEventRefIfUnused() {
       // given
@@ -1300,9 +1323,12 @@ class NormTest {
 
       // then
       assertThat(
-              NodeParser.getNodeFromExpression(
-                  "//*[@eId='meta-1_lebzykl-1_ereignis-1']", norm.getDocument()))
-          .isEmpty();
+        NodeParser.getNodeFromExpression(
+          "//*[@eId='meta-1_lebzykl-1_ereignis-1']",
+          norm.getDocument()
+        )
+      )
+        .isEmpty();
     }
 
     @Test
@@ -1311,17 +1337,23 @@ class NormTest {
       Norm norm = NormFixtures.loadFromDisk("NormWithMods.xml");
 
       assertThat(
-              NodeParser.getNodeFromExpression(
-                  "//*[@eId='meta-1_lebzykl-1_ereignis-2']", norm.getDocument()))
-          .isNotNull();
+        NodeParser.getNodeFromExpression(
+          "//*[@eId='meta-1_lebzykl-1_ereignis-2']",
+          norm.getDocument()
+        )
+      )
+        .isNotNull();
       // when
       norm.deleteEventRefIfUnused("meta-1_lebzykl-1_ereignis-2");
 
       // then
       assertThat(
-              NodeParser.getNodeFromExpression(
-                  "//*[@eId='meta-1_lebzykl-1_ereignis-2']", norm.getDocument()))
-          .isNotNull();
+        NodeParser.getNodeFromExpression(
+          "//*[@eId='meta-1_lebzykl-1_ereignis-2']",
+          norm.getDocument()
+        )
+      )
+        .isNotNull();
     }
   }
 
@@ -1329,44 +1361,45 @@ class NormTest {
   void getNodeByEId() {
     // given
     String normString =
-        """
-                        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                    <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                              http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                        <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                <akn:analysis eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
-                                    <akn:activeModifications eId="meta-1_analysis-1_activemod-1" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3ac">
-                                        <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-2" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
-                                            <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-2_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
-                                            <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-2_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
-                                            <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-2_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
-                                        </akn:textualMod>
-                                    </akn:activeModifications>
-                                    <akn:activeModifications eId="meta-1_analysis-1_activemod-2" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3a2">
-                                        <akn:textualMod eId="meta-1_analysis-1_activemod-2_textualmod-1" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
-                                            <akn:source eId="meta-1_analysis-1_activemod-2_textualmod-1_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
-                                            <akn:destination eId="meta-1_analysis-1_activemod-2_textualmod-1_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
-                                            <akn:force eId="meta-1_analysis-1_activemod-2_textualmod-1_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
-                                        </akn:textualMod>
-                                    </akn:activeModifications>
-                                </akn:analysis>
-                            </akn:meta>
-                        </akn:act>
-                    </akn:akomaNtoso>
-                    """;
+      """
+          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                                http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+          <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                  <akn:analysis eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
+                      <akn:activeModifications eId="meta-1_analysis-1_activemod-1" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3ac">
+                          <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-2" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
+                              <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-2_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
+                              <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-2_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
+                              <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-2_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
+                          </akn:textualMod>
+                      </akn:activeModifications>
+                      <akn:activeModifications eId="meta-1_analysis-1_activemod-2" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3a2">
+                          <akn:textualMod eId="meta-1_analysis-1_activemod-2_textualmod-1" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
+                              <akn:source eId="meta-1_analysis-1_activemod-2_textualmod-1_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
+                              <akn:destination eId="meta-1_analysis-1_activemod-2_textualmod-1_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
+                              <akn:force eId="meta-1_analysis-1_activemod-2_textualmod-1_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
+                          </akn:textualMod>
+                      </akn:activeModifications>
+                  </akn:analysis>
+              </akn:meta>
+          </akn:act>
+      </akn:akomaNtoso>
+      """;
 
     Norm norm = new Norm(toDocument(normString));
 
     // when
-    final Optional<Node> textualMod =
-        norm.getNodeByEId("meta-1_analysis-1_activemod-2_textualmod-1");
+    final Optional<Node> textualMod = norm.getNodeByEId(
+      "meta-1_analysis-1_activemod-2_textualmod-1"
+    );
 
     // then
     assertThat(textualMod).isPresent();
     assertThat(textualMod.get().getAttributes().getNamedItem("GUID").getNodeValue())
-        .contains("8992dd02-ab87-42e8-bee2-86b76f587f81");
+      .contains("8992dd02-ab87-42e8-bee2-86b76f587f81");
   }
 
   @Nested
@@ -1376,39 +1409,40 @@ class NormTest {
     void getNumberOfNodesWithEidReturnsZero() {
       // given
       String normString =
-          """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                                http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                          <akn:act name="regelungstext">
-                              <!-- Metadaten -->
-                              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                  <akn:analysis eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
-                                      <akn:activeModifications eId="meta-1_analysis-1_activemod-1" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3ac">
-                                          <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-1" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
-                                              <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-1_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
-                                              <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-1_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
-                                              <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-1_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
-                                          </akn:textualMod>
-                                      </akn:activeModifications>
-                                      <akn:activeModifications eId="meta-1_analysis-1_activemod-2" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3a2">
-                                          <akn:textualMod eId="meta-1_analysis-1_activemod-2_textualmod-1" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
-                                              <akn:source eId="meta-1_analysis-1_activemod-2_textualmod-1_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-2"/>
-                                              <akn:destination eId="meta-1_analysis-1_activemod-2_textualmod-1_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
-                                              <akn:force eId="meta-1_analysis-1_activemod-2_textualmod-1_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-2"/>
-                                          </akn:textualMod>
-                                      </akn:activeModifications>
-                                  </akn:analysis>
-                              </akn:meta>
-                          </akn:act>
-                      </akn:akomaNtoso>
-                      """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                                  http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+            <akn:act name="regelungstext">
+                <!-- Metadaten -->
+                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                    <akn:analysis eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
+                        <akn:activeModifications eId="meta-1_analysis-1_activemod-1" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3ac">
+                            <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-1" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
+                                <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-1_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
+                                <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-1_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
+                                <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-1_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
+                            </akn:textualMod>
+                        </akn:activeModifications>
+                        <akn:activeModifications eId="meta-1_analysis-1_activemod-2" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3a2">
+                            <akn:textualMod eId="meta-1_analysis-1_activemod-2_textualmod-1" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
+                                <akn:source eId="meta-1_analysis-1_activemod-2_textualmod-1_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-2"/>
+                                <akn:destination eId="meta-1_analysis-1_activemod-2_textualmod-1_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
+                                <akn:force eId="meta-1_analysis-1_activemod-2_textualmod-1_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-2"/>
+                            </akn:textualMod>
+                        </akn:activeModifications>
+                    </akn:analysis>
+                </akn:meta>
+            </akn:act>
+        </akn:akomaNtoso>
+        """;
 
       Norm norm = new Norm(toDocument(normString));
 
       // when
-      final int textualMod =
-          norm.getNumberOfNodesWithEid("meta-1_analysis-1_activemod-3_textualmod-1");
+      final int textualMod = norm.getNumberOfNodesWithEid(
+        "meta-1_analysis-1_activemod-3_textualmod-1"
+      );
 
       // then
       assertThat(textualMod).isZero();
@@ -1418,39 +1452,40 @@ class NormTest {
     void getNumberOfNodesWithEidReturnsOne() {
       // given
       String normString =
-          """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                                http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                          <akn:act name="regelungstext">
-                              <!-- Metadaten -->
-                              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                  <akn:analysis eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
-                                      <akn:activeModifications eId="meta-1_analysis-1_activemod-1" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3ac">
-                                          <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-1" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
-                                              <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-1_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
-                                              <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-1_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
-                                              <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-1_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
-                                          </akn:textualMod>
-                                      </akn:activeModifications>
-                                      <akn:activeModifications eId="meta-1_analysis-1_activemod-2" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3a2">
-                                          <akn:textualMod eId="meta-1_analysis-1_activemod-2_textualmod-1" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
-                                              <akn:source eId="meta-1_analysis-1_activemod-2_textualmod-1_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-2"/>
-                                              <akn:destination eId="meta-1_analysis-1_activemod-2_textualmod-1_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
-                                              <akn:force eId="meta-1_analysis-1_activemod-2_textualmod-1_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-2"/>
-                                          </akn:textualMod>
-                                      </akn:activeModifications>
-                                  </akn:analysis>
-                              </akn:meta>
-                          </akn:act>
-                      </akn:akomaNtoso>
-                      """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                                  http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+            <akn:act name="regelungstext">
+                <!-- Metadaten -->
+                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                    <akn:analysis eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
+                        <akn:activeModifications eId="meta-1_analysis-1_activemod-1" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3ac">
+                            <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-1" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
+                                <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-1_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
+                                <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-1_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
+                                <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-1_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
+                            </akn:textualMod>
+                        </akn:activeModifications>
+                        <akn:activeModifications eId="meta-1_analysis-1_activemod-2" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3a2">
+                            <akn:textualMod eId="meta-1_analysis-1_activemod-2_textualmod-1" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
+                                <akn:source eId="meta-1_analysis-1_activemod-2_textualmod-1_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-2"/>
+                                <akn:destination eId="meta-1_analysis-1_activemod-2_textualmod-1_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
+                                <akn:force eId="meta-1_analysis-1_activemod-2_textualmod-1_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-2"/>
+                            </akn:textualMod>
+                        </akn:activeModifications>
+                    </akn:analysis>
+                </akn:meta>
+            </akn:act>
+        </akn:akomaNtoso>
+        """;
 
       Norm norm = new Norm(toDocument(normString));
 
       // when
-      final int textualMod =
-          norm.getNumberOfNodesWithEid("meta-1_analysis-1_activemod-2_textualmod-1");
+      final int textualMod = norm.getNumberOfNodesWithEid(
+        "meta-1_analysis-1_activemod-2_textualmod-1"
+      );
 
       // then
       assertThat(textualMod).isEqualTo(1);
@@ -1460,33 +1495,33 @@ class NormTest {
     void getNumberOfNodesWithEidReturnsTwo() {
       // given
       String normString =
-          """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                                http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                          <akn:act name="regelungstext">
-                              <!-- Metadaten -->
-                              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                  <akn:analysis eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
-                                      <akn:activeModifications eId="meta-1_analysis-1_activemod-1" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3ac">
-                                          <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-1" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
-                                              <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-1_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
-                                              <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-1_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
-                                              <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-1_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
-                                          </akn:textualMod>
-                                      </akn:activeModifications>
-                                      <akn:activeModifications eId="meta-1_analysis-1_activemod-1" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3a2">
-                                          <akn:textualMod eId="meta-1_analysis-1_activemod-2_textualmod-1" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
-                                              <akn:source eId="meta-1_analysis-1_activemod-2_textualmod-1_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-2"/>
-                                              <akn:destination eId="meta-1_analysis-1_activemod-2_textualmod-1_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
-                                              <akn:force eId="meta-1_analysis-1_activemod-2_textualmod-1_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-2"/>
-                                          </akn:textualMod>
-                                      </akn:activeModifications>
-                                  </akn:analysis>
-                              </akn:meta>
-                          </akn:act>
-                      </akn:akomaNtoso>
-                      """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                                  http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+            <akn:act name="regelungstext">
+                <!-- Metadaten -->
+                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                    <akn:analysis eId="meta-1_analysis-1" GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1" source="attributsemantik-noch-undefiniert">
+                        <akn:activeModifications eId="meta-1_analysis-1_activemod-1" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3ac">
+                            <akn:textualMod eId="meta-1_analysis-1_activemod-1_textualmod-1" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
+                                <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-1_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"/>
+                                <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-1_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
+                                <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-1_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
+                            </akn:textualMod>
+                        </akn:activeModifications>
+                        <akn:activeModifications eId="meta-1_analysis-1_activemod-1" GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3a2">
+                            <akn:textualMod eId="meta-1_analysis-1_activemod-2_textualmod-1" GUID="8992dd02-ab87-42e8-bee2-86b76f587f81" type="substitution">
+                                <akn:source eId="meta-1_analysis-1_activemod-2_textualmod-1_source-1" GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3" href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-2"/>
+                                <akn:destination eId="meta-1_analysis-1_activemod-2_textualmod-1_destination-1" GUID="83a4e169-ec57-4981-b191-84afe42130c8" href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml"/>
+                                <akn:force eId="meta-1_analysis-1_activemod-2_textualmod-1_gelzeitnachw-1" GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9" period="#meta-1_geltzeiten-1_geltungszeitgr-2"/>
+                            </akn:textualMod>
+                        </akn:activeModifications>
+                    </akn:analysis>
+                </akn:meta>
+            </akn:act>
+        </akn:akomaNtoso>
+        """;
 
       Norm norm = new Norm(toDocument(normString));
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/ProprietaryTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/ProprietaryTest.java
@@ -8,89 +8,97 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class ProprietaryTest {
+
   @Nested
   class Fna {
+
     @Test
     void returnsTheFna() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                              <akn:proprietary xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                        eId="meta-1_proprietary-1"
-                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                        source="attributsemantik-noch-undefiniert"
-                      >
-                        <meta:legalDocML.de_metadaten
-                          xmlns:meta="http://Metadaten.LegalDocML.de/1.6/"
-                        >
-                          <meta:typ>gesetz</meta:typ>
-                          <meta:fna>754-28-1</meta:fna>
-                          <meta:fassung>verkuendungsfassung</meta:fassung>
-                        </meta:legalDocML.de_metadaten>
-                      </akn:proprietary>
-                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                    <akn:proprietary xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+              eId="meta-1_proprietary-1"
+              GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+              source="attributsemantik-noch-undefiniert"
+            >
+              <meta:legalDocML.de_metadaten
+                xmlns:meta="http://Metadaten.LegalDocML.de/1.6/"
+              >
+                <meta:typ>gesetz</meta:typ>
+                <meta:fna>754-28-1</meta:fna>
+                <meta:fassung>verkuendungsfassung</meta:fassung>
+              </meta:legalDocML.de_metadaten>
+            </akn:proprietary>
+            """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getFna()).contains("754-28-1");
     }
 
     @Test
     void returnsEmptyOptionalIfFnaIsMissing() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                              <akn:proprietary xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                        eId="meta-1_proprietary-1"
-                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                        source="attributsemantik-noch-undefiniert"
-                      >
-                        <meta:legalDocML.de_metadaten
-                          xmlns:meta="http://Metadaten.LegalDocML.de/1.6/"
-                        >
-                          <meta:typ>gesetz</meta:typ>
-                          <meta:form>stammform</meta:form>
-                          <meta:fassung>verkuendungsfassung</meta:fassung>
-                        </meta:legalDocML.de_metadaten>
-                      </akn:proprietary>
-                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                    <akn:proprietary xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+              eId="meta-1_proprietary-1"
+              GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+              source="attributsemantik-noch-undefiniert"
+            >
+              <meta:legalDocML.de_metadaten
+                xmlns:meta="http://Metadaten.LegalDocML.de/1.6/"
+              >
+                <meta:typ>gesetz</meta:typ>
+                <meta:form>stammform</meta:form>
+                <meta:fassung>verkuendungsfassung</meta:fassung>
+              </meta:legalDocML.de_metadaten>
+            </akn:proprietary>
+            """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getFna()).isEmpty();
     }
 
     @Test
     void returnsTheFnaAtDate() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                              <akn:proprietary xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                        eId="meta-1_proprietary-1"
-                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                        source="attributsemantik-noch-undefiniert"
-                      >
-                        <meta:legalDocML.de_metadaten
-                          xmlns:meta="http://Metadaten.LegalDocML.de/1.6/"
-                        >
-                          <meta:typ>gesetz</meta:typ>
-                          <meta:fna>000-00-0</meta:fna>
-                          <meta:fassung>verkuendungsfassung</meta:fassung>
-                        </meta:legalDocML.de_metadaten>
-                        <meta:legalDocML.de_metadaten_ds
-                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                        >
-                          <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
-                          <meta:fna start="1995-01-01" end="2000-12-31">222-22-2</meta:fna>
-                          <meta:fna start="2001-01-01">333-33-3</meta:fna>
-                        </meta:legalDocML.de_metadaten_ds>
-                      </akn:proprietary>
-                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                    <akn:proprietary xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+              eId="meta-1_proprietary-1"
+              GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+              source="attributsemantik-noch-undefiniert"
+            >
+              <meta:legalDocML.de_metadaten
+                xmlns:meta="http://Metadaten.LegalDocML.de/1.6/"
+              >
+                <meta:typ>gesetz</meta:typ>
+                <meta:fna>000-00-0</meta:fna>
+                <meta:fassung>verkuendungsfassung</meta:fassung>
+              </meta:legalDocML.de_metadaten>
+              <meta:legalDocML.de_metadaten_ds
+                xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+              >
+                <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
+                <meta:fna start="1995-01-01" end="2000-12-31">222-22-2</meta:fna>
+                <meta:fna start="2001-01-01">333-33-3</meta:fna>
+              </meta:legalDocML.de_metadaten_ds>
+            </akn:proprietary>
+            """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getFna(LocalDate.parse("1980-01-01"))).contains("000-00-0");
 
@@ -109,63 +117,70 @@ class ProprietaryTest {
 
   @Nested
   class MetadatenDs {
+
     @Test
     void returnsNode() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                          <akn:proprietary xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_proprietary-1" GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c" source="attributsemantik-noch-undefiniert">
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+            <akn:proprietary xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_proprietary-1" GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c" source="attributsemantik-noch-undefiniert">
 
-                                                <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                                    <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
-                                                    <meta:fna start="1995-01-01" end="2000-12-31">222-22-2</meta:fna>
-                                                    <meta:fna start="2001-01-01">333-33-3</meta:fna>
-                                                </meta:legalDocML.de_metadaten_ds>
-                                            </akn:proprietary>
-                                            """))
-              .build();
+                                  <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                                      <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
+                                      <meta:fna start="1995-01-01" end="2000-12-31">222-22-2</meta:fna>
+                                      <meta:fna start="2001-01-01">333-33-3</meta:fna>
+                                  </meta:legalDocML.de_metadaten_ds>
+                              </akn:proprietary>
+                              """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getMetadatenDs()).isNotEmpty();
     }
 
     @Test
     void returnsNodeEmpty() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                          <akn:proprietary xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_proprietary-1" GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c" source="attributsemantik-noch-undefiniert">
-                                            <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
-                                                <meta:typ>gesetz</meta:typ>
-                                                <meta:fna>000-00-0</meta:fna>
-                                                <meta:fassung>verkuendungsfassung</meta:fassung>
-                                            </meta:legalDocML.de_metadaten>
-                                            </akn:proprietary>
-                                            """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+            <akn:proprietary xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_proprietary-1" GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c" source="attributsemantik-noch-undefiniert">
+                              <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+                                  <meta:typ>gesetz</meta:typ>
+                                  <meta:fna>000-00-0</meta:fna>
+                                  <meta:fassung>verkuendungsfassung</meta:fassung>
+                              </meta:legalDocML.de_metadaten>
+                              </akn:proprietary>
+                              """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getMetadatenDs()).isEmpty();
     }
 
     @Test
     void returnsNodeByCreatingIt() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                          <akn:proprietary xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_proprietary-1" GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c" source="attributsemantik-noch-undefiniert">
-                                            <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
-                                                <meta:typ>gesetz</meta:typ>
-                                                <meta:fna>000-00-0</meta:fna>
-                                                <meta:fassung>verkuendungsfassung</meta:fassung>
-                                            </meta:legalDocML.de_metadaten>
-                                            </akn:proprietary>
-                                            """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+            <akn:proprietary xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_proprietary-1" GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c" source="attributsemantik-noch-undefiniert">
+                              <meta:legalDocML.de_metadaten xmlns:meta="http://Metadaten.LegalDocML.de/1.6/">
+                                  <meta:typ>gesetz</meta:typ>
+                                  <meta:fna>000-00-0</meta:fna>
+                                  <meta:fassung>verkuendungsfassung</meta:fassung>
+                              </meta:legalDocML.de_metadaten>
+                              </akn:proprietary>
+                              """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getOrCreateMetadatenDs()).isNotNull();
     }
@@ -173,88 +188,95 @@ class ProprietaryTest {
 
   @Nested
   class Art {
+
     @Test
     void returnsTheArt() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                      <akn:proprietary
-                                xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                        eId="meta-1_proprietary-1"
-                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                        source="attributsemantik-noch-undefiniert"
-                      >
-                        <meta:legalDocML.de_metadaten
-                          xmlns:meta="http://Metadaten.LegalDocML.de/1.6/"
-                        >
-                          <meta:art>rechtsetzungsdokument</meta:art>
-                        </meta:legalDocML.de_metadaten>
-                      </akn:proprietary>
-                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+            <akn:proprietary
+                      xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+              eId="meta-1_proprietary-1"
+              GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+              source="attributsemantik-noch-undefiniert"
+            >
+              <meta:legalDocML.de_metadaten
+                xmlns:meta="http://Metadaten.LegalDocML.de/1.6/"
+              >
+                <meta:art>rechtsetzungsdokument</meta:art>
+              </meta:legalDocML.de_metadaten>
+            </akn:proprietary>
+            """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getArt(LocalDate.parse("2010-10-10")))
-          .contains("rechtsetzungsdokument");
+        .contains("rechtsetzungsdokument");
     }
 
     @Test
     void returnsEmptyOptionalIfArtIsMissing() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                      <akn:proprietary
-                                xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                        eId="meta-1_proprietary-1"
-                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                        source="attributsemantik-noch-undefiniert"
-                      >
-                        <meta:legalDocML.de_metadaten
-                          xmlns:meta="http://Metadaten.LegalDocML.de/1.6/"
-                        >
-                        <!-- Art is missing -->
-                        </meta:legalDocML.de_metadaten>
-                      </akn:proprietary>
-                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+            <akn:proprietary
+                      xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+              eId="meta-1_proprietary-1"
+              GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+              source="attributsemantik-noch-undefiniert"
+            >
+              <meta:legalDocML.de_metadaten
+                xmlns:meta="http://Metadaten.LegalDocML.de/1.6/"
+              >
+              <!-- Art is missing -->
+              </meta:legalDocML.de_metadaten>
+            </akn:proprietary>
+            """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getArt(LocalDate.parse("2010-10-10"))).isEmpty();
     }
 
     @Test
     void returnsTheArtAtDate() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                      <akn:proprietary
-                                xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                        eId="meta-1_proprietary-1"
-                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                        source="attributsemantik-noch-undefiniert"
-                      >
-                        <meta:legalDocML.de_metadaten
-                          xmlns:meta="http://Metadaten.LegalDocML.de/1.6/"
-                        >
-                          <meta:art>rechtsetzungsdokument</meta:art>
-                        </meta:legalDocML.de_metadaten>
-                        <meta:legalDocML.de_metadaten_ds
-                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                        >
-                          <meta:art start="1990-01-01" end="1994-12-31">regelungstext</meta:art>
-                          <meta:art start="1995-01-01" end="2000-12-31">begruendung</meta:art>
-                          <meta:art start="2001-01-01">anschreiben</meta:art>
-                        </meta:legalDocML.de_metadaten_ds>
-                      </akn:proprietary>
-                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+            <akn:proprietary
+                      xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+              eId="meta-1_proprietary-1"
+              GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+              source="attributsemantik-noch-undefiniert"
+            >
+              <meta:legalDocML.de_metadaten
+                xmlns:meta="http://Metadaten.LegalDocML.de/1.6/"
+              >
+                <meta:art>rechtsetzungsdokument</meta:art>
+              </meta:legalDocML.de_metadaten>
+              <meta:legalDocML.de_metadaten_ds
+                xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+              >
+                <meta:art start="1990-01-01" end="1994-12-31">regelungstext</meta:art>
+                <meta:art start="1995-01-01" end="2000-12-31">begruendung</meta:art>
+                <meta:art start="2001-01-01">anschreiben</meta:art>
+              </meta:legalDocML.de_metadaten_ds>
+            </akn:proprietary>
+            """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getArt(LocalDate.parse("1980-01-01")))
-          .contains("rechtsetzungsdokument");
+        .contains("rechtsetzungsdokument");
 
       assertThat(proprietary.getArt(LocalDate.parse("1990-01-01"))).contains("regelungstext");
       assertThat(proprietary.getArt(LocalDate.parse("1992-01-01"))).contains("regelungstext");
@@ -271,85 +293,92 @@ class ProprietaryTest {
 
   @Nested
   class Typ {
+
     @Test
     void returnsTheTyp() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                      <akn:proprietary
-                                xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                        eId="meta-1_proprietary-1"
-                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                        source="attributsemantik-noch-undefiniert"
-                      >
-                        <meta:legalDocML.de_metadaten
-                          xmlns:meta="http://Metadaten.LegalDocML.de/1.6/"
-                        >
-                          <meta:typ>rechtsetzungsdokument</meta:typ>
-                        </meta:legalDocML.de_metadaten>
-                      </akn:proprietary>
-                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+            <akn:proprietary
+                      xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+              eId="meta-1_proprietary-1"
+              GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+              source="attributsemantik-noch-undefiniert"
+            >
+              <meta:legalDocML.de_metadaten
+                xmlns:meta="http://Metadaten.LegalDocML.de/1.6/"
+              >
+                <meta:typ>rechtsetzungsdokument</meta:typ>
+              </meta:legalDocML.de_metadaten>
+            </akn:proprietary>
+            """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getTyp(LocalDate.parse("2010-10-10")))
-          .contains("rechtsetzungsdokument");
+        .contains("rechtsetzungsdokument");
     }
 
     @Test
     void returnsEmptyOptionalIfTypIsMissing() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                      <akn:proprietary
-                                xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                        eId="meta-1_proprietary-1"
-                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                        source="attributsemantik-noch-undefiniert"
-                      >
-                        <meta:legalDocML.de_metadaten
-                          xmlns:meta="http://Metadaten.LegalDocML.de/1.6/"
-                        >
-                        <!-- Typ is missing -->
-                        </meta:legalDocML.de_metadaten>
-                      </akn:proprietary>
-                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+            <akn:proprietary
+                      xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+              eId="meta-1_proprietary-1"
+              GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+              source="attributsemantik-noch-undefiniert"
+            >
+              <meta:legalDocML.de_metadaten
+                xmlns:meta="http://Metadaten.LegalDocML.de/1.6/"
+              >
+              <!-- Typ is missing -->
+              </meta:legalDocML.de_metadaten>
+            </akn:proprietary>
+            """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getTyp(LocalDate.parse("2010-10-10"))).isEmpty();
     }
 
     @Test
     void returnsTheTypAtDate() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                      <akn:proprietary
-                                xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                        eId="meta-1_proprietary-1"
-                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                        source="attributsemantik-noch-undefiniert"
-                      >
-                        <meta:legalDocML.de_metadaten
-                          xmlns:meta="http://Metadaten.LegalDocML.de/1.6/"
-                        >
-                          <meta:typ>gesetz</meta:typ>
-                        </meta:legalDocML.de_metadaten>
-                        <meta:legalDocML.de_metadaten_ds
-                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                        >
-                          <meta:typ start="1990-01-01" end="1994-12-31">verordnung</meta:typ>
-                          <meta:typ start="1995-01-01" end="2000-12-31">begruendung</meta:typ>
-                          <meta:typ start="2001-01-01">satzung</meta:typ>
-                        </meta:legalDocML.de_metadaten_ds>
-                      </akn:proprietary>
-                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+            <akn:proprietary
+                      xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+              eId="meta-1_proprietary-1"
+              GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+              source="attributsemantik-noch-undefiniert"
+            >
+              <meta:legalDocML.de_metadaten
+                xmlns:meta="http://Metadaten.LegalDocML.de/1.6/"
+              >
+                <meta:typ>gesetz</meta:typ>
+              </meta:legalDocML.de_metadaten>
+              <meta:legalDocML.de_metadaten_ds
+                xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+              >
+                <meta:typ start="1990-01-01" end="1994-12-31">verordnung</meta:typ>
+                <meta:typ start="1995-01-01" end="2000-12-31">begruendung</meta:typ>
+                <meta:typ start="2001-01-01">satzung</meta:typ>
+              </meta:legalDocML.de_metadaten_ds>
+            </akn:proprietary>
+            """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getTyp(LocalDate.parse("1980-01-01"))).contains("gesetz");
 
@@ -368,98 +397,105 @@ class ProprietaryTest {
 
   @Nested
   class Subtyp {
+
     @Test
     void returnsTheSubtyp() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                      <akn:proprietary
-                                xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                        eId="meta-1_proprietary-1"
-                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                        source="attributsemantik-noch-undefiniert"
-                      >
-                        <meta:legalDocML.de_metadaten_ds
-                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                        >
-                          <meta:subtyp>Anordnung des Bundespräsidenten</meta:subtyp>
-                       </meta:legalDocML.de_metadaten_ds>
-                      </akn:proprietary>
-                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+            <akn:proprietary
+                      xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+              eId="meta-1_proprietary-1"
+              GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+              source="attributsemantik-noch-undefiniert"
+            >
+              <meta:legalDocML.de_metadaten_ds
+                xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+              >
+                <meta:subtyp>Anordnung des Bundespräsidenten</meta:subtyp>
+             </meta:legalDocML.de_metadaten_ds>
+            </akn:proprietary>
+            """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getSubtyp(LocalDate.parse("2010-10-10")))
-          .contains("Anordnung des Bundespräsidenten");
+        .contains("Anordnung des Bundespräsidenten");
     }
 
     @Test
     void returnsEmptyOptionalIfSubtypIsMissing() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                      <akn:proprietary
-                                xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                        eId="meta-1_proprietary-1"
-                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                        source="attributsemantik-noch-undefiniert"
-                      >
-                        <meta:legalDocML.de_metadaten_ds
-                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                        >
-                        <!-- Subtyp is missing -->
-                        </meta:legalDocML.de_metadaten_ds>
-                      </akn:proprietary>
-                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+            <akn:proprietary
+                      xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+              eId="meta-1_proprietary-1"
+              GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+              source="attributsemantik-noch-undefiniert"
+            >
+              <meta:legalDocML.de_metadaten_ds
+                xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+              >
+              <!-- Subtyp is missing -->
+              </meta:legalDocML.de_metadaten_ds>
+            </akn:proprietary>
+            """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getSubtyp(LocalDate.parse("2010-10-10"))).isEmpty();
     }
 
     @Test
     void returnsTheSubtypAtDate() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                      <akn:proprietary
-                                xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                        eId="meta-1_proprietary-1"
-                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                        source="attributsemantik-noch-undefiniert"
-                      >
-                        <meta:legalDocML.de_metadaten_ds
-                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                        >
-                          <meta:subtyp end="1989-12-31">Anordnung des Bundespräsidenten</meta:subtyp>
-                          <meta:subtyp start="1990-01-01" end="1994-12-31">Bekanntmachung vor einer Neufassung</meta:subtyp>
-                          <meta:subtyp start="1995-01-01" end="2000-12-31">Völkerrechtliche Vereinbarung</meta:subtyp>
-                          <meta:subtyp start="2001-01-01">Geschäftsordnung</meta:subtyp>
-                        </meta:legalDocML.de_metadaten_ds>
-                      </akn:proprietary>
-                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+            <akn:proprietary
+                      xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+              eId="meta-1_proprietary-1"
+              GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+              source="attributsemantik-noch-undefiniert"
+            >
+              <meta:legalDocML.de_metadaten_ds
+                xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+              >
+                <meta:subtyp end="1989-12-31">Anordnung des Bundespräsidenten</meta:subtyp>
+                <meta:subtyp start="1990-01-01" end="1994-12-31">Bekanntmachung vor einer Neufassung</meta:subtyp>
+                <meta:subtyp start="1995-01-01" end="2000-12-31">Völkerrechtliche Vereinbarung</meta:subtyp>
+                <meta:subtyp start="2001-01-01">Geschäftsordnung</meta:subtyp>
+              </meta:legalDocML.de_metadaten_ds>
+            </akn:proprietary>
+            """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getSubtyp(LocalDate.parse("1980-01-01")))
-          .contains("Anordnung des Bundespräsidenten");
+        .contains("Anordnung des Bundespräsidenten");
 
       assertThat(proprietary.getSubtyp(LocalDate.parse("1990-01-01")))
-          .contains("Bekanntmachung vor einer Neufassung");
+        .contains("Bekanntmachung vor einer Neufassung");
       assertThat(proprietary.getSubtyp(LocalDate.parse("1992-01-01")))
-          .contains("Bekanntmachung vor einer Neufassung");
+        .contains("Bekanntmachung vor einer Neufassung");
       assertThat(proprietary.getSubtyp(LocalDate.parse("1994-12-31")))
-          .contains("Bekanntmachung vor einer Neufassung");
+        .contains("Bekanntmachung vor einer Neufassung");
 
       assertThat(proprietary.getSubtyp(LocalDate.parse("1995-01-01")))
-          .contains("Völkerrechtliche Vereinbarung");
+        .contains("Völkerrechtliche Vereinbarung");
       assertThat(proprietary.getSubtyp(LocalDate.parse("1998-01-01")))
-          .contains("Völkerrechtliche Vereinbarung");
+        .contains("Völkerrechtliche Vereinbarung");
       assertThat(proprietary.getSubtyp(LocalDate.parse("2000-12-31")))
-          .contains("Völkerrechtliche Vereinbarung");
+        .contains("Völkerrechtliche Vereinbarung");
 
       assertThat(proprietary.getSubtyp(LocalDate.parse("2001-01-01"))).contains("Geschäftsordnung");
       assertThat(proprietary.getSubtyp(LocalDate.parse("2024-01-01"))).contains("Geschäftsordnung");
@@ -468,182 +504,196 @@ class ProprietaryTest {
 
   @Nested
   class BezeichnungInVorlage {
+
     @Test
     void returnsTheBezeichnungInVorlage() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                      <akn:proprietary
-                          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                        eId="meta-1_proprietary-1"
-                                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                                        source="attributsemantik-noch-undefiniert"
-                                      >
-                                        <meta:legalDocML.de_metadaten_ds
-                                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                                        >
-                                          <meta:bezeichnungInVorlage>Bezeichnung gemäß Vorlage</meta:bezeichnungInVorlage>
-                                       </meta:legalDocML.de_metadaten_ds>
-                                      </akn:proprietary>
-                                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                        <akn:proprietary
+            xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                          eId="meta-1_proprietary-1"
+                          GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+                          source="attributsemantik-noch-undefiniert"
+                        >
+                          <meta:legalDocML.de_metadaten_ds
+                            xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+                          >
+                            <meta:bezeichnungInVorlage>Bezeichnung gemäß Vorlage</meta:bezeichnungInVorlage>
+                         </meta:legalDocML.de_metadaten_ds>
+                        </akn:proprietary>
+                        """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getBezeichnungInVorlage(LocalDate.parse("2010-10-10")))
-          .contains("Bezeichnung gemäß Vorlage");
+        .contains("Bezeichnung gemäß Vorlage");
     }
 
     @Test
     void returnsEmptyOptionalIfBezeichnungInVorlageIsMissing() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                      <akn:proprietary
-                          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                        eId="meta-1_proprietary-1"
-                                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                                        source="attributsemantik-noch-undefiniert"
-                                      >
-                                        <meta:legalDocML.de_metadaten_ds
-                                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                                        >
-                                        <!-- BezeichnungInVorlage is missing -->
-                                        </meta:legalDocML.de_metadaten_ds>
-                                      </akn:proprietary>
-                                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                        <akn:proprietary
+            xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                          eId="meta-1_proprietary-1"
+                          GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+                          source="attributsemantik-noch-undefiniert"
+                        >
+                          <meta:legalDocML.de_metadaten_ds
+                            xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+                          >
+                          <!-- BezeichnungInVorlage is missing -->
+                          </meta:legalDocML.de_metadaten_ds>
+                        </akn:proprietary>
+                        """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getBezeichnungInVorlage(LocalDate.parse("2010-10-10"))).isEmpty();
     }
 
     @Test
     void returnsTheBezeichnungInVorlageAtDate() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                      <akn:proprietary
-                          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                        eId="meta-1_proprietary-1"
-                                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                                        source="attributsemantik-noch-undefiniert"
-                                      >
-                                        <meta:legalDocML.de_metadaten_ds
-                                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                                        >
-                                          <meta:bezeichnungInVorlage end="1989-12-31">Bezeichnung gemäß Vorlage 1</meta:bezeichnungInVorlage>
-                                          <meta:bezeichnungInVorlage start="1990-01-01" end="1994-12-31">Bezeichnung gemäß Vorlage 2</meta:bezeichnungInVorlage>
-                                          <meta:bezeichnungInVorlage start="1995-01-01" end="2000-12-31">Bezeichnung gemäß Vorlage 3</meta:bezeichnungInVorlage>
-                                          <meta:bezeichnungInVorlage start="2001-01-01">Bezeichnung gemäß Vorlage 4</meta:bezeichnungInVorlage>
-                                        </meta:legalDocML.de_metadaten_ds>
-                                      </akn:proprietary>
-                                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                        <akn:proprietary
+            xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                          eId="meta-1_proprietary-1"
+                          GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+                          source="attributsemantik-noch-undefiniert"
+                        >
+                          <meta:legalDocML.de_metadaten_ds
+                            xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+                          >
+                            <meta:bezeichnungInVorlage end="1989-12-31">Bezeichnung gemäß Vorlage 1</meta:bezeichnungInVorlage>
+                            <meta:bezeichnungInVorlage start="1990-01-01" end="1994-12-31">Bezeichnung gemäß Vorlage 2</meta:bezeichnungInVorlage>
+                            <meta:bezeichnungInVorlage start="1995-01-01" end="2000-12-31">Bezeichnung gemäß Vorlage 3</meta:bezeichnungInVorlage>
+                            <meta:bezeichnungInVorlage start="2001-01-01">Bezeichnung gemäß Vorlage 4</meta:bezeichnungInVorlage>
+                          </meta:legalDocML.de_metadaten_ds>
+                        </akn:proprietary>
+                        """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getBezeichnungInVorlage(LocalDate.parse("1980-01-01")))
-          .contains("Bezeichnung gemäß Vorlage 1");
+        .contains("Bezeichnung gemäß Vorlage 1");
 
       assertThat(proprietary.getBezeichnungInVorlage(LocalDate.parse("1990-01-01")))
-          .contains("Bezeichnung gemäß Vorlage 2");
+        .contains("Bezeichnung gemäß Vorlage 2");
       assertThat(proprietary.getBezeichnungInVorlage(LocalDate.parse("1992-01-01")))
-          .contains("Bezeichnung gemäß Vorlage 2");
+        .contains("Bezeichnung gemäß Vorlage 2");
       assertThat(proprietary.getBezeichnungInVorlage(LocalDate.parse("1994-12-31")))
-          .contains("Bezeichnung gemäß Vorlage 2");
+        .contains("Bezeichnung gemäß Vorlage 2");
 
       assertThat(proprietary.getBezeichnungInVorlage(LocalDate.parse("1995-01-01")))
-          .contains("Bezeichnung gemäß Vorlage 3");
+        .contains("Bezeichnung gemäß Vorlage 3");
       assertThat(proprietary.getBezeichnungInVorlage(LocalDate.parse("1998-01-01")))
-          .contains("Bezeichnung gemäß Vorlage 3");
+        .contains("Bezeichnung gemäß Vorlage 3");
       assertThat(proprietary.getBezeichnungInVorlage(LocalDate.parse("2000-12-31")))
-          .contains("Bezeichnung gemäß Vorlage 3");
+        .contains("Bezeichnung gemäß Vorlage 3");
 
       assertThat(proprietary.getBezeichnungInVorlage(LocalDate.parse("2001-01-01")))
-          .contains("Bezeichnung gemäß Vorlage 4");
+        .contains("Bezeichnung gemäß Vorlage 4");
       assertThat(proprietary.getBezeichnungInVorlage(LocalDate.parse("2024-01-01")))
-          .contains("Bezeichnung gemäß Vorlage 4");
+        .contains("Bezeichnung gemäß Vorlage 4");
     }
   }
 
   @Nested
   class ArtDerNorm {
+
     @Test
     void returnsArtDerNorm() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                      <akn:proprietary
-                          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                                        eId="meta-1_proprietary-1"
-                                                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                                                        source="attributsemantik-noch-undefiniert"
-                                                      >
-                                                        <meta:legalDocML.de_metadaten_ds
-                                                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                                                        >
-                                                          <meta:artDerNorm>SN,ÄN,ÜN</meta:artDerNorm>
-                                                       </meta:legalDocML.de_metadaten_ds>
-                                                      </akn:proprietary>
-                                                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                                        <akn:proprietary
+            xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                                          eId="meta-1_proprietary-1"
+                                          GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+                                          source="attributsemantik-noch-undefiniert"
+                                        >
+                                          <meta:legalDocML.de_metadaten_ds
+                                            xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+                                          >
+                                            <meta:artDerNorm>SN,ÄN,ÜN</meta:artDerNorm>
+                                         </meta:legalDocML.de_metadaten_ds>
+                                        </akn:proprietary>
+                                        """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getArtDerNorm(LocalDate.parse("2010-10-10"))).contains("SN,ÄN,ÜN");
     }
 
     @Test
     void returnsEmptyOptionalIfArtDerNormIsMissing() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                      <akn:proprietary
-                          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                                        eId="meta-1_proprietary-1"
-                                                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                                                        source="attributsemantik-noch-undefiniert"
-                                                      >
-                                                        <meta:legalDocML.de_metadaten_ds
-                                                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                                                        >
-                                                        <!-- ArtDerNorm is missing -->
-                                                        </meta:legalDocML.de_metadaten_ds>
-                                                      </akn:proprietary>
-                                                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                                        <akn:proprietary
+            xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                                          eId="meta-1_proprietary-1"
+                                          GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+                                          source="attributsemantik-noch-undefiniert"
+                                        >
+                                          <meta:legalDocML.de_metadaten_ds
+                                            xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+                                          >
+                                          <!-- ArtDerNorm is missing -->
+                                          </meta:legalDocML.de_metadaten_ds>
+                                        </akn:proprietary>
+                                        """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getArtDerNorm(LocalDate.parse("2010-10-10"))).isEmpty();
     }
 
     @Test
     void returnsTheArtDerNormAtDate() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                      <akn:proprietary
-                          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                                        eId="meta-1_proprietary-1"
-                                                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                                                        source="attributsemantik-noch-undefiniert"
-                                                      >
-                                                        <meta:legalDocML.de_metadaten_ds
-                                                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                                                        >
-                                                          <meta:artDerNorm end="1989-12-31">SN,ÄN,ÜN</meta:artDerNorm>
-                                                          <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN,ÄN</meta:artDerNorm>
-                                                          <meta:artDerNorm start="1995-01-01" end="2000-12-31">SN,ÜN</meta:artDerNorm>
-                                                          <meta:artDerNorm start="2001-01-01">ÄN,ÜN</meta:artDerNorm>
-                                                        </meta:legalDocML.de_metadaten_ds>
-                                                      </akn:proprietary>
-                                                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                                        <akn:proprietary
+            xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                                          eId="meta-1_proprietary-1"
+                                          GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+                                          source="attributsemantik-noch-undefiniert"
+                                        >
+                                          <meta:legalDocML.de_metadaten_ds
+                                            xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+                                          >
+                                            <meta:artDerNorm end="1989-12-31">SN,ÄN,ÜN</meta:artDerNorm>
+                                            <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN,ÄN</meta:artDerNorm>
+                                            <meta:artDerNorm start="1995-01-01" end="2000-12-31">SN,ÜN</meta:artDerNorm>
+                                            <meta:artDerNorm start="2001-01-01">ÄN,ÜN</meta:artDerNorm>
+                                          </meta:legalDocML.de_metadaten_ds>
+                                        </akn:proprietary>
+                                        """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getArtDerNorm(LocalDate.parse("1980-01-01"))).contains("SN,ÄN,ÜN");
 
@@ -662,80 +712,87 @@ class ProprietaryTest {
 
   @Nested
   class Staat {
+
     @Test
     void returnsStaat() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                                      <akn:proprietary
-                          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                                                        eId="meta-1_proprietary-1"
-                                                                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                                                                        source="attributsemantik-noch-undefiniert"
-                                                                      >
-                                                                        <meta:legalDocML.de_metadaten_ds
-                                                                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                                                                        >
-                                                                          <meta:normgeber>DEU</meta:normgeber>
-                                                                       </meta:legalDocML.de_metadaten_ds>
-                                                                      </akn:proprietary>
-                                                                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                                                        <akn:proprietary
+            xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                                                          eId="meta-1_proprietary-1"
+                                                          GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+                                                          source="attributsemantik-noch-undefiniert"
+                                                        >
+                                                          <meta:legalDocML.de_metadaten_ds
+                                                            xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+                                                          >
+                                                            <meta:normgeber>DEU</meta:normgeber>
+                                                         </meta:legalDocML.de_metadaten_ds>
+                                                        </akn:proprietary>
+                                                        """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getStaat(LocalDate.parse("2010-10-10"))).contains("DEU");
     }
 
     @Test
     void returnsEmptyOptionalIfStaatIsMissing() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                                      <akn:proprietary
-                          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                                                        eId="meta-1_proprietary-1"
-                                                                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                                                                        source="attributsemantik-noch-undefiniert"
-                                                                      >
-                                                                        <meta:legalDocML.de_metadaten_ds
-                                                                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                                                                        >
-                                                                        <!-- Normgeber is missing -->
-                                                                        </meta:legalDocML.de_metadaten_ds>
-                                                                      </akn:proprietary>
-                                                                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                                                        <akn:proprietary
+            xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                                                          eId="meta-1_proprietary-1"
+                                                          GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+                                                          source="attributsemantik-noch-undefiniert"
+                                                        >
+                                                          <meta:legalDocML.de_metadaten_ds
+                                                            xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+                                                          >
+                                                          <!-- Normgeber is missing -->
+                                                          </meta:legalDocML.de_metadaten_ds>
+                                                        </akn:proprietary>
+                                                        """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getStaat(LocalDate.parse("2010-10-10"))).isEmpty();
     }
 
     @Test
     void returnsTheStaatAtDate() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                                      <akn:proprietary
-                          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                                                        eId="meta-1_proprietary-1"
-                                                                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                                                                        source="attributsemantik-noch-undefiniert"
-                                                                      >
-                                                                        <meta:legalDocML.de_metadaten_ds
-                                                                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                                                                        >
-                                                                          <meta:normgeber end="1989-12-31">DEU</meta:normgeber>
-                                                                          <meta:normgeber start="1990-01-01" end="1994-12-31">DDR</meta:normgeber>
-                                                                          <meta:normgeber start="1995-01-01" end="2000-12-31">BW</meta:normgeber>
-                                                                          <meta:normgeber start="2001-01-01">BY</meta:normgeber>
-                                                                        </meta:legalDocML.de_metadaten_ds>
-                                                                      </akn:proprietary>
-                                                                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                                                        <akn:proprietary
+            xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                                                          eId="meta-1_proprietary-1"
+                                                          GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+                                                          source="attributsemantik-noch-undefiniert"
+                                                        >
+                                                          <meta:legalDocML.de_metadaten_ds
+                                                            xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+                                                          >
+                                                            <meta:normgeber end="1989-12-31">DEU</meta:normgeber>
+                                                            <meta:normgeber start="1990-01-01" end="1994-12-31">DDR</meta:normgeber>
+                                                            <meta:normgeber start="1995-01-01" end="2000-12-31">BW</meta:normgeber>
+                                                            <meta:normgeber start="2001-01-01">BY</meta:normgeber>
+                                                          </meta:legalDocML.de_metadaten_ds>
+                                                        </akn:proprietary>
+                                                        """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getStaat(LocalDate.parse("1980-01-01"))).contains("DEU");
 
@@ -754,55 +811,60 @@ class ProprietaryTest {
 
   @Nested
   class BeschliessendesOrgan {
+
     @Test
     void returnsBeschliessendesOrgan() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                                                      <akn:proprietary
-                          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                                                                        eId="meta-1_proprietary-1"
-                                                                                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                                                                                        source="attributsemantik-noch-undefiniert"
-                                                                                      >
-                                                                                        <meta:legalDocML.de_metadaten_ds
-                                                                                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                                                                                        >
-                                                                                          <meta:beschliessendesOrgan qualifizierteMehrheit="true">Bundestag</meta:beschliessendesOrgan>
-                                                                                       </meta:legalDocML.de_metadaten_ds>
-                                                                                      </akn:proprietary>
-                                                                                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                                                                        <akn:proprietary
+            xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                                                                          eId="meta-1_proprietary-1"
+                                                                          GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+                                                                          source="attributsemantik-noch-undefiniert"
+                                                                        >
+                                                                          <meta:legalDocML.de_metadaten_ds
+                                                                            xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+                                                                          >
+                                                                            <meta:beschliessendesOrgan qualifizierteMehrheit="true">Bundestag</meta:beschliessendesOrgan>
+                                                                         </meta:legalDocML.de_metadaten_ds>
+                                                                        </akn:proprietary>
+                                                                        """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getBeschliessendesOrgan(LocalDate.parse("2010-10-10")))
-          .contains("Bundestag");
+        .contains("Bundestag");
       assertThat(proprietary.getQualifizierteMehrheit(LocalDate.parse("2010-10-10")))
-          .contains(true);
+        .contains(true);
     }
 
     @Test
     void returnsEmptyOptionalIfBeschliessendesOrganIsMissing() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                                                      <akn:proprietary
-                          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                                                                        eId="meta-1_proprietary-1"
-                                                                                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                                                                                        source="attributsemantik-noch-undefiniert"
-                                                                                      >
-                                                                                        <meta:legalDocML.de_metadaten_ds
-                                                                                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                                                                                        >
-                                                                                        <!-- BeschliessendesOrgan is missing -->
-                                                                                        </meta:legalDocML.de_metadaten_ds>
-                                                                                      </akn:proprietary>
-                                                                                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                                                                        <akn:proprietary
+            xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                                                                          eId="meta-1_proprietary-1"
+                                                                          GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+                                                                          source="attributsemantik-noch-undefiniert"
+                                                                        >
+                                                                          <meta:legalDocML.de_metadaten_ds
+                                                                            xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+                                                                          >
+                                                                          <!-- BeschliessendesOrgan is missing -->
+                                                                          </meta:legalDocML.de_metadaten_ds>
+                                                                        </akn:proprietary>
+                                                                        """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getBeschliessendesOrgan(LocalDate.parse("2010-10-10"))).isEmpty();
       assertThat(proprietary.getQualifizierteMehrheit(LocalDate.parse("2010-10-10"))).isEmpty();
@@ -810,230 +872,244 @@ class ProprietaryTest {
 
     @Test
     void returnsTheBeschliessendesOrganAtDate() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                                                      <akn:proprietary
-                          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                                                                        eId="meta-1_proprietary-1"
-                                                                                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                                                                                        source="attributsemantik-noch-undefiniert"
-                                                                                      >
-                                                                                        <meta:legalDocML.de_metadaten_ds
-                                                                                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                                                                                        >
-                                                                                          <meta:beschliessendesOrgan end="1989-12-31" qualifizierteMehrheit="true">Bundestag 1</meta:beschliessendesOrgan>
-                                                                                          <meta:beschliessendesOrgan start="1990-01-01" end="1994-12-31" qualifizierteMehrheit="true">Bundestag 2</meta:beschliessendesOrgan>
-                                                                                          <meta:beschliessendesOrgan start="1995-01-01" end="2000-12-31" qualifizierteMehrheit="true">Bundestag 3</meta:beschliessendesOrgan>
-                                                                                          <meta:beschliessendesOrgan start="2001-01-01" qualifizierteMehrheit="true">Bundestag 4</meta:beschliessendesOrgan>
-                                                                                        </meta:legalDocML.de_metadaten_ds>
-                                                                                      </akn:proprietary>
-                                                                                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                                                                        <akn:proprietary
+            xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                                                                          eId="meta-1_proprietary-1"
+                                                                          GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+                                                                          source="attributsemantik-noch-undefiniert"
+                                                                        >
+                                                                          <meta:legalDocML.de_metadaten_ds
+                                                                            xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+                                                                          >
+                                                                            <meta:beschliessendesOrgan end="1989-12-31" qualifizierteMehrheit="true">Bundestag 1</meta:beschliessendesOrgan>
+                                                                            <meta:beschliessendesOrgan start="1990-01-01" end="1994-12-31" qualifizierteMehrheit="true">Bundestag 2</meta:beschliessendesOrgan>
+                                                                            <meta:beschliessendesOrgan start="1995-01-01" end="2000-12-31" qualifizierteMehrheit="true">Bundestag 3</meta:beschliessendesOrgan>
+                                                                            <meta:beschliessendesOrgan start="2001-01-01" qualifizierteMehrheit="true">Bundestag 4</meta:beschliessendesOrgan>
+                                                                          </meta:legalDocML.de_metadaten_ds>
+                                                                        </akn:proprietary>
+                                                                        """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getBeschliessendesOrgan(LocalDate.parse("1980-01-01")))
-          .contains("Bundestag 1");
+        .contains("Bundestag 1");
 
       assertThat(proprietary.getBeschliessendesOrgan(LocalDate.parse("1990-01-01")))
-          .contains("Bundestag 2");
+        .contains("Bundestag 2");
       assertThat(proprietary.getBeschliessendesOrgan(LocalDate.parse("1992-01-01")))
-          .contains("Bundestag 2");
+        .contains("Bundestag 2");
       assertThat(proprietary.getBeschliessendesOrgan(LocalDate.parse("1994-12-31")))
-          .contains("Bundestag 2");
+        .contains("Bundestag 2");
 
       assertThat(proprietary.getBeschliessendesOrgan(LocalDate.parse("1995-01-01")))
-          .contains("Bundestag 3");
+        .contains("Bundestag 3");
       assertThat(proprietary.getBeschliessendesOrgan(LocalDate.parse("1998-01-01")))
-          .contains("Bundestag 3");
+        .contains("Bundestag 3");
       assertThat(proprietary.getBeschliessendesOrgan(LocalDate.parse("2000-12-31")))
-          .contains("Bundestag 3");
+        .contains("Bundestag 3");
 
       assertThat(proprietary.getBeschliessendesOrgan(LocalDate.parse("2001-01-01")))
-          .contains("Bundestag 4");
+        .contains("Bundestag 4");
       assertThat(proprietary.getBeschliessendesOrgan(LocalDate.parse("2024-01-01")))
-          .contains("Bundestag 4");
+        .contains("Bundestag 4");
     }
 
     @Test
     void returnsTheBeschliessendesOrganQualifizierteMehrheitAtDate() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                                                                      <akn:proprietary
-                          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                                                                                        eId="meta-1_proprietary-1"
-                                                                                                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                                                                                                        source="attributsemantik-noch-undefiniert"
-                                                                                                      >
-                                                                                                        <meta:legalDocML.de_metadaten_ds
-                                                                                                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                                                                                                        >
-                                                                                                          <meta:beschliessendesOrgan end="1989-12-31" qualifizierteMehrheit="true">Bundestag 1</meta:beschliessendesOrgan>
-                                                                                                          <meta:beschliessendesOrgan start="1990-01-01" end="1994-12-31" qualifizierteMehrheit="false">Bundestag 2</meta:beschliessendesOrgan>
-                                                                                                          <meta:beschliessendesOrgan start="1995-01-01" end="2000-12-31" qualifizierteMehrheit="true">Bundestag 3</meta:beschliessendesOrgan>
-                                                                                                          <meta:beschliessendesOrgan start="2001-01-01" qualifizierteMehrheit="false">Bundestag 4</meta:beschliessendesOrgan>
-                                                                                                        </meta:legalDocML.de_metadaten_ds>
-                                                                                                      </akn:proprietary>
-                                                                                                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                                                                                        <akn:proprietary
+            xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                                                                                          eId="meta-1_proprietary-1"
+                                                                                          GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+                                                                                          source="attributsemantik-noch-undefiniert"
+                                                                                        >
+                                                                                          <meta:legalDocML.de_metadaten_ds
+                                                                                            xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+                                                                                          >
+                                                                                            <meta:beschliessendesOrgan end="1989-12-31" qualifizierteMehrheit="true">Bundestag 1</meta:beschliessendesOrgan>
+                                                                                            <meta:beschliessendesOrgan start="1990-01-01" end="1994-12-31" qualifizierteMehrheit="false">Bundestag 2</meta:beschliessendesOrgan>
+                                                                                            <meta:beschliessendesOrgan start="1995-01-01" end="2000-12-31" qualifizierteMehrheit="true">Bundestag 3</meta:beschliessendesOrgan>
+                                                                                            <meta:beschliessendesOrgan start="2001-01-01" qualifizierteMehrheit="false">Bundestag 4</meta:beschliessendesOrgan>
+                                                                                          </meta:legalDocML.de_metadaten_ds>
+                                                                                        </akn:proprietary>
+                                                                                        """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getQualifizierteMehrheit(LocalDate.parse("1980-01-01")))
-          .contains(true);
+        .contains(true);
 
       assertThat(proprietary.getQualifizierteMehrheit(LocalDate.parse("1990-01-01")))
-          .contains(false);
+        .contains(false);
       assertThat(proprietary.getQualifizierteMehrheit(LocalDate.parse("1992-01-01")))
-          .contains(false);
+        .contains(false);
       assertThat(proprietary.getQualifizierteMehrheit(LocalDate.parse("1994-12-31")))
-          .contains(false);
+        .contains(false);
 
       assertThat(proprietary.getQualifizierteMehrheit(LocalDate.parse("1995-01-01")))
-          .contains(true);
+        .contains(true);
       assertThat(proprietary.getQualifizierteMehrheit(LocalDate.parse("1998-01-01")))
-          .contains(true);
+        .contains(true);
       assertThat(proprietary.getQualifizierteMehrheit(LocalDate.parse("2000-12-31")))
-          .contains(true);
+        .contains(true);
 
       assertThat(proprietary.getQualifizierteMehrheit(LocalDate.parse("2001-01-01")))
-          .contains(false);
+        .contains(false);
       assertThat(proprietary.getQualifizierteMehrheit(LocalDate.parse("2024-01-01")))
-          .contains(false);
+        .contains(false);
     }
   }
 
   @Nested
   class OrganisationsEinheit {
+
     @Test
     void returnsOrganisationsEinheit() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                      <akn:proprietary
-                          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                        eId="meta-1_proprietary-1"
-                                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                                        source="attributsemantik-noch-undefiniert"
-                                      >
-                                        <meta:legalDocML.de_metadaten_ds
-                                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                                        >
-                                          <meta:organisationsEinheit>Organisationseinheit 1</meta:organisationsEinheit>
-                                       </meta:legalDocML.de_metadaten_ds>
-                                      </akn:proprietary>
-                                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                        <akn:proprietary
+            xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                          eId="meta-1_proprietary-1"
+                          GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+                          source="attributsemantik-noch-undefiniert"
+                        >
+                          <meta:legalDocML.de_metadaten_ds
+                            xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+                          >
+                            <meta:organisationsEinheit>Organisationseinheit 1</meta:organisationsEinheit>
+                         </meta:legalDocML.de_metadaten_ds>
+                        </akn:proprietary>
+                        """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getOrganisationsEinheit(LocalDate.parse("2010-10-10")))
-          .contains("Organisationseinheit 1");
+        .contains("Organisationseinheit 1");
     }
 
     @Test
     void returnsEmptyOptionalIfOrganisationsEinheitIsMissing() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                                                      <akn:proprietary
-                          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                                                                        eId="meta-1_proprietary-1"
-                                                                                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                                                                                        source="attributsemantik-noch-undefiniert"
-                                                                                      >
-                                                                                        <meta:legalDocML.de_metadaten_ds
-                                                                                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                                                                                        >
-                                                                                        <!-- OrganisationsEinheit is missing -->
-                                                                                        </meta:legalDocML.de_metadaten_ds>
-                                                                                      </akn:proprietary>
-                                                                                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                                                                        <akn:proprietary
+            xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                                                                          eId="meta-1_proprietary-1"
+                                                                          GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+                                                                          source="attributsemantik-noch-undefiniert"
+                                                                        >
+                                                                          <meta:legalDocML.de_metadaten_ds
+                                                                            xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+                                                                          >
+                                                                          <!-- OrganisationsEinheit is missing -->
+                                                                          </meta:legalDocML.de_metadaten_ds>
+                                                                        </akn:proprietary>
+                                                                        """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getOrganisationsEinheit(LocalDate.parse("2010-10-10"))).isEmpty();
     }
 
     @Test
     void returnsTheOrganisationsEinheitAtDate() {
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                                                      <akn:proprietary
-                          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                                                                        eId="meta-1_proprietary-1"
-                                                                                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                                                                                        source="attributsemantik-noch-undefiniert"
-                                                                                      >
-                                                                                        <meta:legalDocML.de_metadaten_ds
-                                                                                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                                                                                        >
-                                                                                          <meta:organisationsEinheit end="1989-12-31">Organisationseinheit 1</meta:organisationsEinheit>
-                                                                                          <meta:organisationsEinheit start="1990-01-01" end="1994-12-31">Organisationseinheit 2</meta:organisationsEinheit>
-                                                                                          <meta:organisationsEinheit start="1995-01-01" end="2000-12-31">Organisationseinheit 3</meta:organisationsEinheit>
-                                                                                          <meta:organisationsEinheit start="2001-01-01">Organisationseinheit 4</meta:organisationsEinheit>
-                                                                                        </meta:legalDocML.de_metadaten_ds>
-                                                                                      </akn:proprietary>
-                                                                                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                                                                        <akn:proprietary
+            xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                                                                          eId="meta-1_proprietary-1"
+                                                                          GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+                                                                          source="attributsemantik-noch-undefiniert"
+                                                                        >
+                                                                          <meta:legalDocML.de_metadaten_ds
+                                                                            xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+                                                                          >
+                                                                            <meta:organisationsEinheit end="1989-12-31">Organisationseinheit 1</meta:organisationsEinheit>
+                                                                            <meta:organisationsEinheit start="1990-01-01" end="1994-12-31">Organisationseinheit 2</meta:organisationsEinheit>
+                                                                            <meta:organisationsEinheit start="1995-01-01" end="2000-12-31">Organisationseinheit 3</meta:organisationsEinheit>
+                                                                            <meta:organisationsEinheit start="2001-01-01">Organisationseinheit 4</meta:organisationsEinheit>
+                                                                          </meta:legalDocML.de_metadaten_ds>
+                                                                        </akn:proprietary>
+                                                                        """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getOrganisationsEinheit(LocalDate.parse("1980-01-01")))
-          .contains("Organisationseinheit 1");
+        .contains("Organisationseinheit 1");
 
       assertThat(proprietary.getOrganisationsEinheit(LocalDate.parse("1990-01-01")))
-          .contains("Organisationseinheit 2");
+        .contains("Organisationseinheit 2");
       assertThat(proprietary.getOrganisationsEinheit(LocalDate.parse("1992-01-01")))
-          .contains("Organisationseinheit 2");
+        .contains("Organisationseinheit 2");
       assertThat(proprietary.getOrganisationsEinheit(LocalDate.parse("1994-12-31")))
-          .contains("Organisationseinheit 2");
+        .contains("Organisationseinheit 2");
 
       assertThat(proprietary.getOrganisationsEinheit(LocalDate.parse("1995-01-01")))
-          .contains("Organisationseinheit 3");
+        .contains("Organisationseinheit 3");
       assertThat(proprietary.getOrganisationsEinheit(LocalDate.parse("1998-01-01")))
-          .contains("Organisationseinheit 3");
+        .contains("Organisationseinheit 3");
       assertThat(proprietary.getOrganisationsEinheit(LocalDate.parse("2000-12-31")))
-          .contains("Organisationseinheit 3");
+        .contains("Organisationseinheit 3");
 
       assertThat(proprietary.getOrganisationsEinheit(LocalDate.parse("2001-01-01")))
-          .contains("Organisationseinheit 4");
+        .contains("Organisationseinheit 4");
       assertThat(proprietary.getOrganisationsEinheit(LocalDate.parse("2024-01-01")))
-          .contains("Organisationseinheit 4");
+        .contains("Organisationseinheit 4");
     }
   }
 
   @Nested
   class EinzelelementArtDerNorm {
+
     @Test
     void returnsEinzelelementArtDerNorm() {
       var eid = "hauptteil-1_abschnitt-0_para-1";
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                            <akn:proprietary
-                          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                              eId="meta-1_proprietary-1"
-                                              GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                                              source="attributsemantik-noch-undefiniert"
-                                            >
-                                              <meta:legalDocML.de_metadaten_ds
-                                                xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                                              >
-                                                <meta:artDerNorm>SN,ÄN,ÜN</meta:artDerNorm>
-                                                <meta:einzelelement href="#hauptteil-1_abschnitt-0_para-1">
-                                                    <meta:artDerNorm>ÜN</meta:artDerNorm>
-                                                </meta:einzelelement>
-                                             </meta:legalDocML.de_metadaten_ds>
-                                            </akn:proprietary>
-                                            """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                              <akn:proprietary
+            xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                                eId="meta-1_proprietary-1"
+                                GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+                                source="attributsemantik-noch-undefiniert"
+                              >
+                                <meta:legalDocML.de_metadaten_ds
+                                  xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+                                >
+                                  <meta:artDerNorm>SN,ÄN,ÜN</meta:artDerNorm>
+                                  <meta:einzelelement href="#hauptteil-1_abschnitt-0_para-1">
+                                      <meta:artDerNorm>ÜN</meta:artDerNorm>
+                                  </meta:einzelelement>
+                               </meta:legalDocML.de_metadaten_ds>
+                              </akn:proprietary>
+                              """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getArtDerNorm(LocalDate.parse("2010-10-10"), eid)).contains("ÜN");
     }
@@ -1041,25 +1117,27 @@ class ProprietaryTest {
     @Test
     void returnsEmptyOptionalIfEinzelelementArtDerNormIsMissing() {
       var eid = "hauptteil-1_abschnitt-0_para-1";
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                                      <akn:proprietary
-                          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                                                        eId="meta-1_proprietary-1"
-                                                                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                                                                        source="attributsemantik-noch-undefiniert"
-                                                                      >
-                                                                        <meta:legalDocML.de_metadaten_ds
-                                                                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                                                                        >
-                                                                        <!-- ArtDerNorm is missing -->
-                                                                        </meta:legalDocML.de_metadaten_ds>
-                                                                      </akn:proprietary>
-                                                                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                                                        <akn:proprietary
+            xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                                                          eId="meta-1_proprietary-1"
+                                                          GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+                                                          source="attributsemantik-noch-undefiniert"
+                                                        >
+                                                          <meta:legalDocML.de_metadaten_ds
+                                                            xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+                                                          >
+                                                          <!-- ArtDerNorm is missing -->
+                                                          </meta:legalDocML.de_metadaten_ds>
+                                                        </akn:proprietary>
+                                                        """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getArtDerNorm(LocalDate.parse("2010-10-10"), eid)).isEmpty();
     }
@@ -1067,34 +1145,36 @@ class ProprietaryTest {
     @Test
     void returnsTheEinzelelementArtDerNormAtDate() {
       var eid = "hauptteil-1_abschnitt-0_para-1";
-      final Proprietary proprietary =
-          Proprietary.builder()
-              .node(
-                  XmlMapper.toNode(
-                      """
-                                                                      <akn:proprietary
-                          xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
-                                                                        eId="meta-1_proprietary-1"
-                                                                        GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
-                                                                        source="attributsemantik-noch-undefiniert"
-                                                                      >
-                                                                        <meta:legalDocML.de_metadaten_ds
-                                                                          xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
-                                                                        >
-                                                                          <meta:artDerNorm end="1989-12-31">SN,ÄN,ÜN</meta:artDerNorm>
-                                                                          <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN,ÄN</meta:artDerNorm>
-                                                                          <meta:artDerNorm start="1995-01-01" end="2000-12-31">SN,ÜN</meta:artDerNorm>
-                                                                          <meta:artDerNorm start="2001-01-01">ÄN,ÜN</meta:artDerNorm>
-                                                                          <meta:einzelelement href="#hauptteil-1_abschnitt-0_para-1">
-                                                                              <meta:artDerNorm end="1989-12-31">ÜN</meta:artDerNorm>
-                                                                              <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN</meta:artDerNorm>
-                                                                              <meta:artDerNorm start="1995-01-01" end="2000-12-31">ÄN</meta:artDerNorm>
-                                                                              <meta:artDerNorm start="2001-01-01">ÜN</meta:artDerNorm>
-                                                                          </meta:einzelelement>
-                                                                        </meta:legalDocML.de_metadaten_ds>
-                                                                      </akn:proprietary>
-                                                                      """))
-              .build();
+      final Proprietary proprietary = Proprietary
+        .builder()
+        .node(
+          XmlMapper.toNode(
+            """
+                                                        <akn:proprietary
+            xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/"
+                                                          eId="meta-1_proprietary-1"
+                                                          GUID="952262d3-de92-4c1d-a06d-95aa94f5f21c"
+                                                          source="attributsemantik-noch-undefiniert"
+                                                        >
+                                                          <meta:legalDocML.de_metadaten_ds
+                                                            xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/"
+                                                          >
+                                                            <meta:artDerNorm end="1989-12-31">SN,ÄN,ÜN</meta:artDerNorm>
+                                                            <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN,ÄN</meta:artDerNorm>
+                                                            <meta:artDerNorm start="1995-01-01" end="2000-12-31">SN,ÜN</meta:artDerNorm>
+                                                            <meta:artDerNorm start="2001-01-01">ÄN,ÜN</meta:artDerNorm>
+                                                            <meta:einzelelement href="#hauptteil-1_abschnitt-0_para-1">
+                                                                <meta:artDerNorm end="1989-12-31">ÜN</meta:artDerNorm>
+                                                                <meta:artDerNorm start="1990-01-01" end="1994-12-31">SN</meta:artDerNorm>
+                                                                <meta:artDerNorm start="1995-01-01" end="2000-12-31">ÄN</meta:artDerNorm>
+                                                                <meta:artDerNorm start="2001-01-01">ÜN</meta:artDerNorm>
+                                                            </meta:einzelelement>
+                                                          </meta:legalDocML.de_metadaten_ds>
+                                                        </akn:proprietary>
+                                                        """
+          )
+        )
+        .build();
 
       assertThat(proprietary.getArtDerNorm(LocalDate.parse("1980-01-01"), eid)).contains("ÜN");
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/SimpleProprietaryTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/SimpleProprietaryTest.java
@@ -10,84 +10,96 @@ class SimpleProprietaryTest {
 
   @Test
   void getValue() {
-    final SimpleProprietary fna =
-        SimpleProprietary.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                            <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
-                           """))
-            .build();
+    final SimpleProprietary fna = SimpleProprietary
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+           <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
+          """
+        )
+      )
+      .build();
 
     assertThat(fna.getValue()).isEqualTo("111-11-1");
   }
 
   @Test
   void getValueNull() {
-    final SimpleProprietary fna =
-        SimpleProprietary.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                                            <meta:fna start="1990-01-01" end="1994-12-31"></meta:fna>
-                                           """))
-            .build();
+    final SimpleProprietary fna = SimpleProprietary
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+           <meta:fna start="1990-01-01" end="1994-12-31"></meta:fna>
+          """
+        )
+      )
+      .build();
 
     assertThat(fna.getValue()).isEmpty();
   }
 
   @Test
   void getStart() {
-    final SimpleProprietary fna =
-        SimpleProprietary.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                                            <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
-                                           """))
-            .build();
+    final SimpleProprietary fna = SimpleProprietary
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+           <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
+          """
+        )
+      )
+      .build();
 
     assertThat(fna.getStart()).contains(LocalDate.parse("1990-01-01"));
   }
 
   @Test
   void getStartEmpty() {
-    final SimpleProprietary fna =
-        SimpleProprietary.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                                            <meta:fna end="1994-12-31">111-11-1</meta:fna>
-                                           """))
-            .build();
+    final SimpleProprietary fna = SimpleProprietary
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+           <meta:fna end="1994-12-31">111-11-1</meta:fna>
+          """
+        )
+      )
+      .build();
 
     assertThat(fna.getStart()).isEmpty();
   }
 
   @Test
   void getEnd() {
-    final SimpleProprietary fna =
-        SimpleProprietary.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                                            <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
-                                           """))
-            .build();
+    final SimpleProprietary fna = SimpleProprietary
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+           <meta:fna start="1990-01-01" end="1994-12-31">111-11-1</meta:fna>
+          """
+        )
+      )
+      .build();
 
     assertThat(fna.getEnd()).contains(LocalDate.parse("1994-12-31"));
   }
 
   @Test
   void getEndEmpty() {
-    final SimpleProprietary fna =
-        SimpleProprietary.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                                            <meta:fna start="1990-01-01">111-11-1</meta:fna>
-                                           """))
-            .build();
+    final SimpleProprietary fna = SimpleProprietary
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+           <meta:fna start="1990-01-01">111-11-1</meta:fna>
+          """
+        )
+      )
+      .build();
 
     assertThat(fna.getEnd()).isEmpty();
   }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/TemporalDataTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/TemporalDataTest.java
@@ -10,23 +10,25 @@ class TemporalDataTest {
   @Test
   void getTemporalGroups() {
     // given
-    final TemporalData temporalData =
-        TemporalData.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                              <akn:temporalData xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1" GUID="58a31120-e277-4a33-a093-6a3637fd603d" source="attributsemantik-noch-undefiniert">
-                                        <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ee45119b-2485-4115-b587-da54b95e3ebd">
-                                           <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="a43d0287-920d-4fbb-91d1-42fd7e03fe16"
-                                                             start="#meta-1_lebzykl-1_ereignis-2" refersTo="geltungszeit"/>
-                                        </akn:temporalGroup>
-                                        <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="0477223f-0f4e-4f79-9656-5ff7d2afd9c4">
-                                           <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="ebd52dd5-7122-4000-93e8-b6e96d0ac75f"
-                                                             start="#meta-1_lebzykl-1_ereignis-4" refersTo="geltungszeit"/>
-                                        </akn:temporalGroup>
-                                    </akn:temporalData>
-                           """))
-            .build();
+    final TemporalData temporalData = TemporalData
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+             <akn:temporalData xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1" GUID="58a31120-e277-4a33-a093-6a3637fd603d" source="attributsemantik-noch-undefiniert">
+                       <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ee45119b-2485-4115-b587-da54b95e3ebd">
+                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="a43d0287-920d-4fbb-91d1-42fd7e03fe16"
+                                            start="#meta-1_lebzykl-1_ereignis-2" refersTo="geltungszeit"/>
+                       </akn:temporalGroup>
+                       <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="0477223f-0f4e-4f79-9656-5ff7d2afd9c4">
+                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="ebd52dd5-7122-4000-93e8-b6e96d0ac75f"
+                                            start="#meta-1_lebzykl-1_ereignis-4" refersTo="geltungszeit"/>
+                       </akn:temporalGroup>
+                   </akn:temporalData>
+          """
+        )
+      )
+      .build();
 
     assertThat(temporalData.getTemporalGroups()).hasSize(2);
   }
@@ -34,15 +36,17 @@ class TemporalDataTest {
   @Test
   void getTemporalGroupsEmptyList() {
     // given
-    final TemporalData temporalData =
-        TemporalData.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:temporalData xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1" GUID="58a31120-e277-4a33-a093-6a3637fd603d" source="attributsemantik-noch-undefiniert">
-                             </akn:temporalData>
-                            """))
-            .build();
+    final TemporalData temporalData = TemporalData
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:temporalData xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1" GUID="58a31120-e277-4a33-a093-6a3637fd603d" source="attributsemantik-noch-undefiniert">
+               </akn:temporalData>
+              """
+        )
+      )
+      .build();
 
     assertThat(temporalData.getTemporalGroups()).isEmpty();
   }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/TemporalGroupTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/TemporalGroupTest.java
@@ -10,16 +10,18 @@ class TemporalGroupTest {
   @Test
   void getEid() {
     // given
-    TemporalGroup temporalGroup =
-        TemporalGroup.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:temporalGroup xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                           <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                        </akn:temporalGroup>
-                        """))
-            .build();
+    TemporalGroup temporalGroup = TemporalGroup
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:temporalGroup xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+             <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+          </akn:temporalGroup>
+          """
+        )
+      )
+      .build();
 
     // when
     var eid = temporalGroup.getEid();
@@ -31,16 +33,18 @@ class TemporalGroupTest {
   @Test
   void getEventRefEId() {
     // given
-    TemporalGroup temporalGroup =
-        TemporalGroup.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:temporalGroup xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                           <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                        </akn:temporalGroup>
-                        """))
-            .build();
+    TemporalGroup temporalGroup = TemporalGroup
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:temporalGroup xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+             <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+          </akn:temporalGroup>
+          """
+        )
+      )
+      .build();
 
     // when
     var timeInterval = temporalGroup.getTimeInterval();

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/TextualModTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/TextualModTest.java
@@ -9,22 +9,22 @@ import org.junit.jupiter.api.Test;
 class TextualModTest {
 
   private static final String COMMON_XML =
-      """
-          <akn:textualMod xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_analysis-1_activemod-1_textualmod-1"
-                          GUID="2e5533d3-d0e3-43ba-aa1a-5859d108eb46"
-                          type="substitution">
-            <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-1_source-1"
-                        GUID="8b3e1841-5d63-4400-96ae-214f6ee28db6"
-                        href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1"/>
-            <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-1_destination-1"
-                             GUID="94c1e417-e849-4269-8320-9f0173b39626"
-                             href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-9_abs-3/100-126.xml"
-                             upTo="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-9_abs-4.xml"/>
-            <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-1_gelzeitnachw-1"
-                       GUID="6f5eabe9-1102-4d29-9d25-a44643354519"
-                       period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
-          </akn:textualMod>
-          """;
+    """
+    <akn:textualMod xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_analysis-1_activemod-1_textualmod-1"
+                    GUID="2e5533d3-d0e3-43ba-aa1a-5859d108eb46"
+                    type="substitution">
+      <akn:source eId="meta-1_analysis-1_activemod-1_textualmod-1_source-1"
+                  GUID="8b3e1841-5d63-4400-96ae-214f6ee28db6"
+                  href="#hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1"/>
+      <akn:destination eId="meta-1_analysis-1_activemod-1_textualmod-1_destination-1"
+                       GUID="94c1e417-e849-4269-8320-9f0173b39626"
+                       href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-9_abs-3/100-126.xml"
+                       upTo="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-9_abs-4.xml"/>
+      <akn:force eId="meta-1_analysis-1_activemod-1_textualmod-1_gelzeitnachw-1"
+                 GUID="6f5eabe9-1102-4d29-9d25-a44643354519"
+                 period="#meta-1_geltzeiten-1_geltungszeitgr-1"/>
+    </akn:textualMod>
+    """;
 
   private TextualMod textualMod;
 
@@ -58,9 +58,9 @@ class TextualModTest {
 
     // then
     assertThat(sourceHref)
-        .contains(
-            new Href(
-                "#hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1"));
+      .contains(
+        new Href("#hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1")
+      );
   }
 
   @Test
@@ -70,44 +70,53 @@ class TextualModTest {
 
     // then
     assertThat(destinationHref)
-        .contains(
-            new Href(
-                "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-9_abs-3/100-126.xml"));
+      .contains(
+        new Href(
+          "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-9_abs-3/100-126.xml"
+        )
+      );
   }
 
   @Test
   void setDestinationHref() {
     // when
     textualMod.setDestinationHref(
-        "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-9_abs-3/100-130.xml");
+      "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-9_abs-3/100-130.xml"
+    );
     var destinationHref = textualMod.getDestinationHref();
 
     // then
     assertThat(destinationHref)
-        .contains(
-            new Href(
-                "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-9_abs-3/100-130.xml"));
+      .contains(
+        new Href(
+          "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-9_abs-3/100-130.xml"
+        )
+      );
   }
 
   @Test
   void setDestinationUpto() {
     // when
     textualMod.setDestinationUpTo(
-        "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-9_abs-3/100-130.xml");
+      "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-9_abs-3/100-130.xml"
+    );
     var destinationUpTo = textualMod.getDestinationUpTo();
 
     // then
     assertThat(destinationUpTo)
-        .contains(
-            new Href(
-                "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-9_abs-3/100-130.xml"));
+      .contains(
+        new Href(
+          "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-9_abs-3/100-130.xml"
+        )
+      );
   }
 
   @Test
   void deleteDestinationUpto() {
     // given
     textualMod.setDestinationUpTo(
-        "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-9_abs-3/100-130.xml");
+      "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-9_abs-3/100-130.xml"
+    );
 
     // when
     textualMod.setDestinationUpTo(null);

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/TimeBoundaryTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/TimeBoundaryTest.java
@@ -9,30 +9,29 @@ import org.junit.jupiter.api.Test;
 class TimeBoundaryTest {
 
   String xml =
-      """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                               </akn:lifecycle>
-                               <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                           <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                              <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                           </akn:temporalGroup>
-                               </akn:temporalData>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """
-          .strip();
+    """
+      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+         <akn:act name="regelungstext">
+            <!-- Metadaten -->
+            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+               <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+               </akn:lifecycle>
+               <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                           <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                              <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                           </akn:temporalGroup>
+               </akn:temporalData>
+            </akn:meta>
+         </akn:act>
+      </akn:akomaNtoso>
+    """.strip();
 
   @Test
   void getDate() {
@@ -79,6 +78,6 @@ class TimeBoundaryTest {
 
     // then
     assertThat(tb.getTimeIntervalEid())
-        .contains("meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1");
+      .contains("meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1");
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/TimeIntervalTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/TimeIntervalTest.java
@@ -10,14 +10,16 @@ class TimeIntervalTest {
   @Test
   void getEventRefEId() {
     // given
-    final TimeInterval timeInterval =
-        TimeInterval.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:timeInterval xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                           """))
-            .build();
+    final TimeInterval timeInterval = TimeInterval
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:timeInterval xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+             """
+        )
+      )
+      .build();
 
     assertThat(timeInterval.getEventRefEId()).contains("meta-1_lebzykl-1_ereignis-2");
   }
@@ -25,14 +27,16 @@ class TimeIntervalTest {
   @Test
   void getEventRefEIdEmpty() {
     // given
-    final TimeInterval timeInterval =
-        TimeInterval.builder()
-            .node(
-                XmlMapper.toNode(
-                    """
-                        <akn:timeInterval xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" />
-                                           """))
-            .build();
+    final TimeInterval timeInterval = TimeInterval
+      .builder()
+      .node(
+        XmlMapper.toNode(
+          """
+          <akn:timeInterval xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" />
+                             """
+        )
+      )
+      .build();
 
     assertThat(timeInterval.getEventRefEId()).isEmpty();
   }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/helper/MemoryAppender.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/helper/MemoryAppender.java
@@ -6,18 +6,20 @@ import ch.qos.logback.core.read.ListAppender;
 import java.util.List;
 
 public class MemoryAppender extends ListAppender<ILoggingEvent> {
+
   public void reset() {
     this.list.clear();
   }
 
   public boolean contains(String string, Level level) {
     return this.list.stream()
-        .anyMatch(event -> event.toString().contains(string) && event.getLevel().equals(level));
+      .anyMatch(event -> event.toString().contains(string) && event.getLevel().equals(level));
   }
 
   public int countEventsForLogger(String loggerName) {
-    return (int)
-        this.list.stream().filter(event -> event.getLoggerName().contains(loggerName)).count();
+    return (int) this.list.stream()
+      .filter(event -> event.getLoggerName().contains(loggerName))
+      .count();
   }
 
   public List<ILoggingEvent> search(String string) {
@@ -26,8 +28,8 @@ public class MemoryAppender extends ListAppender<ILoggingEvent> {
 
   public List<ILoggingEvent> search(String string, Level level) {
     return this.list.stream()
-        .filter(event -> event.toString().contains(string) && event.getLevel().equals(level))
-        .toList();
+      .filter(event -> event.toString().contains(string) && event.getLevel().equals(level))
+      .toList();
   }
 
   public int getSize() {

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/BaseIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/BaseIntegrationTest.java
@@ -25,8 +25,9 @@ import org.testcontainers.utility.DockerImageName;
  */
 @DirtiesContext
 @SpringBootTest(
-    webEnvironment = WebEnvironment.RANDOM_PORT,
-    properties = "spring.flyway.locations=classpath:db/migration")
+  webEnvironment = WebEnvironment.RANDOM_PORT,
+  properties = "spring.flyway.locations=classpath:db/migration"
+)
 @AutoConfigureDataJpa
 @AutoConfigureMockMvc
 @Testcontainers(disabledWithoutDocker = true)
@@ -34,28 +35,29 @@ import org.testcontainers.utility.DockerImageName;
 public abstract class BaseIntegrationTest {
 
   @Container
-  static final PostgreSQLContainer<?> postgreSQLContainer =
-      new PostgreSQLContainer<>("postgres:15")
-          .withDatabaseName("postgres")
-          .withUsername("postgres")
-          .withPassword("pass");
+  static final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:15")
+    .withDatabaseName("postgres")
+    .withUsername("postgres")
+    .withPassword("pass");
 
   @Container
-  static final GenericContainer<?> redis =
-      new GenericContainer<>(DockerImageName.parse("cgr.dev/chainguard/redis"))
-          .withExposedPorts(6379);
+  static final GenericContainer<?> redis = new GenericContainer<>(
+    DockerImageName.parse("cgr.dev/chainguard/redis")
+  )
+    .withExposedPorts(6379);
 
   @DynamicPropertySource
   static void registerDynamicProperties(DynamicPropertyRegistry registry) {
     registry.add("spring.datasource.username", postgreSQLContainer::getUsername);
     registry.add("spring.datasource.password", postgreSQLContainer::getPassword);
     registry.add(
-        "spring.datasource.url",
-        () ->
-            "jdbc:postgresql://localhost:%d/%s"
-                .formatted(
-                    postgreSQLContainer.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT),
-                    postgreSQLContainer.getDatabaseName()));
+      "spring.datasource.url",
+      () ->
+        "jdbc:postgresql://localhost:%d/%s".formatted(
+            postgreSQLContainer.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT),
+            postgreSQLContainer.getDatabaseName()
+          )
+    );
 
     registry.add("spring.data.redis.host", redis::getHost);
     registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379).toString());

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/SecurityTxtIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/SecurityTxtIntegrationTest.java
@@ -13,10 +13,12 @@ class SecurityTxtIntegrationTest extends BaseIntegrationTest {
 
   @Test
   void shouldExposeSecurityTxt(@Autowired MockMvc mvc) throws Exception {
-    mvc.perform(get("/.well-known/security.txt"))
-        .andExpectAll(
-            status().isOk(),
-            header().stringValues("Content-Type", MediaType.TEXT_PLAIN.toString()),
-            content().string(containsString("Contact: ")));
+    mvc
+      .perform(get("/.well-known/security.txt"))
+      .andExpectAll(
+        status().isOk(),
+        header().stringValues("Content-Type", MediaType.TEXT_PLAIN.toString()),
+        content().string(containsString("Contact: "))
+      );
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/SessionIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/SessionIntegrationTest.java
@@ -13,11 +13,11 @@ import org.springframework.test.web.servlet.MockMvc;
 
 class SessionIntegrationTest extends BaseIntegrationTest {
 
-  @Autowired private RedisTemplate<String, String> redisTemplate;
+  @Autowired
+  private RedisTemplate<String, String> redisTemplate;
 
   @Test
   void sessionShouldBePersistedToRedis(@Autowired MockMvc mvc) throws Exception {
-
     final Set<String> keysBefore = redisTemplate.keys("*");
     assertThat(keysBefore).isEmpty();
 
@@ -29,17 +29,19 @@ class SessionIntegrationTest extends BaseIntegrationTest {
 
   @Test
   void setCookieHeaderShouldBePresentInResponse(@Autowired MockMvc mvc) throws Exception {
-
-    final HttpServletResponse response =
-        mvc.perform(get("/actuator/health")).andExpect(status().isOk()).andReturn().getResponse();
+    final HttpServletResponse response = mvc
+      .perform(get("/actuator/health"))
+      .andExpect(status().isOk())
+      .andReturn()
+      .getResponse();
 
     final String setCookieHeader = response.getHeader("Set-Cookie");
     assertThat(setCookieHeader)
-        .isNotNull()
-        .contains("SESSION=")
-        .contains("; Max-Age=43200")
-        .contains("; Expires=")
-        .contains("; HttpOnly")
-        .contains("; SameSite=Lax");
+      .isNotNull()
+      .contains("SESSION=")
+      .contains("; Max-Age=43200")
+      .contains("; Expires=")
+      .contains("; HttpOnly")
+      .contains("; SameSite=Lax");
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/AnnouncementControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/AnnouncementControllerIntegrationTest.java
@@ -24,10 +24,14 @@ import org.springframework.test.web.servlet.MockMvc;
 
 class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
 
-  @Autowired private MockMvc mockMvc;
+  @Autowired
+  private MockMvc mockMvc;
 
-  @Autowired private AnnouncementRepository announcementRepository;
-  @Autowired private NormRepository normRepository;
+  @Autowired
+  private AnnouncementRepository announcementRepository;
+
+  @Autowired
+  private NormRepository normRepository;
 
   @AfterEach
   void cleanUp() {
@@ -41,212 +45,229 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
 
     // when
     mockMvc
-        .perform(get("/api/v1/announcements").accept(MediaType.APPLICATION_JSON))
-        // then
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$[0]").doesNotExist());
+      .perform(get("/api/v1/announcements").accept(MediaType.APPLICATION_JSON))
+      // then
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$[0]").doesNotExist());
   }
 
   @Test
   void itReturnsAllAnnouncementsNorm() throws Exception {
     // Given
-    var norm =
-        Norm.builder()
-            .document(
-                XmlMapper.toDocument(
-                    """
-                        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                           <akn:act name="regelungstext">
-                              <!-- Metadaten -->
-                              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                    <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                       <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="413" />
-                                       <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
-                                       <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="2023-12-29" name="verkuendungsfassung" />
-                                    </akn:FRBRWork>
-                                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
-                                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                                       <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                                    </akn:FRBRExpression>
-                                </akn:identification>
-                              </akn:meta>
+    var norm = Norm
+      .builder()
+      .document(
+        XmlMapper.toDocument(
+          """
+          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+             <akn:act name="regelungstext">
+                <!-- Metadaten -->
+                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                      <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                         <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="413" />
+                         <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                         <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="2023-12-29" name="verkuendungsfassung" />
+                      </akn:FRBRWork>
+                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
+                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                         <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                      </akn:FRBRExpression>
+                  </akn:identification>
+                </akn:meta>
 
-                              <akn:preface eId="einleitung-1" GUID="fc10e89f-fde4-44bf-aa98-b6bdea01f0ea">
-                                 <akn:longTitle eId="einleitung-1_doktitel-1" GUID="abbb08de-e7e2-40ab-aba0-079ce786e6d6">
-                                    <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="3e7c2134-d82c-44ba-b50d-bad9790375a0">
-                                       <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Gesetz zum ersten Teil der Reform des Nachrichtendienstrechts</akn:docTitle>
-                                    </akn:p>
-                                 </akn:longTitle>
-                              </akn:preface>
-                           </akn:act>
-                        </akn:akomaNtoso>
-                        """))
-            .build();
+                <akn:preface eId="einleitung-1" GUID="fc10e89f-fde4-44bf-aa98-b6bdea01f0ea">
+                   <akn:longTitle eId="einleitung-1_doktitel-1" GUID="abbb08de-e7e2-40ab-aba0-079ce786e6d6">
+                      <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="3e7c2134-d82c-44ba-b50d-bad9790375a0">
+                         <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Gesetz zum ersten Teil der Reform des Nachrichtendienstrechts</akn:docTitle>
+                      </akn:p>
+                   </akn:longTitle>
+                </akn:preface>
+             </akn:act>
+          </akn:akomaNtoso>
+          """
+        )
+      )
+      .build();
     var announcement = Announcement.builder().norm(norm).releasedByDocumentalistAt(null).build();
     announcementRepository.save(AnnouncementMapper.mapToDto(announcement));
 
     // When
     mockMvc
-        .perform(get("/api/v1/announcements").accept(MediaType.APPLICATION_JSON))
-        // Then
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$[0]").exists())
-        .andExpect(jsonPath("$[1]").doesNotExist())
-        .andExpect(
-            jsonPath(
-                "$[0].title",
-                equalTo("Gesetz zum ersten Teil der Reform des Nachrichtendienstrechts")))
-        .andExpect(
-            jsonPath(
-                "$[0].eli", equalTo("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1")));
+      .perform(get("/api/v1/announcements").accept(MediaType.APPLICATION_JSON))
+      // Then
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$[0]").exists())
+      .andExpect(jsonPath("$[1]").doesNotExist())
+      .andExpect(
+        jsonPath(
+          "$[0].title",
+          equalTo("Gesetz zum ersten Teil der Reform des Nachrichtendienstrechts")
+        )
+      )
+      .andExpect(
+        jsonPath("$[0].eli", equalTo("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1"))
+      );
   }
 
   @Test
   void itReturnsRelease() throws Exception {
     // Given
-    var amendingNorm =
-        Norm.builder()
-            .document(
-                XmlMapper.toDocument(
-                    """
-                             <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                           <akn:act name="regelungstext">
+    var amendingNorm = Norm
+      .builder()
+      .document(
+        XmlMapper.toDocument(
+          """
+               <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+             <akn:act name="regelungstext">
 
-                              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
-                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                    </akn:FRBRExpression>
-                                 </akn:identification>
-                              </akn:meta>
-                              <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                 <!-- Artikel 1 : Hauptänderung -->
-                                 <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                    <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                       <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                                    <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                                    <!-- Absatz (1) -->
-                                    <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                                       <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                                          <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                                       </akn:num>
-                                       <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                          <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                             <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                                   href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                          </akn:intro>
-                                       </akn:list>
-                                    </akn:paragraph>
-                                 </akn:article>
-                                  <!-- Artikel 3: Geltungszeitregel-->
-                                  <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                     <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                        <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
-                                     <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                                     <!-- Absatz (1) -->
-                                     <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                        <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-                                           <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
-                                        </akn:num>
-                                        <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                           <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                              nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                        </akn:content>
-                                     </akn:paragraph>
-                                  </akn:article>
-                              </akn:body>
-                           </akn:act>
-                        </akn:akomaNtoso>
-                        """))
-            .build();
-    var affectedNorm =
-        Norm.builder()
-            .document(
-                XmlMapper.toDocument(
-                    """
-                          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                             <akn:act name="regelungstext">
-                                <!-- Metadaten -->
-                                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="49eec691-392b-4d77-abaf-23eb871132ad" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
-                                      </akn:FRBRExpression>
-                                  </akn:identification>
-                                </akn:meta>
-                             </akn:act>
-                          </akn:akomaNtoso>
-                        """))
-            .build();
-    var affectedNormZf0 =
-        Norm.builder()
-            .document(
-                XmlMapper.toDocument(
-                    """
-                          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                             <akn:act name="regelungstext">
-                                <!-- Metadaten -->
-                                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
-                                      </akn:FRBRExpression>
-                                  </akn:identification>
-                                </akn:meta>
-                             </akn:act>
-                          </akn:akomaNtoso>
-                        """))
-            .build();
-    var announcement =
-        Announcement.builder()
-            .norm(amendingNorm)
-            .releasedByDocumentalistAt(Instant.parse("2024-01-02T10:20:30.0Z"))
-            .build();
+                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
+                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                      </akn:FRBRExpression>
+                   </akn:identification>
+                </akn:meta>
+                <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                   <!-- Artikel 1 : Hauptänderung -->
+                   <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                      <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                         <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                      <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                      <!-- Absatz (1) -->
+                      <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                         <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                            <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                         </akn:num>
+                         <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                            <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                               <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                     href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                            </akn:intro>
+                         </akn:list>
+                      </akn:paragraph>
+                   </akn:article>
+                    <!-- Artikel 3: Geltungszeitregel-->
+                    <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                       <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
+                          <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
+                       <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+                       <!-- Absatz (1) -->
+                       <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
+                          <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
+                             <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
+                          </akn:num>
+                          <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
+                             <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
+                                nach der Verkündung</akn:date> in Kraft. </akn:p>
+                          </akn:content>
+                       </akn:paragraph>
+                    </akn:article>
+                </akn:body>
+             </akn:act>
+          </akn:akomaNtoso>
+          """
+        )
+      )
+      .build();
+    var affectedNorm = Norm
+      .builder()
+      .document(
+        XmlMapper.toDocument(
+          """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+               <akn:act name="regelungstext">
+                  <!-- Metadaten -->
+                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="49eec691-392b-4d77-abaf-23eb871132ad" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
+                        </akn:FRBRExpression>
+                    </akn:identification>
+                  </akn:meta>
+               </akn:act>
+            </akn:akomaNtoso>
+          """
+        )
+      )
+      .build();
+    var affectedNormZf0 = Norm
+      .builder()
+      .document(
+        XmlMapper.toDocument(
+          """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+               <akn:act name="regelungstext">
+                  <!-- Metadaten -->
+                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
+                        </akn:FRBRExpression>
+                    </akn:identification>
+                  </akn:meta>
+               </akn:act>
+            </akn:akomaNtoso>
+          """
+        )
+      )
+      .build();
+    var announcement = Announcement
+      .builder()
+      .norm(amendingNorm)
+      .releasedByDocumentalistAt(Instant.parse("2024-01-02T10:20:30.0Z"))
+      .build();
     announcementRepository.save(AnnouncementMapper.mapToDto(announcement));
     normRepository.save(NormMapper.mapToDto(affectedNorm));
     normRepository.save(NormMapper.mapToDto(affectedNormZf0));
 
     // When
     mockMvc
-        .perform(
-            get("/api/v1/announcements/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/release")
-                .accept(MediaType.APPLICATION_JSON))
-        // Then
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("releaseAt", equalTo("2024-01-02T10:20:30Z")))
-        .andExpect(
-            jsonPath(
-                "amendingLawEli",
-                equalTo("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1")))
-        .andExpect(jsonPath("zf0Elis[0]").exists())
-        .andExpect(jsonPath("zf0Elis[1]").doesNotExist())
-        .andExpect(
-            jsonPath(
-                "zf0Elis[0]",
-                equalTo("eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1")));
+      .perform(
+        get(
+          "/api/v1/announcements/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/release"
+        )
+          .accept(MediaType.APPLICATION_JSON)
+      )
+      // Then
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("releaseAt", equalTo("2024-01-02T10:20:30Z")))
+      .andExpect(
+        jsonPath(
+          "amendingLawEli",
+          equalTo("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1")
+        )
+      )
+      .andExpect(jsonPath("zf0Elis[0]").exists())
+      .andExpect(jsonPath("zf0Elis[1]").doesNotExist())
+      .andExpect(
+        jsonPath(
+          "zf0Elis[0]",
+          equalTo("eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1")
+        )
+      );
   }
 
   @Test
@@ -255,153 +276,173 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
 
     // when
     mockMvc
-        .perform(
-            put("/api/v1/announcements/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/release")
-                .accept(MediaType.APPLICATION_JSON))
-        // then
-        .andExpect(status().isNotFound())
-        .andExpect(
-            result ->
-                assertEquals(
-                    "Announcement for norm with eli eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1 does not exist",
-                    Objects.requireNonNull(result.getResolvedException()).getMessage()));
+      .perform(
+        put(
+          "/api/v1/announcements/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/release"
+        )
+          .accept(MediaType.APPLICATION_JSON)
+      )
+      // then
+      .andExpect(status().isNotFound())
+      .andExpect(result ->
+        assertEquals(
+          "Announcement for norm with eli eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1 does not exist",
+          Objects.requireNonNull(result.getResolvedException()).getMessage()
+        )
+      );
   }
 
   @Test
   void itReleaseAnnouncement() throws Exception {
     // Given
-    var amendingNorm =
-        Norm.builder()
-            .document(
-                XmlMapper.toDocument(
-                    """
-                             <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                           <akn:act name="regelungstext">
+    var amendingNorm = Norm
+      .builder()
+      .document(
+        XmlMapper.toDocument(
+          """
+               <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+             <akn:act name="regelungstext">
 
-                              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
-                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                    </akn:FRBRExpression>
-                                 </akn:identification>
-                              </akn:meta>
-                              <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                 <!-- Artikel 1 : Hauptänderung -->
-                                 <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                    <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                       <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                                    <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                                    <!-- Absatz (1) -->
-                                    <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                                       <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                                          <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                                       </akn:num>
-                                       <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                          <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                             <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                                   href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                          </akn:intro>
-                                       </akn:list>
-                                    </akn:paragraph>
-                                 </akn:article>
-                                  <!-- Artikel 3: Geltungszeitregel-->
-                                  <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                     <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                        <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
-                                     <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                                     <!-- Absatz (1) -->
-                                     <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                        <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-                                           <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
-                                        </akn:num>
-                                        <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                           <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                              nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                        </akn:content>
-                                     </akn:paragraph>
-                                  </akn:article>
-                              </akn:body>
-                           </akn:act>
-                        </akn:akomaNtoso>
-                        """))
-            .build();
-    var affectedNorm =
-        Norm.builder()
-            .document(
-                XmlMapper.toDocument(
-                    """
-                          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                             <akn:act name="regelungstext">
-                                <!-- Metadaten -->
-                                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="49eec691-392b-4d77-abaf-23eb871132ad" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
-                                      </akn:FRBRExpression>
-                                  </akn:identification>
-                                </akn:meta>
-                             </akn:act>
-                          </akn:akomaNtoso>
-                        """))
-            .build();
-    var affectedNormZf0 =
-        Norm.builder()
-            .document(
-                XmlMapper.toDocument(
-                    """
-                          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                             <akn:act name="regelungstext">
-                                <!-- Metadaten -->
-                                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
-                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
-                                      </akn:FRBRExpression>
-                                  </akn:identification>
-                                </akn:meta>
-                             </akn:act>
-                          </akn:akomaNtoso>
-                        """))
-            .build();
-    var announcement =
-        Announcement.builder().norm(amendingNorm).releasedByDocumentalistAt(null).build();
+                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
+                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                      </akn:FRBRExpression>
+                   </akn:identification>
+                </akn:meta>
+                <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                   <!-- Artikel 1 : Hauptänderung -->
+                   <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                      <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                         <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                      <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                      <!-- Absatz (1) -->
+                      <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                         <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                            <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                         </akn:num>
+                         <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                            <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                               <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                     href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                            </akn:intro>
+                         </akn:list>
+                      </akn:paragraph>
+                   </akn:article>
+                    <!-- Artikel 3: Geltungszeitregel-->
+                    <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                       <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
+                          <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
+                       <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+                       <!-- Absatz (1) -->
+                       <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
+                          <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
+                             <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
+                          </akn:num>
+                          <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
+                             <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
+                                nach der Verkündung</akn:date> in Kraft. </akn:p>
+                          </akn:content>
+                       </akn:paragraph>
+                    </akn:article>
+                </akn:body>
+             </akn:act>
+          </akn:akomaNtoso>
+          """
+        )
+      )
+      .build();
+    var affectedNorm = Norm
+      .builder()
+      .document(
+        XmlMapper.toDocument(
+          """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+               <akn:act name="regelungstext">
+                  <!-- Metadaten -->
+                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="49eec691-392b-4d77-abaf-23eb871132ad" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
+                        </akn:FRBRExpression>
+                    </akn:identification>
+                  </akn:meta>
+               </akn:act>
+            </akn:akomaNtoso>
+          """
+        )
+      )
+      .build();
+    var affectedNormZf0 = Norm
+      .builder()
+      .document(
+        XmlMapper.toDocument(
+          """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+               <akn:act name="regelungstext">
+                  <!-- Metadaten -->
+                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
+                        </akn:FRBRExpression>
+                    </akn:identification>
+                  </akn:meta>
+               </akn:act>
+            </akn:akomaNtoso>
+          """
+        )
+      )
+      .build();
+    var announcement = Announcement
+      .builder()
+      .norm(amendingNorm)
+      .releasedByDocumentalistAt(null)
+      .build();
     announcementRepository.save(AnnouncementMapper.mapToDto(announcement));
     normRepository.save(NormMapper.mapToDto(affectedNorm));
     normRepository.save(NormMapper.mapToDto(affectedNormZf0));
 
     // When // Then
     mockMvc
-        .perform(
-            put("/api/v1/announcements/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/release")
-                .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("releaseAt").exists())
-        .andExpect(
-            jsonPath(
-                "amendingLawEli",
-                equalTo("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1")))
-        .andExpect(jsonPath("zf0Elis[0]").exists())
-        .andExpect(jsonPath("zf0Elis[1]").doesNotExist())
-        .andExpect(
-            jsonPath(
-                "zf0Elis[0]",
-                equalTo("eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1")));
+      .perform(
+        put(
+          "/api/v1/announcements/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/release"
+        )
+          .accept(MediaType.APPLICATION_JSON)
+      )
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("releaseAt").exists())
+      .andExpect(
+        jsonPath(
+          "amendingLawEli",
+          equalTo("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1")
+        )
+      )
+      .andExpect(jsonPath("zf0Elis[0]").exists())
+      .andExpect(jsonPath("zf0Elis[1]").doesNotExist())
+      .andExpect(
+        jsonPath(
+          "zf0Elis[0]",
+          equalTo("eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1")
+        )
+      );
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ArticleControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ArticleControllerIntegrationTest.java
@@ -20,9 +20,11 @@ import org.springframework.test.web.servlet.MockMvc;
 
 class ArticleControllerIntegrationTest extends BaseIntegrationTest {
 
-  @Autowired private MockMvc mockMvc;
+  @Autowired
+  private MockMvc mockMvc;
 
-  @Autowired private NormRepository normRepository;
+  @Autowired
+  private NormRepository normRepository;
 
   @AfterEach
   void cleanUp() {
@@ -31,121 +33,128 @@ class ArticleControllerIntegrationTest extends BaseIntegrationTest {
 
   @Nested
   class getArticles {
+
     @Test
     void itReturnsArticles() throws Exception {
       // Given
-      var amendingNorm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                           <akn:act name="regelungstext">
+      var amendingNorm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
 
-                              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
-                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                    </akn:FRBRExpression>
-                                 </akn:identification>
-                              </akn:meta>
-                              <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                 <!-- Artikel 1 : Hauptänderung -->
-                                 <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                    <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                       <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                                    <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                                    <!-- Absatz (1) -->
-                                    <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                                       <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                                          <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                                       </akn:num>
-                                       <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                          <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                             <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                                   href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                          </akn:intro>
-                                       </akn:list>
-                                    </akn:paragraph>
-                                 </akn:article>
-                                  <!-- Artikel 3: Geltungszeitregel-->
-                                  <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                     <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                        <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
-                                     <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                                     <!-- Absatz (1) -->
-                                     <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                        <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-                                           <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
-                                        </akn:num>
-                                        <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                           <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                              nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                        </akn:content>
-                                     </akn:paragraph>
-                                  </akn:article>
-                              </akn:body>
-                           </akn:act>
-                        </akn:akomaNtoso>
-                      """))
-              .build();
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                          </akn:FRBRExpression>
+                       </akn:identification>
+                    </akn:meta>
+                    <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                       <!-- Artikel 1 : Hauptänderung -->
+                       <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                          <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                             <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                          <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                          <!-- Absatz (1) -->
+                          <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                             <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                                <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                             </akn:num>
+                             <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                                <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                                   <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                         href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                                </akn:intro>
+                             </akn:list>
+                          </akn:paragraph>
+                       </akn:article>
+                        <!-- Artikel 3: Geltungszeitregel-->
+                        <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                           <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
+                              <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
+                           <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+                           <!-- Absatz (1) -->
+                           <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
+                              <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
+                                 <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
+                              </akn:num>
+                              <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
+                                 <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
+                                    nach der Verkündung</akn:date> in Kraft. </akn:p>
+                              </akn:content>
+                           </akn:paragraph>
+                        </akn:article>
+                    </akn:body>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
-      var affectedNorm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                           <akn:act name="regelungstext">
-                              <!-- Metadaten -->
-                              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="49eec691-392b-4d77-abaf-23eb871132ad" />
-                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
-                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
-                                    </akn:FRBRExpression>
-                                </akn:identification>
-                              </akn:meta>
-                           </akn:act>
-                        </akn:akomaNtoso>
-                      """))
-              .build();
+      var affectedNorm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="49eec691-392b-4d77-abaf-23eb871132ad" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
-      var affectedNormZf0 =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                           <akn:act name="regelungstext">
-                              <!-- Metadaten -->
-                              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
-                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
-                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
-                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
-                                    </akn:FRBRExpression>
-                                </akn:identification>
-                              </akn:meta>
-                           </akn:act>
-                        </akn:akomaNtoso>
-                      """))
-              .build();
+      var affectedNormZf0 = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
       normRepository.save(NormMapper.mapToDto(amendingNorm));
       normRepository.save(NormMapper.mapToDto(affectedNorm));
@@ -153,23 +162,26 @@ class ArticleControllerIntegrationTest extends BaseIntegrationTest {
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles")
-                  .accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$[0]").exists())
-          .andExpect(jsonPath("$[0].eid").value("hauptteil-1_art-1"))
-          .andExpect(
-              jsonPath("$[0].affectedDocumentEli")
-                  .value("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"))
-          .andExpect(
-              jsonPath("$[0].affectedDocumentZf0Eli")
-                  .value("eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1"))
-          .andExpect(jsonPath("$[1]").exists())
-          .andExpect(jsonPath("$[1].eid").value("hauptteil-1_art-3"))
-          .andExpect(jsonPath("$[1].affectedDocumentEli").doesNotExist())
-          .andExpect(jsonPath("$[1].affectedDocumentZf0Eli").doesNotExist())
-          .andExpect(jsonPath("$[2]").doesNotExist());
+        .perform(
+          get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles")
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0]").exists())
+        .andExpect(jsonPath("$[0].eid").value("hauptteil-1_art-1"))
+        .andExpect(
+          jsonPath("$[0].affectedDocumentEli")
+            .value("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+        )
+        .andExpect(
+          jsonPath("$[0].affectedDocumentZf0Eli")
+            .value("eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1")
+        )
+        .andExpect(jsonPath("$[1]").exists())
+        .andExpect(jsonPath("$[1].eid").value("hauptteil-1_art-3"))
+        .andExpect(jsonPath("$[1].affectedDocumentEli").doesNotExist())
+        .andExpect(jsonPath("$[1].affectedDocumentZf0Eli").doesNotExist())
+        .andExpect(jsonPath("$[2]").doesNotExist());
     }
 
     @Test
@@ -180,31 +192,38 @@ class ArticleControllerIntegrationTest extends BaseIntegrationTest {
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles?amendedAt=meta-1_lebzykl-1_ereignis-4")
-                  .accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$[0]").exists())
-          .andExpect(jsonPath("$[0].eid").value("hauptteil-1_para-20"))
-          .andExpect(jsonPath("$[1]").doesNotExist());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles?amendedAt=meta-1_lebzykl-1_ereignis-4"
+          )
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0]").exists())
+        .andExpect(jsonPath("$[0].eid").value("hauptteil-1_para-20"))
+        .andExpect(jsonPath("$[1]").doesNotExist());
     }
 
     @Test
     void itReturnsArticlesFilteredByAmendedBy() throws Exception {
       // Given
-      var affectedNorm =
-          NormFixtures.loadFromDisk("NormWithPassiveModificationsInDifferentArticles.xml");
+      var affectedNorm = NormFixtures.loadFromDisk(
+        "NormWithPassiveModificationsInDifferentArticles.xml"
+      );
       normRepository.save(NormMapper.mapToDto(affectedNorm));
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles?amendedBy=eli/bund/bgbl-1/2017/s815/1995-03-15/1/deu/regelungstext-1")
-                  .accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$[0]").exists())
-          .andExpect(jsonPath("$[0].eid").value("hauptteil-1_para-1"))
-          .andExpect(jsonPath("$[1]").doesNotExist());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles?amendedBy=eli/bund/bgbl-1/2017/s815/1995-03-15/1/deu/regelungstext-1"
+          )
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0]").exists())
+        .andExpect(jsonPath("$[0].eid").value("hauptteil-1_para-1"))
+        .andExpect(jsonPath("$[1]").doesNotExist());
     }
 
     @Test
@@ -215,11 +234,12 @@ class ArticleControllerIntegrationTest extends BaseIntegrationTest {
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/articles")
-                  .accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$[0]").doesNotExist());
+        .perform(
+          get("/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/articles")
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0]").doesNotExist());
     }
 
     @Test
@@ -230,11 +250,14 @@ class ArticleControllerIntegrationTest extends BaseIntegrationTest {
 
       // When / Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles?amendedBy=eli/bund/DOES-NOT-EXIST/2017/s419/2017-03-15/1/deu/regelungstext-1&amendedAt=meta-1_lebzykl-1_ereignis-4")
-                  .accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$[0]").doesNotExist());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles?amendedBy=eli/bund/DOES-NOT-EXIST/2017/s419/2017-03-15/1/deu/regelungstext-1&amendedAt=meta-1_lebzykl-1_ereignis-4"
+          )
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0]").doesNotExist());
     }
 
     @Test
@@ -245,11 +268,14 @@ class ArticleControllerIntegrationTest extends BaseIntegrationTest {
 
       // When / Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles?amendedBy=eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1&amendedAt=DOES-NOT-EXIST")
-                  .accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$[0]").doesNotExist());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles?amendedBy=eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1&amendedAt=DOES-NOT-EXIST"
+          )
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0]").doesNotExist());
     }
 
     @Test
@@ -259,220 +285,27 @@ class ArticleControllerIntegrationTest extends BaseIntegrationTest {
 
       // When / Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles")
-                  .accept(MediaType.APPLICATION_JSON))
-          // Then
-          .andExpect(status().isNotFound());
+        .perform(
+          get("/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles")
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        // Then
+        .andExpect(status().isNotFound());
     }
   }
 
   @Nested
   class getArticlesRender {
+
     @Test
     void itReturnsTheXmlOfArticles() throws Exception {
       // Given
-      var amendingNorm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                         <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                            xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                            <akn:act name="regelungstext">
-
-                               <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                  <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                     <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
-                                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                     </akn:FRBRExpression>
-                                  </akn:identification>
-                               </akn:meta>
-                               <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                  <!-- Artikel 1 : Hauptänderung -->
-                                  <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                     <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                        <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                                     <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                                     <!-- Absatz (1) -->
-                                     <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                                        <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                                           <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                                        </akn:num>
-                                        <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                           <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                              <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                                    href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                           </akn:intro>
-                                        </akn:list>
-                                     </akn:paragraph>
-                                  </akn:article>
-                                   <!-- Artikel 3: Geltungszeitregel-->
-                                   <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                      <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                         <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
-                                      <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                                      <!-- Absatz (1) -->
-                                      <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                         <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-                                            <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
-                                         </akn:num>
-                                         <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                            <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                               nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                         </akn:content>
-                                      </akn:paragraph>
-                                   </akn:article>
-                               </akn:body>
-                            </akn:act>
-                         </akn:akomaNtoso>
-                      """))
-              .build();
-
-      normRepository.save(NormMapper.mapToDto(amendingNorm));
-      // When // Then
-      mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles")
-                  .accept(MediaType.TEXT_HTML_VALUE))
-          .andExpect(status().isOk())
-          .andExpectAll(
-              content()
-                  .node(
-                      hasXPath(
-                          "//span[@data-eId=\"hauptteil-1_art-1_überschrift-1\"]",
-                          equalTo("Änderung des Vereinsgesetzes"))),
-              content()
-                  .node(
-                      hasXPath(
-                          "//span/@data-href",
-                          equalTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"))),
-              content()
-                  .node(
-                      hasXPath(
-                          "//span[@data-eId=\"hauptteil-1_art-3_überschrift-1\"]",
-                          equalTo("Inkrafttreten"))));
-    }
-
-    @Test
-    void itReturnsTheXmlOfTheArticleInkrafttreten() throws Exception {
-      // Given
-      var amendingNorm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                       <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                          xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                              http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                          <akn:act name="regelungstext">
-
-                             <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                   <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                      <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
-                                      <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                      <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                   </akn:FRBRExpression>
-                                </akn:identification>
-                             </akn:meta>
-                             <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                <!-- Artikel 1 : Hauptänderung -->
-                                <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                   <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                      <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                                   <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                                   <!-- Absatz (1) -->
-                                   <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                                      <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                                         <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                                      </akn:num>
-                                      <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                         <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                            <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                                  href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                         </akn:intro>
-                                      </akn:list>
-                                   </akn:paragraph>
-                                </akn:article>
-                                 <!-- Artikel 3: Geltungszeitregel-->
-                                 <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                    <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                       <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
-                                    <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                                    <!-- Absatz (1) -->
-                                    <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                       <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-                                          <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
-                                       </akn:num>
-                                       <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                          <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                             nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                       </akn:content>
-                                    </akn:paragraph>
-                                 </akn:article>
-                             </akn:body>
-                          </akn:act>
-                       </akn:akomaNtoso>
-                      """))
-              .build();
-
-      normRepository.save(NormMapper.mapToDto(amendingNorm));
-
-      // When // Then
-      mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles?refersTo=geltungszeitregel")
-                  .accept(MediaType.TEXT_HTML_VALUE))
-          .andExpect(status().isOk())
-          .andExpectAll(
-              content()
-                  .node(
-                      IsNot.not(
-                          hasXPath(
-                              "//span[@data-eId=\"hauptteil-1_art-1_überschrift-1\"]",
-                              equalTo("Änderung des Vereinsgesetzes")))),
-              content()
-                  .node(
-                      IsNot.not(
-                          hasXPath(
-                              "//span/@data-href",
-                              equalTo(
-                                  "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")))),
-              content()
-                  .node(
-                      hasXPath(
-                          "//span[@data-eId=\"hauptteil-1_art-3_überschrift-1\"]",
-                          equalTo("Inkrafttreten"))));
-    }
-
-    @Test
-    void itReturnsNotFoundIfTheNormDoesntExist() throws Exception {
-      // Given
-      // Nothing saved to the repository
-
-      // When // Then
-      mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles")
-                  .accept(MediaType.TEXT_HTML_VALUE))
-          .andExpect(status().isNotFound());
-    }
-
-    @Test
-    void itReturnsNotFoundIfNoArticleOfTypeExist() throws Exception {
-      // Given
-      var amendingNorm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+      var amendingNorm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
                                       http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
@@ -506,180 +339,416 @@ class ArticleControllerIntegrationTest extends BaseIntegrationTest {
                               </akn:list>
                            </akn:paragraph>
                         </akn:article>
+                         <!-- Artikel 3: Geltungszeitregel-->
+                         <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                            <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
+                               <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
+                            <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+                            <!-- Absatz (1) -->
+                            <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
+                               <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
+                                  <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
+                               </akn:num>
+                               <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
+                                  <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
+                                     nach der Verkündung</akn:date> in Kraft. </akn:p>
+                               </akn:content>
+                            </akn:paragraph>
+                         </akn:article>
                      </akn:body>
                   </akn:act>
                </akn:akomaNtoso>
-              """))
-              .build();
+            """
+          )
+        )
+        .build();
+
+      normRepository.save(NormMapper.mapToDto(amendingNorm));
+      // When // Then
+      mockMvc
+        .perform(
+          get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles")
+            .accept(MediaType.TEXT_HTML_VALUE)
+        )
+        .andExpect(status().isOk())
+        .andExpectAll(
+          content()
+            .node(
+              hasXPath(
+                "//span[@data-eId=\"hauptteil-1_art-1_überschrift-1\"]",
+                equalTo("Änderung des Vereinsgesetzes")
+              )
+            ),
+          content()
+            .node(
+              hasXPath(
+                "//span/@data-href",
+                equalTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+              )
+            ),
+          content()
+            .node(
+              hasXPath(
+                "//span[@data-eId=\"hauptteil-1_art-3_überschrift-1\"]",
+                equalTo("Inkrafttreten")
+              )
+            )
+        );
+    }
+
+    @Test
+    void itReturnsTheXmlOfTheArticleInkrafttreten() throws Exception {
+      // Given
+      var amendingNorm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+             <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                    http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                <akn:act name="regelungstext">
+
+                   <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                      <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                         <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                            <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
+                            <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                            <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                         </akn:FRBRExpression>
+                      </akn:identification>
+                   </akn:meta>
+                   <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                      <!-- Artikel 1 : Hauptänderung -->
+                      <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                         <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                            <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                         <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                         <!-- Absatz (1) -->
+                         <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                            <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                               <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                            </akn:num>
+                            <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                               <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                                  <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                        href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                               </akn:intro>
+                            </akn:list>
+                         </akn:paragraph>
+                      </akn:article>
+                       <!-- Artikel 3: Geltungszeitregel-->
+                       <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                          <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
+                             <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
+                          <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+                          <!-- Absatz (1) -->
+                          <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
+                             <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
+                                <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
+                             </akn:num>
+                             <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
+                                <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
+                                   nach der Verkündung</akn:date> in Kraft. </akn:p>
+                             </akn:content>
+                          </akn:paragraph>
+                       </akn:article>
+                   </akn:body>
+                </akn:act>
+             </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
       normRepository.save(NormMapper.mapToDto(amendingNorm));
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles?refersTo=geltungszeitregel")
-                  .accept(MediaType.TEXT_HTML_VALUE))
-          .andExpect(status().isNotFound());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles?refersTo=geltungszeitregel"
+          )
+            .accept(MediaType.TEXT_HTML_VALUE)
+        )
+        .andExpect(status().isOk())
+        .andExpectAll(
+          content()
+            .node(
+              IsNot.not(
+                hasXPath(
+                  "//span[@data-eId=\"hauptteil-1_art-1_überschrift-1\"]",
+                  equalTo("Änderung des Vereinsgesetzes")
+                )
+              )
+            ),
+          content()
+            .node(
+              IsNot.not(
+                hasXPath(
+                  "//span/@data-href",
+                  equalTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+                )
+              )
+            ),
+          content()
+            .node(
+              hasXPath(
+                "//span[@data-eId=\"hauptteil-1_art-3_überschrift-1\"]",
+                equalTo("Inkrafttreten")
+              )
+            )
+        );
+    }
+
+    @Test
+    void itReturnsNotFoundIfTheNormDoesntExist() throws Exception {
+      // Given
+      // Nothing saved to the repository
+
+      // When // Then
+      mockMvc
+        .perform(
+          get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles")
+            .accept(MediaType.TEXT_HTML_VALUE)
+        )
+        .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void itReturnsNotFoundIfNoArticleOfTypeExist() throws Exception {
+      // Given
+      var amendingNorm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+             <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                    http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                <akn:act name="regelungstext">
+
+                   <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                      <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                         <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                            <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
+                            <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                            <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                         </akn:FRBRExpression>
+                      </akn:identification>
+                   </akn:meta>
+                   <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                      <!-- Artikel 1 : Hauptänderung -->
+                      <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                         <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                            <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                         <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                         <!-- Absatz (1) -->
+                         <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                            <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                               <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                            </akn:num>
+                            <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                               <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                                  <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                        href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                               </akn:intro>
+                            </akn:list>
+                         </akn:paragraph>
+                      </akn:article>
+                   </akn:body>
+                </akn:act>
+             </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
+
+      normRepository.save(NormMapper.mapToDto(amendingNorm));
+
+      // When // Then
+      mockMvc
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles?refersTo=geltungszeitregel"
+          )
+            .accept(MediaType.TEXT_HTML_VALUE)
+        )
+        .andExpect(status().isNotFound());
     }
 
     @Test
     void itReturnsNotFoundIfTheNormHasNoArticles() throws Exception {
       // Given
-      var amendingNorm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                          xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                              http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                          <akn:act name="regelungstext">
+      var amendingNorm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                    http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                <akn:act name="regelungstext">
 
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                              <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                  <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
-                                  <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                  <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                </akn:FRBRExpression>
-                              </akn:identification>
-                            </akn:meta>
-                              <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                              </akn:body>
-                            </akn:act>
-                        </akn:akomaNtoso>
-                      """))
-              .build();
+                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                    <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
+                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                        <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                      </akn:FRBRExpression>
+                    </akn:identification>
+                  </akn:meta>
+                    <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                    </akn:body>
+                  </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
       normRepository.save(NormMapper.mapToDto(amendingNorm));
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles?refersTo=geltungszeitregel")
-                  .accept(MediaType.TEXT_HTML_VALUE))
-          .andExpect(status().isNotFound());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles?refersTo=geltungszeitregel"
+          )
+            .accept(MediaType.TEXT_HTML_VALUE)
+        )
+        .andExpect(status().isNotFound());
     }
   }
 
   @Nested
   class getArticle {
+
     @Test
     void itReturnsArticle() throws Exception {
       // Given
-      var amendingNorm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                                       <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                                          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                                             <akn:act name="regelungstext">
+      var amendingNorm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+               <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                      http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                  <akn:act name="regelungstext">
 
-                                                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
-                                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                                      </akn:FRBRExpression>
-                                                   </akn:identification>
-                                                </akn:meta>
-                                                <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                                   <!-- Artikel 1 : Hauptänderung -->
-                                                   <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                                      <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                                         <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                                                      <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                                                      <!-- Absatz (1) -->
-                                                      <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                                                         <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                                                            <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                                                         </akn:num>
-                                                         <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                                            <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                                               <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                                                     href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                                            </akn:intro>
-                                                         </akn:list>
-                                                      </akn:paragraph>
-                                                   </akn:article>
-                                                    <!-- Artikel 3: Geltungszeitregel-->
-                                                    <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                                       <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                                          <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
-                                                       <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                                                       <!-- Absatz (1) -->
-                                                       <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                                          <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-                                                             <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
-                                                          </akn:num>
-                                                          <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                                             <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                                                nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                                          </akn:content>
-                                                       </akn:paragraph>
-                                                    </akn:article>
-                                                </akn:body>
-                                             </akn:act>
-                                          </akn:akomaNtoso>
-                                       """))
-              .build();
+                     <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                        <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                           <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                              <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
+                              <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                              <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                           </akn:FRBRExpression>
+                        </akn:identification>
+                     </akn:meta>
+                     <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                        <!-- Artikel 1 : Hauptänderung -->
+                        <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                           <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                              <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                           <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                           <!-- Absatz (1) -->
+                           <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                              <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                                 <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                              </akn:num>
+                              <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                                 <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                                    <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                          href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                                 </akn:intro>
+                              </akn:list>
+                           </akn:paragraph>
+                        </akn:article>
+                         <!-- Artikel 3: Geltungszeitregel-->
+                         <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                            <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
+                               <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
+                            <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+                            <!-- Absatz (1) -->
+                            <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
+                               <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
+                                  <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
+                               </akn:num>
+                               <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
+                                  <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
+                                     nach der Verkündung</akn:date> in Kraft. </akn:p>
+                               </akn:content>
+                            </akn:paragraph>
+                         </akn:article>
+                     </akn:body>
+                  </akn:act>
+               </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
-      var affectedNorm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                                        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                                           <akn:act name="regelungstext">
-                                              <!-- Metadaten -->
-                                              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="49eec691-392b-4d77-abaf-23eb871132ad" />
-                                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
-                                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
-                                                    </akn:FRBRExpression>
-                                                </akn:identification>
-                                              </akn:meta>
-                                           </akn:act>
-                                        </akn:akomaNtoso>
-                                      """))
-              .build();
+      var affectedNorm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="49eec691-392b-4d77-abaf-23eb871132ad" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
-      var affectedNormZf0 =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                                        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                                           <akn:act name="regelungstext">
-                                              <!-- Metadaten -->
-                                              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
-                                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
-                                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
-                                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
-                                                    </akn:FRBRExpression>
-                                                </akn:identification>
-                                              </akn:meta>
-                                           </akn:act>
-                                        </akn:akomaNtoso>
-                                      """))
-              .build();
+      var affectedNormZf0 = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
+                    <!-- Metadaten -->
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
+                          </akn:FRBRExpression>
+                      </akn:identification>
+                    </akn:meta>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
       normRepository.save(NormMapper.mapToDto(amendingNorm));
       normRepository.save(NormMapper.mapToDto(affectedNorm));
@@ -687,17 +756,22 @@ class ArticleControllerIntegrationTest extends BaseIntegrationTest {
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles/hauptteil-1_art-1")
-                  .accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("eid").value("hauptteil-1_art-1"))
-          .andExpect(
-              jsonPath("affectedDocumentEli")
-                  .value("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"))
-          .andExpect(
-              jsonPath("affectedDocumentZf0Eli")
-                  .value("eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1"));
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles/hauptteil-1_art-1"
+          )
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("eid").value("hauptteil-1_art-1"))
+        .andExpect(
+          jsonPath("affectedDocumentEli")
+            .value("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+        )
+        .andExpect(
+          jsonPath("affectedDocumentZf0Eli")
+            .value("eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1")
+        );
     }
 
     @Test
@@ -707,127 +781,136 @@ class ArticleControllerIntegrationTest extends BaseIntegrationTest {
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles/hauptteil-1_art-1")
-                  .accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isNotFound());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles/hauptteil-1_art-1"
+          )
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isNotFound());
     }
 
     @Test
     void itReturnsNothingIfArticleDoesNotExist() throws Exception {
       // Given
-      var amendingNorm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                           <akn:act name="regelungstext">
+      var amendingNorm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                 <akn:act name="regelungstext">
 
-                              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
-                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                    </akn:FRBRExpression>
-                                 </akn:identification>
-                              </akn:meta>
-                              <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                 <!-- Artikel 1 : Hauptänderung -->
-                                 <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                    <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                       <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                                    <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                                    <!-- Absatz (1) -->
-                                    <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                                       <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                                          <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                                       </akn:num>
-                                       <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                          <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                             <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                                   href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                          </akn:intro>
-                                       </akn:list>
-                                    </akn:paragraph>
-                                 </akn:article>
-                                  <!-- Artikel 3: Geltungszeitregel-->
-                                  <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                     <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                        <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
-                                     <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                                     <!-- Absatz (1) -->
-                                     <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                        <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-                                           <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
-                                        </akn:num>
-                                        <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                           <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                              nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                        </akn:content>
-                                     </akn:paragraph>
-                                  </akn:article>
-                              </akn:body>
-                           </akn:act>
-                        </akn:akomaNtoso>
-                      """))
-              .build();
+                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                          </akn:FRBRExpression>
+                       </akn:identification>
+                    </akn:meta>
+                    <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                       <!-- Artikel 1 : Hauptänderung -->
+                       <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                          <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                             <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                          <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                          <!-- Absatz (1) -->
+                          <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                             <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                                <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                             </akn:num>
+                             <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                                <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                                   <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                         href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                                </akn:intro>
+                             </akn:list>
+                          </akn:paragraph>
+                       </akn:article>
+                        <!-- Artikel 3: Geltungszeitregel-->
+                        <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                           <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
+                              <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
+                           <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+                           <!-- Absatz (1) -->
+                           <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
+                              <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
+                                 <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
+                              </akn:num>
+                              <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
+                                 <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
+                                    nach der Verkündung</akn:date> in Kraft. </akn:p>
+                              </akn:content>
+                           </akn:paragraph>
+                        </akn:article>
+                    </akn:body>
+                 </akn:act>
+              </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
-      var affectedNorm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                  <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                     <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="49eec691-392b-4d77-abaf-23eb871132ad" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
-                                  </akn:FRBRExpression>
-                              </akn:identification>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                      """))
-              .build();
+      var affectedNorm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+               <akn:act name="regelungstext">
+                  <!-- Metadaten -->
+                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="49eec691-392b-4d77-abaf-23eb871132ad" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
+                        </akn:FRBRExpression>
+                    </akn:identification>
+                  </akn:meta>
+               </akn:act>
+            </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
-      var affectedNormZf0 =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                  <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                     <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
-                                     <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
-                                  </akn:FRBRExpression>
-                              </akn:identification>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                      """))
-              .build();
+      var affectedNormZf0 = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+               <akn:act name="regelungstext">
+                  <!-- Metadaten -->
+                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
+                           <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
+                        </akn:FRBRExpression>
+                    </akn:identification>
+                  </akn:meta>
+               </akn:act>
+            </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
       normRepository.save(NormMapper.mapToDto(amendingNorm));
       normRepository.save(NormMapper.mapToDto(affectedNorm));
@@ -835,91 +918,101 @@ class ArticleControllerIntegrationTest extends BaseIntegrationTest {
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles/hauptteil-1_art-9999")
-                  .accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isNotFound());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles/hauptteil-1_art-9999"
+          )
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isNotFound());
     }
   }
 
   @Nested
   class getArticleRender {
+
     @Test
     void itReturnsArticleRender() throws Exception {
       // Given
-      var amendingNorm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                                       <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                                          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                                             <akn:act name="regelungstext">
+      var amendingNorm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+               <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                      http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+                  <akn:act name="regelungstext">
 
-                                                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                                      <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                                         <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
-                                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                                                         <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                                                      </akn:FRBRExpression>
-                                                   </akn:identification>
-                                                </akn:meta>
-                                                <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                                                   <!-- Artikel 1 : Hauptänderung -->
-                                                   <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
-                                                      <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                                         <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
-                                                      <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                                                      <!-- Absatz (1) -->
-                                                      <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                                                         <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-                                                            <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
-                                                         </akn:num>
-                                                         <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                                            <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                                               <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                                                     href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                                            </akn:intro>
-                                                         </akn:list>
-                                                      </akn:paragraph>
-                                                   </akn:article>
-                                                    <!-- Artikel 3: Geltungszeitregel-->
-                                                    <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
-                                                       <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                                          <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
-                                                       <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                                                       <!-- Absatz (1) -->
-                                                       <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                                          <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-                                                             <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
-                                                          </akn:num>
-                                                          <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                                             <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                                                nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                                          </akn:content>
-                                                       </akn:paragraph>
-                                                    </akn:article>
-                                                </akn:body>
-                                             </akn:act>
-                                          </akn:akomaNtoso>
-                                       """))
-              .build();
+                     <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                        <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                           <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                              <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
+                              <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                              <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                           </akn:FRBRExpression>
+                        </akn:identification>
+                     </akn:meta>
+                     <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+                        <!-- Artikel 1 : Hauptänderung -->
+                        <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#geltungszeitgr-1" refersTo="hauptaenderung">
+                           <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                              <akn:marker eId="hauptteil-1_art-1_bezeichnung-1_zaehlbez-1" GUID="81c9c481-9427-4f03-9f51-099aa9b2201e" name="1" />Artikel 1</akn:num>
+                           <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                           <!-- Absatz (1) -->
+                           <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+                              <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                                 <akn:marker eId="hauptteil-1_art-1_abs-1_bezeichnung-1_zaehlbez-1" GUID="eab5a7e7-b649-4c23-b495-648b8ec71843" name="1" />
+                              </akn:num>
+                              <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
+                                 <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                                    <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                          href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                                 </akn:intro>
+                              </akn:list>
+                           </akn:paragraph>
+                        </akn:article>
+                         <!-- Artikel 3: Geltungszeitregel-->
+                         <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#geltungszeitgr-1" refersTo="geltungszeitregel">
+                            <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
+                               <akn:marker eId="hauptteil-1_art-3_bezeichnung-1_zaehlbez-1" GUID="7bbcdd71-a27b-4932-91b7-6c18356ed3e5" name="3" />Artikel 3</akn:num>
+                            <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+                            <!-- Absatz (1) -->
+                            <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
+                               <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
+                                  <akn:marker eId="hauptteil-1_art-3_abs-1_bezeichnung-1_zaehlbez-1" GUID="1d41fa26-e36a-4d03-8f4a-4790d3184944" name="1" />
+                               </akn:num>
+                               <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
+                                  <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
+                                     nach der Verkündung</akn:date> in Kraft. </akn:p>
+                               </akn:content>
+                            </akn:paragraph>
+                         </akn:article>
+                     </akn:body>
+                  </akn:act>
+               </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
 
       normRepository.save(NormMapper.mapToDto(amendingNorm));
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles/hauptteil-1_art-1")
-                  .accept(MediaType.TEXT_HTML))
-          .andExpect(status().isOk())
-          .andExpect(
-              xpath("//span[@data-eId=\"hauptteil-1_art-1_überschrift-1\"]")
-                  .string("Änderung des Vereinsgesetzes"))
-          .andExpect(xpath("//span[@data-eId=\"hauptteil-1_art-3_überschrift-1\"]").doesNotExist());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/articles/hauptteil-1_art-1"
+          )
+            .accept(MediaType.TEXT_HTML)
+        )
+        .andExpect(status().isOk())
+        .andExpect(
+          xpath("//span[@data-eId=\"hauptteil-1_art-1_überschrift-1\"]")
+            .string("Änderung des Vereinsgesetzes")
+        )
+        .andExpect(xpath("//span[@data-eId=\"hauptteil-1_art-3_überschrift-1\"]").doesNotExist());
     }
 
     @Test
@@ -933,12 +1026,15 @@ class ArticleControllerIntegrationTest extends BaseIntegrationTest {
 
       // When / Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles/hauptteil-1_para-20?atIsoDate=2017-03-01T00:00:00.000Z")
-                  .accept(MediaType.TEXT_HTML))
-          .andExpect(status().isOk())
-          .andExpect(content().string(containsString("§ 9 Absatz 1 Satz 2, Absatz 2 oder 3")))
-          .andExpect(content().string(not(containsString("§ 9 Abs. 1 Satz 2, Abs. 2"))));
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles/hauptteil-1_para-20?atIsoDate=2017-03-01T00:00:00.000Z"
+          )
+            .accept(MediaType.TEXT_HTML)
+        )
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("§ 9 Absatz 1 Satz 2, Absatz 2 oder 3")))
+        .andExpect(content().string(not(containsString("§ 9 Abs. 1 Satz 2, Abs. 2"))));
     }
 
     @Test
@@ -947,10 +1043,13 @@ class ArticleControllerIntegrationTest extends BaseIntegrationTest {
 
       // When / Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles/hauptteil-1_para-20?atIsoDate=thisIsNotADate")
-                  .accept(MediaType.TEXT_HTML))
-          .andExpect(status().isInternalServerError());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles/hauptteil-1_para-20?atIsoDate=thisIsNotADate"
+          )
+            .accept(MediaType.TEXT_HTML)
+        )
+        .andExpect(status().isInternalServerError());
     }
 
     @Test
@@ -960,10 +1059,13 @@ class ArticleControllerIntegrationTest extends BaseIntegrationTest {
 
       // When / Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles/hauptteil-1_para-20?atIsoDate=2017-03-01T00:00:00.000Z")
-                  .accept(MediaType.TEXT_HTML))
-          .andExpect(status().isNotFound());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles/hauptteil-1_para-20?atIsoDate=2017-03-01T00:00:00.000Z"
+          )
+            .accept(MediaType.TEXT_HTML)
+        )
+        .andExpect(status().isNotFound());
     }
 
     @Test
@@ -977,10 +1079,13 @@ class ArticleControllerIntegrationTest extends BaseIntegrationTest {
 
       // When / Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles/hauptteil-1_para-9999?atIsoDate=2017-03-01T00:00:00.000Z")
-                  .accept(MediaType.TEXT_HTML))
-          .andExpect(status().isNotFound());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles/hauptteil-1_para-9999?atIsoDate=2017-03-01T00:00:00.000Z"
+          )
+            .accept(MediaType.TEXT_HTML)
+        )
+        .andExpect(status().isNotFound());
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ElementControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ElementControllerIntegrationTest.java
@@ -18,8 +18,11 @@ import org.springframework.test.web.servlet.MockMvc;
 
 class ElementControllerIntegrationTest extends BaseIntegrationTest {
 
-  @Autowired private MockMvc mockMvc;
-  @Autowired private NormRepository normRepository;
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private NormRepository normRepository;
 
   @AfterEach
   void cleanUp() {
@@ -28,16 +31,20 @@ class ElementControllerIntegrationTest extends BaseIntegrationTest {
 
   @Nested
   class GetElement {
+
     @Test
     void returns404IfNormNotFoundByEli() throws Exception {
       // given no norm
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/NONEXISTENT_NORM/1964/s593/1964-08-05/1/deu/regelungstext-1/elements/hauptteil-1_art-3")
-                  .accept(MediaType.TEXT_HTML))
-          // then
-          .andExpect(status().isNotFound());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/NONEXISTENT_NORM/1964/s593/1964-08-05/1/deu/regelungstext-1/elements/hauptteil-1_art-3"
+          )
+            .accept(MediaType.TEXT_HTML)
+        )
+        // then
+        .andExpect(status().isNotFound());
     }
 
     @Test
@@ -48,11 +55,14 @@ class ElementControllerIntegrationTest extends BaseIntegrationTest {
 
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements/NONEXISTENT_EID")
-                  .accept(MediaType.TEXT_HTML))
-          // then
-          .andExpect(status().isNotFound());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements/NONEXISTENT_EID"
+          )
+            .accept(MediaType.TEXT_HTML)
+        )
+        // then
+        .andExpect(status().isNotFound());
     }
 
     @Test
@@ -63,12 +73,15 @@ class ElementControllerIntegrationTest extends BaseIntegrationTest {
 
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements/hauptteil-1_art-1")
-                  .accept(MediaType.TEXT_HTML))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(content().string(containsString("Änderung des Vereinsgesetzes")));
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements/hauptteil-1_art-1"
+          )
+            .accept(MediaType.TEXT_HTML)
+        )
+        // then
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("Änderung des Vereinsgesetzes")));
     }
 
     @Test
@@ -79,19 +92,21 @@ class ElementControllerIntegrationTest extends BaseIntegrationTest {
 
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements/hauptteil-1_art-1")
-                  .accept(MediaType.APPLICATION_JSON))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("eid").value("hauptteil-1_art-1"))
-          .andExpect(jsonPath("type").value("article"))
-          .andExpect(jsonPath("title").value("Artikel 1 Änderung des Vereinsgesetzes"));
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements/hauptteil-1_art-1"
+          )
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("eid").value("hauptteil-1_art-1"))
+        .andExpect(jsonPath("type").value("article"))
+        .andExpect(jsonPath("title").value("Artikel 1 Änderung des Vereinsgesetzes"));
     }
 
     @Test
     void returnsElementAtGivenIsoDateRenderedAsHtml() throws Exception {
-
       // Given
       var amendingNorm = NormFixtures.loadFromDisk("NormWithMultipleMods.xml");
       var targetNorm = NormFixtures.loadFromDisk("NormWithMultiplePassiveModifications.xml");
@@ -101,12 +116,15 @@ class ElementControllerIntegrationTest extends BaseIntegrationTest {
 
       // When / Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/elements/hauptteil-1_para-20?atIsoDate=2017-03-01T00:00:00.000Z")
-                  .accept(MediaType.TEXT_HTML))
-          .andExpect(status().isOk())
-          .andExpect(content().string(containsString("§ 9 Absatz 1 Satz 2, Absatz 2 oder 3")))
-          .andExpect(content().string(not(containsString("§ 9 Abs. 1 Satz 2, Abs. 2"))));
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/elements/hauptteil-1_para-20?atIsoDate=2017-03-01T00:00:00.000Z"
+          )
+            .accept(MediaType.TEXT_HTML)
+        )
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("§ 9 Absatz 1 Satz 2, Absatz 2 oder 3")))
+        .andExpect(content().string(not(containsString("§ 9 Abs. 1 Satz 2, Abs. 2"))));
     }
 
     @Test
@@ -115,10 +133,13 @@ class ElementControllerIntegrationTest extends BaseIntegrationTest {
 
       // When / Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/elements/hauptteil-1_para-20?atIsoDate=INVALID")
-                  .accept(MediaType.TEXT_HTML))
-          .andExpect(status().is5xxServerError());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/elements/hauptteil-1_para-20?atIsoDate=INVALID"
+          )
+            .accept(MediaType.TEXT_HTML)
+        )
+        .andExpect(status().is5xxServerError());
     }
   }
 
@@ -131,11 +152,11 @@ class ElementControllerIntegrationTest extends BaseIntegrationTest {
 
       // when
       mockMvc
-          .perform(
-              get(
-                  "/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/elements"))
-          // then
-          .andExpect(status().is5xxServerError());
+        .perform(
+          get("/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/elements")
+        )
+        // then
+        .andExpect(status().is5xxServerError());
     }
 
     @Test
@@ -144,11 +165,13 @@ class ElementControllerIntegrationTest extends BaseIntegrationTest {
 
       // when
       mockMvc
-          .perform(
-              get(
-                  "/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/elements?type=foo"))
-          // then
-          .andExpect(status().isBadRequest());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/elements?type=foo"
+          )
+        )
+        // then
+        .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -157,11 +180,13 @@ class ElementControllerIntegrationTest extends BaseIntegrationTest {
 
       // when
       mockMvc
-          .perform(
-              get(
-                  "/api/v1/norms/eli/bund/INVALID_ELI/2023/413/2023-12-29/1/deu/regelungstext-1/elements?type=article"))
-          // then
-          .andExpect(status().isNotFound());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/INVALID_ELI/2023/413/2023-12-29/1/deu/regelungstext-1/elements?type=article"
+          )
+        )
+        // then
+        .andExpect(status().isNotFound());
     }
 
     @Test
@@ -171,12 +196,14 @@ class ElementControllerIntegrationTest extends BaseIntegrationTest {
       normRepository.save(NormMapper.mapToDto(norm));
       // when
       mockMvc
-          .perform(
-              get(
-                  "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements?type=preface"))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$[0]").doesNotExist());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements?type=preface"
+          )
+        )
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0]").doesNotExist());
     }
 
     @Test
@@ -185,102 +212,103 @@ class ElementControllerIntegrationTest extends BaseIntegrationTest {
       var norm = NormFixtures.loadFromDisk("NormWithPrefacePreambleAndConclusions.xml");
       normRepository.save(NormMapper.mapToDto(norm));
       var url =
-          "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements"
-              + "?type=preface"
-              + "&type=preamble"
-              + "&type=article"
-              + "&type=conclusions";
+        "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements" +
+        "?type=preface" +
+        "&type=preamble" +
+        "&type=article" +
+        "&type=conclusions";
 
       // when
       mockMvc
-          .perform(get(url))
-          // then
-          .andExpect(status().isOk())
-          // preface
-          .andExpect(jsonPath("$[0]").exists())
-          .andExpect(jsonPath("$[0].title").value("Dokumentenkopf"))
-          .andExpect(jsonPath("$[0].eid").value("einleitung-1"))
-          .andExpect(jsonPath("$[0].type").value("preface"))
-          // preamble
-          .andExpect(jsonPath("$[1].title").value("Eingangsformel"))
-          .andExpect(jsonPath("$[1].eid").value("preambel-1"))
-          .andExpect(jsonPath("$[1].type").value("preamble"))
-          // articles
-          .andExpect(jsonPath("$[2].title").value("Artikel 1 Änderung des Vereinsgesetzes"))
-          .andExpect(jsonPath("$[2].eid").value("hauptteil-1_art-1"))
-          .andExpect(jsonPath("$[2].type").value("article"))
-          .andExpect(jsonPath("$[3].title").value("Artikel 3 Inkrafttreten"))
-          .andExpect(jsonPath("$[3].eid").value("hauptteil-1_art-3"))
-          .andExpect(jsonPath("$[3].type").value("article"))
-          // conclusion
-          .andExpect(jsonPath("$[4].title").value("Schlussteil"))
-          .andExpect(jsonPath("$[4].eid").value("schluss-1"))
-          .andExpect(jsonPath("$[4].type").value("conclusions"));
+        .perform(get(url))
+        // then
+        .andExpect(status().isOk())
+        // preface
+        .andExpect(jsonPath("$[0]").exists())
+        .andExpect(jsonPath("$[0].title").value("Dokumentenkopf"))
+        .andExpect(jsonPath("$[0].eid").value("einleitung-1"))
+        .andExpect(jsonPath("$[0].type").value("preface"))
+        // preamble
+        .andExpect(jsonPath("$[1].title").value("Eingangsformel"))
+        .andExpect(jsonPath("$[1].eid").value("preambel-1"))
+        .andExpect(jsonPath("$[1].type").value("preamble"))
+        // articles
+        .andExpect(jsonPath("$[2].title").value("Artikel 1 Änderung des Vereinsgesetzes"))
+        .andExpect(jsonPath("$[2].eid").value("hauptteil-1_art-1"))
+        .andExpect(jsonPath("$[2].type").value("article"))
+        .andExpect(jsonPath("$[3].title").value("Artikel 3 Inkrafttreten"))
+        .andExpect(jsonPath("$[3].eid").value("hauptteil-1_art-3"))
+        .andExpect(jsonPath("$[3].type").value("article"))
+        // conclusion
+        .andExpect(jsonPath("$[4].title").value("Schlussteil"))
+        .andExpect(jsonPath("$[4].eid").value("schluss-1"))
+        .andExpect(jsonPath("$[4].type").value("conclusions"));
     }
 
     @Test
     void itReturnsEntriesWithBookPartChapterTitleSubtitleSectionAndSubsectionInformation()
-        throws Exception {
+      throws Exception {
       // given
       var norm = NormFixtures.loadFromDisk("NormWithGliederung.xml");
       normRepository.save(NormMapper.mapToDto(norm));
       var url =
-          "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements"
-              + "?type=book"
-              + "&type=part"
-              + "&type=chapter"
-              + "&type=title"
-              + "&type=subtitle"
-              + "&type=section"
-              + "&type=subsection";
+        "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements" +
+        "?type=book" +
+        "&type=part" +
+        "&type=chapter" +
+        "&type=title" +
+        "&type=subtitle" +
+        "&type=section" +
+        "&type=subsection";
 
       // when
       mockMvc
-          .perform(get(url))
-          // then
-          .andExpect(status().isOk())
-          // book
-          .andExpect(jsonPath("$[0]").exists())
-          .andExpect(jsonPath("$[0].title").value("Buch 1 Überschrift Buch"))
-          .andExpect(jsonPath("$[0].eid").value("hauptteil-1_buch-1"))
-          .andExpect(jsonPath("$[0].type").value("book"))
-          // part
-          .andExpect(jsonPath("$[1]").exists())
-          .andExpect(jsonPath("$[1].title").value("Teil 1 Überschrift Teil"))
-          .andExpect(jsonPath("$[1].eid").value("hauptteil-1_buch-1_teil-1"))
-          .andExpect(jsonPath("$[1].type").value("part"))
-          // chapter
-          .andExpect(jsonPath("$[2]").exists())
-          .andExpect(jsonPath("$[2].title").value("Kapitel 1 Überschrift Kapitel"))
-          .andExpect(jsonPath("$[2].eid").value("hauptteil-1_buch-1_teil-1_kapitel-1"))
-          .andExpect(jsonPath("$[2].type").value("chapter"))
-          // section
-          .andExpect(jsonPath("$[3]").exists())
-          .andExpect(jsonPath("$[3].title").value("Abschnitt 1 Überschrift Abschnitt"))
-          .andExpect(jsonPath("$[3].eid").value("hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1"))
-          .andExpect(jsonPath("$[3].type").value("section"))
-          // subsection
-          .andExpect(jsonPath("$[4]").exists())
-          .andExpect(jsonPath("$[4].title").value("Unterabschnitt 1 Überschrift Unterabschnitt"))
-          .andExpect(
-              jsonPath("$[4].eid")
-                  .value("hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1"))
-          .andExpect(jsonPath("$[4].type").value("subsection"))
-          // title
-          .andExpect(jsonPath("$[5]").exists())
-          .andExpect(jsonPath("$[5].title").value("Titel 1 Überschrift Titel"))
-          .andExpect(
-              jsonPath("$[5].eid")
-                  .value("hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1"))
-          .andExpect(jsonPath("$[5].type").value("title"))
-          // subtitle
-          .andExpect(jsonPath("$[6]").exists())
-          .andExpect(jsonPath("$[6].title").value("Untertitel 1 Überschrift Untertitel"))
-          .andExpect(
-              jsonPath("$[6].eid")
-                  .value(
-                      "hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1_utitel-1"))
-          .andExpect(jsonPath("$[6].type").value("subtitle"));
+        .perform(get(url))
+        // then
+        .andExpect(status().isOk())
+        // book
+        .andExpect(jsonPath("$[0]").exists())
+        .andExpect(jsonPath("$[0].title").value("Buch 1 Überschrift Buch"))
+        .andExpect(jsonPath("$[0].eid").value("hauptteil-1_buch-1"))
+        .andExpect(jsonPath("$[0].type").value("book"))
+        // part
+        .andExpect(jsonPath("$[1]").exists())
+        .andExpect(jsonPath("$[1].title").value("Teil 1 Überschrift Teil"))
+        .andExpect(jsonPath("$[1].eid").value("hauptteil-1_buch-1_teil-1"))
+        .andExpect(jsonPath("$[1].type").value("part"))
+        // chapter
+        .andExpect(jsonPath("$[2]").exists())
+        .andExpect(jsonPath("$[2].title").value("Kapitel 1 Überschrift Kapitel"))
+        .andExpect(jsonPath("$[2].eid").value("hauptteil-1_buch-1_teil-1_kapitel-1"))
+        .andExpect(jsonPath("$[2].type").value("chapter"))
+        // section
+        .andExpect(jsonPath("$[3]").exists())
+        .andExpect(jsonPath("$[3].title").value("Abschnitt 1 Überschrift Abschnitt"))
+        .andExpect(jsonPath("$[3].eid").value("hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1"))
+        .andExpect(jsonPath("$[3].type").value("section"))
+        // subsection
+        .andExpect(jsonPath("$[4]").exists())
+        .andExpect(jsonPath("$[4].title").value("Unterabschnitt 1 Überschrift Unterabschnitt"))
+        .andExpect(
+          jsonPath("$[4].eid").value("hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1")
+        )
+        .andExpect(jsonPath("$[4].type").value("subsection"))
+        // title
+        .andExpect(jsonPath("$[5]").exists())
+        .andExpect(jsonPath("$[5].title").value("Titel 1 Überschrift Titel"))
+        .andExpect(
+          jsonPath("$[5].eid")
+            .value("hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1")
+        )
+        .andExpect(jsonPath("$[5].type").value("title"))
+        // subtitle
+        .andExpect(jsonPath("$[6]").exists())
+        .andExpect(jsonPath("$[6].title").value("Untertitel 1 Überschrift Untertitel"))
+        .andExpect(
+          jsonPath("$[6].eid")
+            .value("hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1_utitel-1")
+        )
+        .andExpect(jsonPath("$[6].type").value("subtitle"));
     }
   }
 
@@ -296,45 +324,46 @@ class ElementControllerIntegrationTest extends BaseIntegrationTest {
       normRepository.save(NormMapper.mapToDto(amendingNorm));
 
       var url =
-          "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements"
-              + "?type=preface"
-              + "&type=preamble"
-              + "&type=article"
-              + "&type=conclusions"
-              + "&amendedBy="
-              + amendingNorm.getEli(); // amending norm eli
+        "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/elements" +
+        "?type=preface" +
+        "&type=preamble" +
+        "&type=article" +
+        "&type=conclusions" +
+        "&amendedBy=" +
+        amendingNorm.getEli(); // amending norm eli
 
       // when
       mockMvc
-          .perform(get(url))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$[0]").doesNotExist());
+        .perform(get(url))
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0]").doesNotExist());
     }
 
     @Test
     void itReturnsOnlyTheElementsMatchingTheGivenAmendingLaw() throws Exception {
-      var targetNorm =
-          NormFixtures.loadFromDisk("NormWithPassiveModificationsInDifferentArticles.xml");
+      var targetNorm = NormFixtures.loadFromDisk(
+        "NormWithPassiveModificationsInDifferentArticles.xml"
+      );
       normRepository.save(NormMapper.mapToDto(targetNorm));
 
       var url =
-          "/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/elements"
-              + "?type=preface"
-              + "&type=preamble"
-              + "&type=article"
-              + "&type=conclusions"
-              + "&amendedBy=eli/bund/bgbl-1/2017/s815/1995-03-15/1/deu/regelungstext-1"; // second
+        "/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/elements" +
+        "?type=preface" +
+        "&type=preamble" +
+        "&type=article" +
+        "&type=conclusions" +
+        "&amendedBy=eli/bund/bgbl-1/2017/s815/1995-03-15/1/deu/regelungstext-1"; // second
 
       // when
       mockMvc
-          .perform(get(url))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$[0].eid").exists())
-          .andExpect(jsonPath("$[0].title").exists())
-          .andExpect(jsonPath("$[0].type").exists())
-          .andExpect(jsonPath("$[1]").doesNotExist());
+        .perform(get(url))
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].eid").exists())
+        .andExpect(jsonPath("$[0].title").exists())
+        .andExpect(jsonPath("$[0].type").exists())
+        .andExpect(jsonPath("$[1]").doesNotExist());
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/NormControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/NormControllerIntegrationTest.java
@@ -22,9 +22,11 @@ import org.springframework.test.web.servlet.MockMvc;
 
 class NormControllerIntegrationTest extends BaseIntegrationTest {
 
-  @Autowired private MockMvc mockMvc;
+  @Autowired
+  private MockMvc mockMvc;
 
-  @Autowired private NormRepository normRepository;
+  @Autowired
+  private NormRepository normRepository;
 
   @AfterEach
   void cleanUp() {
@@ -37,88 +39,92 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
     @Test
     void itCallsNormsServiceAndReturnsNorm() throws Exception {
       // Given
-      var norm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                                 <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                                 <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                    xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                                    <akn:act name="regelungstext">
-                                       <!-- Metadaten -->
-                                       <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                          <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                             <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                                <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
-                                                <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
-                                                <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
-                                             </akn:FRBRWork>
-                                             <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                                <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                                <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                                                <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                                                <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                                             </akn:FRBRExpression>
-                                         </akn:identification>
-                                       </akn:meta>
+      var norm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                   http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+               <akn:act name="regelungstext">
+                  <!-- Metadaten -->
+                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                        <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                           <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                           <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                           <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                        </akn:FRBRWork>
+                        <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                           <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                           <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                           <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                           <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                        </akn:FRBRExpression>
+                    </akn:identification>
+                  </akn:meta>
 
-                                       <akn:preface eId="einleitung-1" GUID="fc10e89f-fde4-44bf-aa98-b6bdea01f0ea">
-                                          <akn:longTitle eId="einleitung-1_doktitel-1" GUID="abbb08de-e7e2-40ab-aba0-079ce786e6d6">
-                                             <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="3e7c2134-d82c-44ba-b50d-bad9790375a0">
-                                                <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="3b355cab-ce10-45b5-9cde-cc618fbf491f" />
-                                                <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="c83abe1e-5fde-4e4e-a9b5-7293505ffeff" />
-                                                <akn:docTitle
-                                                   eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="8c4eabab-9893-455e-b83b-c46f2453f2fb">Gesetz zur Regelung des öffentlichen Vereinsrechts</akn:docTitle>
-                                                <akn:shortTitle eId="einleitung-1_doktitel-1_text-1_kurztitel-1" GUID="fdb8ed28-2e1f-4d81-b780-846fd9ecb716">( <akn:inline
-                                                      eId="einleitung-1_doktitel-1_text-1_kurztitel-1_inline-1" GUID="bdff7240-266e-4ff3-b311-60342bd1afa2" refersTo="amtliche-abkuerzung" name="attributsemantik-noch-undefiniert">Vereinsgesetz</akn:inline>)</akn:shortTitle>
-                                             </akn:p>
-                                          </akn:longTitle>
-                                          <akn:block eId="einleitung-1_block-1" GUID="010d9df0-817a-49b6-a121-d0a1d412a3e3" name="attributsemantik-noch-undefiniert">
-                                             <akn:date eId="einleitung-1_block-1_datum-1" GUID="28fafbe4-403d-4436-8d0d-7241cbbdade0" refersTo="ausfertigung-datum" date="1964-08-05">Vom 5. August 1964 </akn:date>
-                                          </akn:block>
-                                       </akn:preface>
-                                    </akn:act>
-                                 </akn:akomaNtoso>
-                                 """))
-              .build();
+                  <akn:preface eId="einleitung-1" GUID="fc10e89f-fde4-44bf-aa98-b6bdea01f0ea">
+                     <akn:longTitle eId="einleitung-1_doktitel-1" GUID="abbb08de-e7e2-40ab-aba0-079ce786e6d6">
+                        <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="3e7c2134-d82c-44ba-b50d-bad9790375a0">
+                           <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="3b355cab-ce10-45b5-9cde-cc618fbf491f" />
+                           <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="c83abe1e-5fde-4e4e-a9b5-7293505ffeff" />
+                           <akn:docTitle
+                              eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="8c4eabab-9893-455e-b83b-c46f2453f2fb">Gesetz zur Regelung des öffentlichen Vereinsrechts</akn:docTitle>
+                           <akn:shortTitle eId="einleitung-1_doktitel-1_text-1_kurztitel-1" GUID="fdb8ed28-2e1f-4d81-b780-846fd9ecb716">( <akn:inline
+                                 eId="einleitung-1_doktitel-1_text-1_kurztitel-1_inline-1" GUID="bdff7240-266e-4ff3-b311-60342bd1afa2" refersTo="amtliche-abkuerzung" name="attributsemantik-noch-undefiniert">Vereinsgesetz</akn:inline>)</akn:shortTitle>
+                        </akn:p>
+                     </akn:longTitle>
+                     <akn:block eId="einleitung-1_block-1" GUID="010d9df0-817a-49b6-a121-d0a1d412a3e3" name="attributsemantik-noch-undefiniert">
+                        <akn:date eId="einleitung-1_block-1_datum-1" GUID="28fafbe4-403d-4436-8d0d-7241cbbdade0" refersTo="ausfertigung-datum" date="1964-08-05">Vom 5. August 1964 </akn:date>
+                     </akn:block>
+                  </akn:preface>
+               </akn:act>
+            </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
       normRepository.save(NormMapper.mapToDto(norm));
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
-                  .accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isOk())
-          .andExpect(
-              jsonPath("eli").value("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"))
-          .andExpect(jsonPath("title").value("Gesetz zur Regelung des öffentlichen Vereinsrechts"))
-          .andExpect(jsonPath("frbrName").value("BGBl. I"))
-          .andExpect(jsonPath("frbrNumber").value("s593"))
-          .andExpect(jsonPath("frbrDateVerkuendung").value("1964-08-05"));
+        .perform(
+          get("/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isOk())
+        .andExpect(
+          jsonPath("eli").value("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+        )
+        .andExpect(jsonPath("title").value("Gesetz zur Regelung des öffentlichen Vereinsrechts"))
+        .andExpect(jsonPath("frbrName").value("BGBl. I"))
+        .andExpect(jsonPath("frbrNumber").value("s593"))
+        .andExpect(jsonPath("frbrDateVerkuendung").value("1964-08-05"));
     }
 
     @Test
     void itCallsNormsServiceAndReturnsNormXml() throws Exception {
       // Given
       final String xml =
-          """
-               <?xml version="1.0" encoding="UTF-8"?><?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?><akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta GUID="82a65581-0ea7-4525-9190-35ff86c977af" eId="meta-1">
-                       <akn:identification GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" eId="meta-1_ident-1" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRExpression GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d" eId="meta-1_ident-1_frbrexpression-1">
-                             <akn:FRBRthis GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"/>
-                             <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                             <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                             <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                          </akn:FRBRExpression>
-                      </akn:identification>
-                    </akn:meta>
-                 </akn:act>
-               </akn:akomaNtoso>""";
+        """
+        <?xml version="1.0" encoding="UTF-8"?><?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?><akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+          <akn:act name="regelungstext">
+             <!-- Metadaten -->
+             <akn:meta GUID="82a65581-0ea7-4525-9190-35ff86c977af" eId="meta-1">
+                <akn:identification GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" eId="meta-1_ident-1" source="attributsemantik-noch-undefiniert">
+                   <akn:FRBRExpression GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d" eId="meta-1_ident-1_frbrexpression-1">
+                      <akn:FRBRthis GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"/>
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                      <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                   </akn:FRBRExpression>
+               </akn:identification>
+             </akn:meta>
+          </akn:act>
+        </akn:akomaNtoso>""";
 
       // When
       var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
@@ -126,46 +132,47 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
-                  .accept(MediaType.APPLICATION_XML))
-          .andExpect(status().isOk())
-          .andExpect(content().string(xml));
+        .perform(
+          get("/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+            .accept(MediaType.APPLICATION_XML)
+        )
+        .andExpect(status().isOk())
+        .andExpect(content().string(xml));
     }
 
     @Test
     void itCallsNormServiceAndReturnsNormRender() throws Exception {
       // Given
       final String xml =
-          """
-               <?xml version="1.0" encoding="UTF-8"?><?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?><akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta GUID="82a65581-0ea7-4525-9190-35ff86c977af" eId="meta-1">
-                       <akn:identification GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" eId="meta-1_ident-1" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRExpression GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d" eId="meta-1_ident-1_frbrexpression-1">
-                             <akn:FRBRthis GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"/>
-                             <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                             <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                             <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                          </akn:FRBRExpression>
-                      </akn:identification>
-                    </akn:meta>
-                    <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
-                       <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
-                          <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
-                             <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
-                             <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
-                             Innern</akn:docProponent>
-                             <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
-                          </akn:p>
-                       </akn:longTitle>
-                       <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
-                          <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
-                       </akn:block>
-                    </akn:preface>
-                 </akn:act>
-               </akn:akomaNtoso>""";
+        """
+        <?xml version="1.0" encoding="UTF-8"?><?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?><akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+          <akn:act name="regelungstext">
+             <!-- Metadaten -->
+             <akn:meta GUID="82a65581-0ea7-4525-9190-35ff86c977af" eId="meta-1">
+                <akn:identification GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" eId="meta-1_ident-1" source="attributsemantik-noch-undefiniert">
+                   <akn:FRBRExpression GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d" eId="meta-1_ident-1_frbrexpression-1">
+                      <akn:FRBRthis GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"/>
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                      <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                   </akn:FRBRExpression>
+               </akn:identification>
+             </akn:meta>
+             <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                   <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                      <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
+                      <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
+                      Innern</akn:docProponent>
+                      <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
+                   </akn:p>
+                </akn:longTitle>
+                <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                   <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
+                </akn:block>
+             </akn:preface>
+          </akn:act>
+        </akn:akomaNtoso>""";
 
       // When
       var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
@@ -173,17 +180,20 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
-                  .accept(MediaType.TEXT_HTML))
-          .andExpect(status().isOk())
-          .andExpect(
-              content()
-                  .node(
-                      hasXPath(
-                          "//h1//*[@data-eId=\"einleitung-1_doktitel-1_text-1_doctitel-1\"]",
-                          equalTo(
-                              "Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes"))));
+        .perform(
+          get("/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+            .accept(MediaType.TEXT_HTML)
+        )
+        .andExpect(status().isOk())
+        .andExpect(
+          content()
+            .node(
+              hasXPath(
+                "//h1//*[@data-eId=\"einleitung-1_doktitel-1_text-1_doctitel-1\"]",
+                equalTo("Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes")
+              )
+            )
+        );
     }
   }
 
@@ -194,35 +204,35 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
     void itCallsNormServiceAndReturnsNormRenderWithMetadata() throws Exception {
       // Given
       final String xml =
-          """
-               <?xml version="1.0" encoding="UTF-8"?><?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?><akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta GUID="82a65581-0ea7-4525-9190-35ff86c977af" eId="meta-1">
-                       <akn:identification GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" eId="meta-1_ident-1" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRExpression GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d" eId="meta-1_ident-1_frbrexpression-1">
-                             <akn:FRBRthis GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"/>
-                             <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                             <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                             <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                          </akn:FRBRExpression>
-                      </akn:identification>
-                    </akn:meta>
-                    <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
-                       <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
-                          <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
-                             <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
-                             <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
-                             Innern</akn:docProponent>
-                             <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
-                          </akn:p>
-                       </akn:longTitle>
-                       <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
-                          <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
-                       </akn:block>
-                    </akn:preface>
-                 </akn:act>
-               </akn:akomaNtoso>""";
+        """
+        <?xml version="1.0" encoding="UTF-8"?><?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?><akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+          <akn:act name="regelungstext">
+             <!-- Metadaten -->
+             <akn:meta GUID="82a65581-0ea7-4525-9190-35ff86c977af" eId="meta-1">
+                <akn:identification GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" eId="meta-1_ident-1" source="attributsemantik-noch-undefiniert">
+                   <akn:FRBRExpression GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d" eId="meta-1_ident-1_frbrexpression-1">
+                      <akn:FRBRthis GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"/>
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                      <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                   </akn:FRBRExpression>
+               </akn:identification>
+             </akn:meta>
+             <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                   <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                      <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
+                      <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
+                      Innern</akn:docProponent>
+                      <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
+                   </akn:p>
+                </akn:longTitle>
+                <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                   <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
+                </akn:block>
+             </akn:preface>
+          </akn:act>
+        </akn:akomaNtoso>""";
 
       // When
       var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
@@ -230,59 +240,66 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1?showMetadata=true")
-                  .accept(MediaType.TEXT_HTML))
-          .andExpect(status().isOk())
-          .andExpect(
-              content()
-                  .node(
-                      hasXPath(
-                          "//h1//*[@data-eId=\"einleitung-1_doktitel-1_text-1_doctitel-1\"]",
-                          equalTo(
-                              "Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes"))))
-          .andExpect(
-              content()
-                  .node(
-                      hasXPath(
-                          "//section[@class=\"metadata\"]//td[text()=\"Amtliche Langüberschrift\"]/following-sibling::td/text()",
-                          equalTo(
-                              "Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes"))));
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1?showMetadata=true"
+          )
+            .accept(MediaType.TEXT_HTML)
+        )
+        .andExpect(status().isOk())
+        .andExpect(
+          content()
+            .node(
+              hasXPath(
+                "//h1//*[@data-eId=\"einleitung-1_doktitel-1_text-1_doctitel-1\"]",
+                equalTo("Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes")
+              )
+            )
+        )
+        .andExpect(
+          content()
+            .node(
+              hasXPath(
+                "//section[@class=\"metadata\"]//td[text()=\"Amtliche Langüberschrift\"]/following-sibling::td/text()",
+                equalTo("Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes")
+              )
+            )
+        );
     }
 
     @Test
     void itReturnsBadRequestWhenRenderingAtInvalidIsoDate() throws Exception {
       // Given
       final String xml =
-          """
-             <?xml version="1.0" encoding="UTF-8"?><?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?><akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-               <akn:act name="regelungstext">
-                  <!-- Metadaten -->
-                  <akn:meta GUID="82a65581-0ea7-4525-9190-35ff86c977af" eId="meta-1">
-                     <akn:identification GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" eId="meta-1_ident-1" source="attributsemantik-noch-undefiniert">
-                        <akn:FRBRExpression GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d" eId="meta-1_ident-1_frbrexpression-1">
-                           <akn:FRBRthis GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"/>
-                           <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                           <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                           <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                        </akn:FRBRExpression>
-                    </akn:identification>
-                  </akn:meta>
-                  <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
-                     <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
-                        <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
-                           <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
-                           <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
-                           Innern</akn:docProponent>
-                           <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
-                        </akn:p>
-                     </akn:longTitle>
-                     <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
-                        <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
-                     </akn:block>
-                  </akn:preface>
-               </akn:act>
-             </akn:akomaNtoso>""";
+        """
+        <?xml version="1.0" encoding="UTF-8"?><?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?><akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+          <akn:act name="regelungstext">
+             <!-- Metadaten -->
+             <akn:meta GUID="82a65581-0ea7-4525-9190-35ff86c977af" eId="meta-1">
+                <akn:identification GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" eId="meta-1_ident-1" source="attributsemantik-noch-undefiniert">
+                   <akn:FRBRExpression GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d" eId="meta-1_ident-1_frbrexpression-1">
+                      <akn:FRBRthis GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"/>
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                      <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                   </akn:FRBRExpression>
+               </akn:identification>
+             </akn:meta>
+             <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                   <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                      <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
+                      <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
+                      Innern</akn:docProponent>
+                      <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
+                   </akn:p>
+                </akn:longTitle>
+                <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                   <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
+                </akn:block>
+             </akn:preface>
+          </akn:act>
+        </akn:akomaNtoso>""";
 
       // When
       var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
@@ -290,45 +307,48 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1?atIsoDate=NOT_A_DATE")
-                  .accept(MediaType.TEXT_HTML))
-          .andExpect(status().isBadRequest());
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1?atIsoDate=NOT_A_DATE"
+          )
+            .accept(MediaType.TEXT_HTML)
+        )
+        .andExpect(status().isBadRequest());
     }
 
     @Test
     void itReturnsHtmlWhenRenderingAtValidTimeBoundary() throws Exception {
       // Given
       final String xml =
-          """
-             <?xml version="1.0" encoding="UTF-8"?><?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?><akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-               <akn:act name="regelungstext">
-                  <!-- Metadaten -->
-                  <akn:meta GUID="82a65581-0ea7-4525-9190-35ff86c977af" eId="meta-1">
-                     <akn:identification GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" eId="meta-1_ident-1" source="attributsemantik-noch-undefiniert">
-                        <akn:FRBRExpression GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d" eId="meta-1_ident-1_frbrexpression-1">
-                           <akn:FRBRthis GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"/>
-                           <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                           <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                           <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                        </akn:FRBRExpression>
-                    </akn:identification>
-                  </akn:meta>
-                  <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
-                     <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
-                        <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
-                           <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
-                           <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
-                           Innern</akn:docProponent>
-                           <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
-                        </akn:p>
-                     </akn:longTitle>
-                     <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
-                        <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
-                     </akn:block>
-                  </akn:preface>
-               </akn:act>
-             </akn:akomaNtoso>""";
+        """
+        <?xml version="1.0" encoding="UTF-8"?><?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?><akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+          <akn:act name="regelungstext">
+             <!-- Metadaten -->
+             <akn:meta GUID="82a65581-0ea7-4525-9190-35ff86c977af" eId="meta-1">
+                <akn:identification GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" eId="meta-1_ident-1" source="attributsemantik-noch-undefiniert">
+                   <akn:FRBRExpression GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d" eId="meta-1_ident-1_frbrexpression-1">
+                      <akn:FRBRthis GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"/>
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                      <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                   </akn:FRBRExpression>
+               </akn:identification>
+             </akn:meta>
+             <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                   <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                      <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
+                      <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
+                      Innern</akn:docProponent>
+                      <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
+                   </akn:p>
+                </akn:longTitle>
+                <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                   <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
+                </akn:block>
+             </akn:preface>
+          </akn:act>
+        </akn:akomaNtoso>""";
 
       // When
       var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
@@ -336,87 +356,91 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1?atIsoDate=2024-04-25T14:37:14.434Z")
-                  .accept(MediaType.TEXT_HTML))
-          .andExpect(status().isOk())
-          .andExpect(content().node(hasXPath("//div")));
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1?atIsoDate=2024-04-25T14:37:14.434Z"
+          )
+            .accept(MediaType.TEXT_HTML)
+        )
+        .andExpect(status().isOk())
+        .andExpect(content().node(hasXPath("//div")));
     }
   }
 
   @Nested
   class PutNormByEli {
+
     @Test
     void itCallsNormServiceAndUpdatesNorm() throws Exception {
       // Given
       var oldXml =
-          """
-               <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-               <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                      http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                  <akn:act name="regelungstext">
-                     <!-- Metadaten -->
-                     <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                        <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                           <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                              <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                              <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                              <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                              <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                           </akn:FRBRExpression>
-                       </akn:identification>
-                     </akn:meta>
-                     <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
-                         <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
-                            <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
-                               <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
-                               <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
-                               Innern</akn:docProponent>
-                               <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
-                            </akn:p>
-                         </akn:longTitle>
-                         <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
-                            <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
-                         </akn:block>
-                      </akn:preface>
-                  </akn:act>
-               </akn:akomaNtoso>
-               """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                       <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                    </akn:FRBRExpression>
+                </akn:identification>
+              </akn:meta>
+              <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                  <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                     <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                        <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
+                        <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
+                        Innern</akn:docProponent>
+                        <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
+                     </akn:p>
+                  </akn:longTitle>
+                  <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                     <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
+                  </akn:block>
+               </akn:preface>
+           </akn:act>
+        </akn:akomaNtoso>
+        """;
       var newXml =
-          """
-               <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-               <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                      http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                  <akn:act name="regelungstext">
-                     <!-- Metadaten -->
-                     <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                        <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                           <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                              <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                              <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                              <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                              <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                           </akn:FRBRExpression>
-                       </akn:identification>
-                     </akn:meta>
-                     <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
-                         <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
-                            <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
-                               <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
-                               <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
-                               Innern</akn:docProponent>
-                               <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Dritten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
-                            </akn:p>
-                         </akn:longTitle>
-                         <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
-                            <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
-                         </akn:block>
-                      </akn:preface>
-                  </akn:act>
-               </akn:akomaNtoso>
-               """;
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                       <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                    </akn:FRBRExpression>
+                </akn:identification>
+              </akn:meta>
+              <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                  <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                     <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                        <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
+                        <akn:docProponent eId="einleitung-1_doktitel-1_text-1_docproponent-1" GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
+                        Innern</akn:docProponent>
+                        <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Dritten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
+                     </akn:p>
+                  </akn:longTitle>
+                  <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                     <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="1900-01-01">Vom 01.01.1900</akn:date>
+                  </akn:block>
+               </akn:preface>
+           </akn:act>
+        </akn:akomaNtoso>
+        """;
 
       // When
       var norm = Norm.builder().document(XmlMapper.toDocument(oldXml)).build();
@@ -424,19 +448,22 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
 
       // When // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
-                  .accept(MediaType.APPLICATION_XML)
-                  .contentType(MediaType.APPLICATION_XML)
-                  .content(newXml))
-          .andExpect(status().isOk())
-          .andExpect(
-              content()
-                  .node(
-                      hasXPath(
-                          "//*[@eId=\"einleitung-1_doktitel-1_text-1_doctitel-1\"]",
-                          equalTo(
-                              "Entwurf eines Dritten Gesetzes zur Änderung des Vereinsgesetzes"))));
+        .perform(
+          put("/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+            .accept(MediaType.APPLICATION_XML)
+            .contentType(MediaType.APPLICATION_XML)
+            .content(newXml)
+        )
+        .andExpect(status().isOk())
+        .andExpect(
+          content()
+            .node(
+              hasXPath(
+                "//*[@eId=\"einleitung-1_doktitel-1_text-1_doctitel-1\"]",
+                equalTo("Entwurf eines Dritten Gesetzes zur Änderung des Vereinsgesetzes")
+              )
+            )
+        );
     }
   }
 
@@ -447,37 +474,37 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
     void itExtractsAndReturnsTimeBoundariesFromNorm() throws Exception {
       // Given
       final String xml =
-          """
-               <?xml version="1.0" encoding="UTF-8"?><?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?><akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta GUID="82a65581-0ea7-4525-9190-35ff86c977af" eId="meta-1">
-                       <akn:identification GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" eId="meta-1_ident-1" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRExpression GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d" eId="meta-1_ident-1_frbrexpression-1">
-                             <akn:FRBRthis GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"/>
-                             <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                             <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                             <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                          </akn:FRBRExpression>
-                      </akn:identification>
-                      <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                           <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                               source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                           <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                               source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                      </akn:lifecycle>
-                      <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                          <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                             <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                          </akn:temporalGroup>
-                       </akn:temporalData>
-                    </akn:meta>
-                    <akn:body>
-                       <akn:p eId="one">old text</akn:p>
-                       <akn:p eId="two">old text</akn:p>
-                   </akn:body>
-                 </akn:act>
-               </akn:akomaNtoso>""";
+        """
+        <?xml version="1.0" encoding="UTF-8"?><?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?><akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+          <akn:act name="regelungstext">
+             <!-- Metadaten -->
+             <akn:meta GUID="82a65581-0ea7-4525-9190-35ff86c977af" eId="meta-1">
+                <akn:identification GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" eId="meta-1_ident-1" source="attributsemantik-noch-undefiniert">
+                   <akn:FRBRExpression GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d" eId="meta-1_ident-1_frbrexpression-1">
+                      <akn:FRBRthis GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"/>
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                      <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                   </akn:FRBRExpression>
+               </akn:identification>
+               <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+               </akn:lifecycle>
+               <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                                   <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                                      <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                                   </akn:temporalGroup>
+                </akn:temporalData>
+             </akn:meta>
+             <akn:body>
+                <akn:p eId="one">old text</akn:p>
+                <akn:p eId="two">old text</akn:p>
+            </akn:body>
+          </akn:act>
+        </akn:akomaNtoso>""";
 
       // When
       var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
@@ -485,49 +512,52 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/timeBoundaries")
-                  .accept(MediaType.APPLICATION_JSON_VALUE))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$", hasSize(1)))
-          .andExpect(jsonPath("$[0].date", is("2023-12-30")));
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/timeBoundaries"
+          )
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0].date", is("2023-12-30")));
     }
 
     @Test
     void itExtractsAndReturnsTimeBoundariesFromNormWhenDateIsEmpty() throws Exception {
       // Given
       final String xml =
-          """
-               <?xml version="1.0" encoding="UTF-8"?><?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?><akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta GUID="82a65581-0ea7-4525-9190-35ff86c977af" eId="meta-1">
-                       <akn:identification GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" eId="meta-1_ident-1" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRExpression GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d" eId="meta-1_ident-1_frbrexpression-1">
-                             <akn:FRBRthis GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"/>
-                             <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                             <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                             <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                          </akn:FRBRExpression>
-                      </akn:identification>
-                      <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                           <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                               source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                           <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date=""
-                               source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                      </akn:lifecycle>
-                      <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                          <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                             <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                          </akn:temporalGroup>
-                       </akn:temporalData>
-                    </akn:meta>
-                    <akn:body>
-                       <akn:p eId="one">old text</akn:p>
-                       <akn:p eId="two">old text</akn:p>
-                   </akn:body>
-                 </akn:act>
-               </akn:akomaNtoso>""";
+        """
+        <?xml version="1.0" encoding="UTF-8"?><?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?><akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+          <akn:act name="regelungstext">
+             <!-- Metadaten -->
+             <akn:meta GUID="82a65581-0ea7-4525-9190-35ff86c977af" eId="meta-1">
+                <akn:identification GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" eId="meta-1_ident-1" source="attributsemantik-noch-undefiniert">
+                   <akn:FRBRExpression GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d" eId="meta-1_ident-1_frbrexpression-1">
+                      <akn:FRBRthis GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"/>
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                      <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                   </akn:FRBRExpression>
+               </akn:identification>
+               <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date=""
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+               </akn:lifecycle>
+               <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                                   <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                                      <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                                   </akn:temporalGroup>
+                </akn:temporalData>
+             </akn:meta>
+             <akn:body>
+                <akn:p eId="one">old text</akn:p>
+                <akn:p eId="two">old text</akn:p>
+            </akn:body>
+          </akn:act>
+        </akn:akomaNtoso>""";
 
       // When
       var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
@@ -535,12 +565,15 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/timeBoundaries")
-                  .accept(MediaType.APPLICATION_JSON_VALUE))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$", hasSize(1)))
-          .andExpect(jsonPath("$[0].date", is(nullValue())));
+        .perform(
+          get(
+            "/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/timeBoundaries"
+          )
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0].date", is(nullValue())));
     }
   }
 
@@ -548,17 +581,19 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
   class UpdateMod {
 
     @ParameterizedTest
-    @ValueSource(strings = {"", "?dryRun=true"})
+    @ValueSource(strings = { "", "?dryRun=true" })
     void itUpdatesAQuotedTextMod(String queryParameters) throws Exception {
       // When
       normRepository.save(NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithMods.xml")));
       normRepository.save(
-          NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml")));
+        NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml"))
+      );
       normRepository.save(
-          NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithPassiveModifications.xml")));
+        NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithPassiveModifications.xml"))
+      );
 
       String path =
-          "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/mods/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1";
+        "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/mods/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1";
       String refersTo = "THIS_IS_NOT_BEING_HANDLED";
       String timeBoundaryEId = "meta-1_geltzeiten-1_geltungszeitgr-1";
       String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
@@ -569,81 +604,104 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
 
       // When
       mockMvc
-          .perform(
-              put(path + queryParameters)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "{\"refersTo\": \""
-                          + refersTo
-                          + "\", \"timeBoundaryEid\": \""
-                          + timeBoundaryEId
-                          + "\", \"destinationHref\": \""
-                          + destinationHref
-                          + "\", \"newContent\": \""
-                          + newContent
-                          + "\"}"))
-          // Then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("amendingNormXml", notNullValue()))
-          .andExpect(
-              jsonPath("amendingNormXml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//activeModifications/textualMod/destination/@href",
-                              equalTo(destinationHref)))))
-          .andExpect(
-              jsonPath("amendingNormXml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//activeModifications/textualMod/force/@period",
-                              equalTo("#" + timeBoundaryEId)))))
-          .andExpect(
-              jsonPath("amendingNormXml")
-                  .value(
-                      XmlMatcher.xml(hasXPath("//body//mod/ref/@href", equalTo(destinationHref)))))
-          .andExpect(
-              jsonPath("amendingNormXml")
-                  .value(
-                      XmlMatcher.xml(hasXPath("//body//mod/quotedText[2]", equalTo(newContent)))))
-          .andExpect(
-              jsonPath("targetNormZf0Xml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//passiveModifications/textualMod/destination/@href",
-                              equalTo("#" + eId + "/" + characterCount)))))
-          .andExpect(
-              jsonPath("targetNormZf0Xml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//passiveModifications/textualMod/source/@href",
-                              equalTo(
-                                  "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml")))));
+        .perform(
+          put(path + queryParameters)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "{\"refersTo\": \"" +
+              refersTo +
+              "\", \"timeBoundaryEid\": \"" +
+              timeBoundaryEId +
+              "\", \"destinationHref\": \"" +
+              destinationHref +
+              "\", \"newContent\": \"" +
+              newContent +
+              "\"}"
+            )
+        )
+        // Then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("amendingNormXml", notNullValue()))
+        .andExpect(
+          jsonPath("amendingNormXml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//activeModifications/textualMod/destination/@href",
+                  equalTo(destinationHref)
+                )
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("amendingNormXml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//activeModifications/textualMod/force/@period",
+                  equalTo("#" + timeBoundaryEId)
+                )
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("amendingNormXml")
+            .value(XmlMatcher.xml(hasXPath("//body//mod/ref/@href", equalTo(destinationHref))))
+        )
+        .andExpect(
+          jsonPath("amendingNormXml")
+            .value(XmlMatcher.xml(hasXPath("//body//mod/quotedText[2]", equalTo(newContent))))
+        )
+        .andExpect(
+          jsonPath("targetNormZf0Xml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//passiveModifications/textualMod/destination/@href",
+                  equalTo("#" + eId + "/" + characterCount)
+                )
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("targetNormZf0Xml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//passiveModifications/textualMod/source/@href",
+                  equalTo(
+                    "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"
+                  )
+                )
+              )
+            )
+        );
 
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu/regelungstext-1")
-                  .accept(MediaType.APPLICATION_XML))
-          .andExpect(status().isOk())
-          .andExpect(
-              xpath("//passiveModifications/textualMod/destination/@href")
-                  .string("#" + eId + "/" + characterCount));
+        .perform(
+          get("/api/v1/norms/eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu/regelungstext-1")
+            .accept(MediaType.APPLICATION_XML)
+        )
+        .andExpect(status().isOk())
+        .andExpect(
+          xpath("//passiveModifications/textualMod/destination/@href")
+            .string("#" + eId + "/" + characterCount)
+        );
     }
 
     @Test
     void itUpdatesAQuotedStructureMod() throws Exception {
       // When
       normRepository.save(
-          NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithQuotedStructureMods.xml")));
+        NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithQuotedStructureMods.xml"))
+      );
       normRepository.save(
-          NormMapper.mapToDto(
-              NormFixtures.loadFromDisk("NormWithoutPassiveModsQuotedStructure.xml")));
+        NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithoutPassiveModsQuotedStructure.xml"))
+      );
       normRepository.save(
-          NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithPassiveModsQuotedStructure.xml")));
+        NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithPassiveModsQuotedStructure.xml"))
+      );
 
       String refersTo = "THIS_IS_NOT_BEING_HANDLED";
       String timeBoundaryEId = "meta-1_geltzeiten-1_geltungszeitgr-2";
@@ -654,76 +712,96 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
 
       // When
       mockMvc
-          .perform(
-              put("/api/v1/norms/eli/bund/bgbl-1/1002/10/1002-01-10/1/deu/regelungstext-1/mods/hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1")
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "{\"refersTo\": \""
-                          + refersTo
-                          + "\", \"timeBoundaryEid\": \""
-                          + timeBoundaryEId
-                          + "\", \"destinationHref\": \""
-                          + destinationHref
-                          + "\", \"newContent\": \""
-                          + newContent
-                          + "\"}"))
-          // Then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("amendingNormXml", notNullValue()))
-          .andExpect(
-              jsonPath("amendingNormXml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//activeModifications/textualMod/destination/@href",
-                              equalTo(destinationHref)))))
-          .andExpect(
-              jsonPath("amendingNormXml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//activeModifications/textualMod/force/@period",
-                              equalTo("#" + timeBoundaryEId)))))
-          .andExpect(
-              jsonPath("amendingNormXml")
-                  .value(
-                      XmlMatcher.xml(hasXPath("//body//mod/ref/@href", equalTo(destinationHref)))))
-          .andExpect(
-              jsonPath("targetNormZf0Xml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//passiveModifications/textualMod/destination/@href",
-                              equalTo("#" + eId)))))
-          .andExpect(
-              jsonPath("targetNormZf0Xml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//passiveModifications/textualMod/source/@href",
-                              equalTo(
-                                  "eli/bund/bgbl-1/1002/10/1002-01-10/1/deu/regelungstext-1/hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1.xml")))));
+        .perform(
+          put(
+            "/api/v1/norms/eli/bund/bgbl-1/1002/10/1002-01-10/1/deu/regelungstext-1/mods/hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1"
+          )
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "{\"refersTo\": \"" +
+              refersTo +
+              "\", \"timeBoundaryEid\": \"" +
+              timeBoundaryEId +
+              "\", \"destinationHref\": \"" +
+              destinationHref +
+              "\", \"newContent\": \"" +
+              newContent +
+              "\"}"
+            )
+        )
+        // Then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("amendingNormXml", notNullValue()))
+        .andExpect(
+          jsonPath("amendingNormXml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//activeModifications/textualMod/destination/@href",
+                  equalTo(destinationHref)
+                )
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("amendingNormXml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//activeModifications/textualMod/force/@period",
+                  equalTo("#" + timeBoundaryEId)
+                )
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("amendingNormXml")
+            .value(XmlMatcher.xml(hasXPath("//body//mod/ref/@href", equalTo(destinationHref))))
+        )
+        .andExpect(
+          jsonPath("targetNormZf0Xml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath("//passiveModifications/textualMod/destination/@href", equalTo("#" + eId))
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("targetNormZf0Xml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//passiveModifications/textualMod/source/@href",
+                  equalTo(
+                    "eli/bund/bgbl-1/1002/10/1002-01-10/1/deu/regelungstext-1/hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1.xml"
+                  )
+                )
+              )
+            )
+        );
 
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1002/1/1002-01-10/1/deu/regelungstext-1")
-                  .accept(MediaType.APPLICATION_XML))
-          .andExpect(status().isOk())
-          .andExpect(
-              xpath("//passiveModifications/textualMod/destination/@href").string("#" + eId));
+        .perform(
+          get("/api/v1/norms/eli/bund/bgbl-1/1002/1/1002-01-10/1/deu/regelungstext-1")
+            .accept(MediaType.APPLICATION_XML)
+        )
+        .andExpect(status().isOk())
+        .andExpect(xpath("//passiveModifications/textualMod/destination/@href").string("#" + eId));
     }
 
     @Test
     void itUpdatesAQuotedStructureModFromRefToRref() throws Exception {
       // When
       normRepository.save(
-          NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithQuotedStructureMods.xml")));
+        NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithQuotedStructureMods.xml"))
+      );
       normRepository.save(
-          NormMapper.mapToDto(
-              NormFixtures.loadFromDisk("NormWithoutPassiveModsQuotedStructure.xml")));
+        NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithoutPassiveModsQuotedStructure.xml"))
+      );
       normRepository.save(
-          NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithPassiveModsQuotedStructure.xml")));
+        NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithPassiveModsQuotedStructure.xml"))
+      );
 
       String refersTo = "THIS_IS_NOT_BEING_HANDLED";
       String timeBoundaryEId = "meta-1_geltzeiten-1_geltungszeitgr-2";
@@ -735,85 +813,109 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
       String newContent = "THIS_IS_NOT_BEING_HANDLED";
 
       String modEid =
-          "hauptteil-1_para-1_abs-1_untergl-1_listenelem-5_untergl-1_listenelem-a_inhalt-1_text-1_ändbefehl-1";
+        "hauptteil-1_para-1_abs-1_untergl-1_listenelem-5_untergl-1_listenelem-a_inhalt-1_text-1_ändbefehl-1";
 
       // When
       mockMvc
-          .perform(
-              put("/api/v1/norms/eli/bund/bgbl-1/1002/10/1002-01-10/1/deu/regelungstext-1/mods/"
-                      + modEid)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "{\"refersTo\": \""
-                          + refersTo
-                          + "\", \"timeBoundaryEid\": \""
-                          + timeBoundaryEId
-                          + "\", \"destinationHref\": \""
-                          + destinationHref
-                          + "\", \"newContent\": \""
-                          + newContent
-                          + "\", \"destinationUpTo\": \""
-                          + destinationUpTo
-                          + "\"}"))
-          // Then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("amendingNormXml", notNullValue()))
-          .andExpect(
-              jsonPath("amendingNormXml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//activeModifications/textualMod[@eId='meta-1_analysis-1_activemod-1_textualmod-5']/destination/@href",
-                              equalTo(destinationHref)))))
-          .andExpect(
-              jsonPath("amendingNormXml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//activeModifications/textualMod[@eId='meta-1_analysis-1_activemod-1_textualmod-5']/destination/@upTo",
-                              equalTo(destinationUpTo)))))
-          .andExpect(
-              jsonPath("amendingNormXml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//body//mod[@eId='" + modEid + "']/rref/@from",
-                              equalTo(destinationHref)))))
-          .andExpect(
-              jsonPath("amendingNormXml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//body//mod[@eId='" + modEid + "']/rref/@upTo",
-                              equalTo(destinationUpTo)))))
-          .andExpect(
-              jsonPath("targetNormZf0Xml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//passiveModifications/textualMod[@eId='meta-1_analysis-1_pasmod-1_textualmod-5']/destination/@href",
-                              equalTo("#" + destinationHrefEid)))))
-          .andExpect(
-              jsonPath("targetNormZf0Xml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//passiveModifications/textualMod[@eId='meta-1_analysis-1_pasmod-1_textualmod-5']/destination/@upTo",
-                              equalTo("#" + destinationUpToEid)))));
+        .perform(
+          put(
+            "/api/v1/norms/eli/bund/bgbl-1/1002/10/1002-01-10/1/deu/regelungstext-1/mods/" + modEid
+          )
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "{\"refersTo\": \"" +
+              refersTo +
+              "\", \"timeBoundaryEid\": \"" +
+              timeBoundaryEId +
+              "\", \"destinationHref\": \"" +
+              destinationHref +
+              "\", \"newContent\": \"" +
+              newContent +
+              "\", \"destinationUpTo\": \"" +
+              destinationUpTo +
+              "\"}"
+            )
+        )
+        // Then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("amendingNormXml", notNullValue()))
+        .andExpect(
+          jsonPath("amendingNormXml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//activeModifications/textualMod[@eId='meta-1_analysis-1_activemod-1_textualmod-5']/destination/@href",
+                  equalTo(destinationHref)
+                )
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("amendingNormXml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//activeModifications/textualMod[@eId='meta-1_analysis-1_activemod-1_textualmod-5']/destination/@upTo",
+                  equalTo(destinationUpTo)
+                )
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("amendingNormXml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath("//body//mod[@eId='" + modEid + "']/rref/@from", equalTo(destinationHref))
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("amendingNormXml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath("//body//mod[@eId='" + modEid + "']/rref/@upTo", equalTo(destinationUpTo))
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("targetNormZf0Xml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//passiveModifications/textualMod[@eId='meta-1_analysis-1_pasmod-1_textualmod-5']/destination/@href",
+                  equalTo("#" + destinationHrefEid)
+                )
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("targetNormZf0Xml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//passiveModifications/textualMod[@eId='meta-1_analysis-1_pasmod-1_textualmod-5']/destination/@upTo",
+                  equalTo("#" + destinationUpToEid)
+                )
+              )
+            )
+        );
     }
 
     @Test
     void itUpdatesAQuotedStructureModFromRrefToRef() throws Exception {
       // When
       normRepository.save(
-          NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithQuotedStructureModsAndUpTo.xml")));
+        NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithQuotedStructureModsAndUpTo.xml"))
+      );
       normRepository.save(
-          NormMapper.mapToDto(
-              NormFixtures.loadFromDisk("NormWithoutPassiveModsQuotedStructure.xml")));
+        NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithoutPassiveModsQuotedStructure.xml"))
+      );
       normRepository.save(
-          NormMapper.mapToDto(
-              NormFixtures.loadFromDisk("NormWithPassiveModsQuotedStructureAndUpTo.xml")));
+        NormMapper.mapToDto(
+          NormFixtures.loadFromDisk("NormWithPassiveModsQuotedStructureAndUpTo.xml")
+        )
+      );
 
       String refersTo = "THIS_IS_NOT_BEING_HANDLED";
       String timeBoundaryEId = "meta-1_geltzeiten-1_geltungszeitgr-2";
@@ -826,46 +928,58 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
 
       // When
       mockMvc
-          .perform(
-              put("/api/v1/norms/eli/bund/bgbl-1/2002/22/2002-02-20/1/deu/regelungstext-1/mods/"
-                      + modEid)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "{\"refersTo\": \""
-                          + refersTo
-                          + "\", \"timeBoundaryEid\": \""
-                          + timeBoundaryEId
-                          + "\", \"destinationHref\": \""
-                          + destinationHref
-                          + "\", \"newContent\": \""
-                          + newContent
-                          + "\", \"destinationUpTo\": \""
-                          + "\"}"))
-          // Then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("amendingNormXml", notNullValue()))
-          .andExpect(
-              jsonPath("amendingNormXml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//activeModifications/textualMod[@eId='meta-1_analysis-1_activemod-1_textualmod-1']/destination/@href",
-                              equalTo(destinationHref)))))
-          .andExpect(
-              jsonPath("amendingNormXml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//body//mod[@eId='" + modEid + "']/ref/@href",
-                              equalTo(destinationHref)))))
-          .andExpect(
-              jsonPath("targetNormZf0Xml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//passiveModifications/textualMod[@eId='meta-1_analysis-1_pasmod-1_textualmod-1']/destination/@href",
-                              equalTo("#" + destinationHrefEid)))));
+        .perform(
+          put(
+            "/api/v1/norms/eli/bund/bgbl-1/2002/22/2002-02-20/1/deu/regelungstext-1/mods/" + modEid
+          )
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "{\"refersTo\": \"" +
+              refersTo +
+              "\", \"timeBoundaryEid\": \"" +
+              timeBoundaryEId +
+              "\", \"destinationHref\": \"" +
+              destinationHref +
+              "\", \"newContent\": \"" +
+              newContent +
+              "\", \"destinationUpTo\": \"" +
+              "\"}"
+            )
+        )
+        // Then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("amendingNormXml", notNullValue()))
+        .andExpect(
+          jsonPath("amendingNormXml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//activeModifications/textualMod[@eId='meta-1_analysis-1_activemod-1_textualmod-1']/destination/@href",
+                  equalTo(destinationHref)
+                )
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("amendingNormXml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath("//body//mod[@eId='" + modEid + "']/ref/@href", equalTo(destinationHref))
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("targetNormZf0Xml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//passiveModifications/textualMod[@eId='meta-1_analysis-1_pasmod-1_textualmod-1']/destination/@href",
+                  equalTo("#" + destinationHrefEid)
+                )
+              )
+            )
+        );
     }
 
     @Test
@@ -873,12 +987,14 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
       // When
       normRepository.save(NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithMods.xml")));
       normRepository.save(
-          NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml")));
+        NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml"))
+      );
       normRepository.save(
-          NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithPassiveModifications.xml")));
+        NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithPassiveModifications.xml"))
+      );
 
       String path =
-          "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/mods/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1";
+        "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/mods/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1";
       String refersTo = "THIS_IS_NOT_BEING_HANDLED";
       String timeBoundaryEId = "meta-1_geltzeiten-1_geltungszeitgr-1";
       String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
@@ -889,22 +1005,24 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
 
       // When
       mockMvc
-          .perform(
-              put(path)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "{\"refersTo\": \""
-                          + refersTo
-                          + "\", \"timeBoundaryEid\": \""
-                          + timeBoundaryEId
-                          + "\", \"destinationHref\": \""
-                          + destinationHref
-                          + "\", \"newContent\": \""
-                          + newContent
-                          + "\"}"))
-          // Then
-          .andExpect(status().isUnprocessableEntity());
+        .perform(
+          put(path)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "{\"refersTo\": \"" +
+              refersTo +
+              "\", \"timeBoundaryEid\": \"" +
+              timeBoundaryEId +
+              "\", \"destinationHref\": \"" +
+              destinationHref +
+              "\", \"newContent\": \"" +
+              newContent +
+              "\"}"
+            )
+        )
+        // Then
+        .andExpect(status().isUnprocessableEntity());
     }
   }
 
@@ -916,162 +1034,217 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
       // When
       normRepository.save(NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithMods.xml")));
       normRepository.save(
-          NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml")));
+        NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml"))
+      );
       normRepository.save(
-          NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithPassiveModifications.xml")));
+        NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithPassiveModifications.xml"))
+      );
 
       // When
       mockMvc
-          .perform(
-              patch("/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/mods")
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      """
-                              {
-                                "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1": {
-                                  "timeBoundaryEid": "meta-1_geltzeiten-1_geltungszeitgr-2"
-                                }
-                              }
-                          """))
-          // Then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("amendingNormXml", notNullValue()))
-          .andExpect(
-              jsonPath("amendingNormXml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//activeModifications/textualMod/destination/@href",
-                              equalTo(
-                                  "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34.xml")))))
-          .andExpect(
-              jsonPath("amendingNormXml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//activeModifications/textualMod/force/@period",
-                              equalTo("#meta-1_geltzeiten-1_geltungszeitgr-2")))))
-          .andExpect(
-              jsonPath("amendingNormXml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//body//mod/ref/@href",
-                              equalTo(
-                                  "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34.xml")))))
-          .andExpect(
-              jsonPath("amendingNormXml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//body//mod/quotedText[2]",
-                              equalTo("§ 9 Absatz 1 Satz 2, Absatz 2 oder 3")))))
-          .andExpect(
-              jsonPath("targetNormZf0Xml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//passiveModifications/textualMod/destination/@href",
-                              equalTo(
-                                  "#hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34")))))
-          .andExpect(
-              jsonPath("targetNormZf0Xml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//passiveModifications/textualMod/force/@period",
-                              equalTo("#meta-1_geltzeiten-1_geltungszeitgr-4")))))
-          .andExpect(
-              jsonPath("targetNormZf0Xml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//passiveModifications/textualMod/source/@href",
-                              equalTo(
-                                  "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml")))));
+        .perform(
+          patch("/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/mods")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              """
+                  {
+                    "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1": {
+                      "timeBoundaryEid": "meta-1_geltzeiten-1_geltungszeitgr-2"
+                    }
+                  }
+              """
+            )
+        )
+        // Then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("amendingNormXml", notNullValue()))
+        .andExpect(
+          jsonPath("amendingNormXml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//activeModifications/textualMod/destination/@href",
+                  equalTo(
+                    "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34.xml"
+                  )
+                )
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("amendingNormXml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//activeModifications/textualMod/force/@period",
+                  equalTo("#meta-1_geltzeiten-1_geltungszeitgr-2")
+                )
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("amendingNormXml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//body//mod/ref/@href",
+                  equalTo(
+                    "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34.xml"
+                  )
+                )
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("amendingNormXml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//body//mod/quotedText[2]",
+                  equalTo("§ 9 Absatz 1 Satz 2, Absatz 2 oder 3")
+                )
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("targetNormZf0Xml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//passiveModifications/textualMod/destination/@href",
+                  equalTo("#hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34")
+                )
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("targetNormZf0Xml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//passiveModifications/textualMod/force/@period",
+                  equalTo("#meta-1_geltzeiten-1_geltungszeitgr-4")
+                )
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("targetNormZf0Xml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//passiveModifications/textualMod/source/@href",
+                  equalTo(
+                    "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"
+                  )
+                )
+              )
+            )
+        );
 
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1")
-                  .accept(MediaType.APPLICATION_XML))
-          .andExpect(status().isOk())
-          .andExpect(
-              xpath(
-                      "//textualMod[@eId=\"meta-1_analysis-1_activemod-1_textualmod-1\"]/force/@period")
-                  .string("#meta-1_geltzeiten-1_geltungszeitgr-2"));
+        .perform(
+          get("/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1")
+            .accept(MediaType.APPLICATION_XML)
+        )
+        .andExpect(status().isOk())
+        .andExpect(
+          xpath("//textualMod[@eId=\"meta-1_analysis-1_activemod-1_textualmod-1\"]/force/@period")
+            .string("#meta-1_geltzeiten-1_geltungszeitgr-2")
+        );
     }
 
     @Test
     void itUpdatesMultipleMods() throws Exception {
       // When
       normRepository.save(
-          NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithMultipleSimpleMods.xml")));
+        NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithMultipleSimpleMods.xml"))
+      );
       normRepository.save(
-          NormMapper.mapToDto(
-              NormFixtures.loadFromDisk("NormWithMultipleSimpleModsTargetNorm.xml")));
+        NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithMultipleSimpleModsTargetNorm.xml"))
+      );
 
       // When
       mockMvc
-          .perform(
-              patch("/api/v1/norms/eli/bund/bgbl-1/1001/2/1001-02-01/1/deu/regelungstext-1/mods")
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      """
-                              {
-                                "hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1": {
-                                  "timeBoundaryEid": "meta-1_geltzeiten-1_geltungszeitgr-2"
-                                },
-                                "hauptteil-1_para-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1": {
-                                }
-                              }
-                          """))
-          // Then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("amendingNormXml", notNullValue()))
-          .andExpect(
-              jsonPath("amendingNormXml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//textualMod[@eId=\"meta-1_analysis-1_activemod-1_textualmod-1\"]/force/@period",
-                              equalTo("#meta-1_geltzeiten-1_geltungszeitgr-2")))))
-          .andExpect(
-              jsonPath("amendingNormXml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//textualMod[@eId=\"meta-1_analysis-1_activemod-1_textualmod-2\"]/force/@period",
-                              equalTo("")))))
-          .andExpect(
-              jsonPath("targetNormZf0Xml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//textualMod[@eId=\"meta-1_analysis-1_pasmod-1_textualmod-1\"]/force/@period",
-                              equalTo("#meta-1_geltzeiten-1_geltungszeitgr-2")))))
-          .andExpect(
-              jsonPath("targetNormZf0Xml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//textualMod[@eId=\"meta-1_analysis-1_pasmod-1_textualmod-2\"]/force/@period",
-                              equalTo("")))));
+        .perform(
+          patch("/api/v1/norms/eli/bund/bgbl-1/1001/2/1001-02-01/1/deu/regelungstext-1/mods")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              """
+                  {
+                    "hauptteil-1_para-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1": {
+                      "timeBoundaryEid": "meta-1_geltzeiten-1_geltungszeitgr-2"
+                    },
+                    "hauptteil-1_para-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1": {
+                    }
+                  }
+              """
+            )
+        )
+        // Then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("amendingNormXml", notNullValue()))
+        .andExpect(
+          jsonPath("amendingNormXml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//textualMod[@eId=\"meta-1_analysis-1_activemod-1_textualmod-1\"]/force/@period",
+                  equalTo("#meta-1_geltzeiten-1_geltungszeitgr-2")
+                )
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("amendingNormXml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//textualMod[@eId=\"meta-1_analysis-1_activemod-1_textualmod-2\"]/force/@period",
+                  equalTo("")
+                )
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("targetNormZf0Xml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//textualMod[@eId=\"meta-1_analysis-1_pasmod-1_textualmod-1\"]/force/@period",
+                  equalTo("#meta-1_geltzeiten-1_geltungszeitgr-2")
+                )
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("targetNormZf0Xml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//textualMod[@eId=\"meta-1_analysis-1_pasmod-1_textualmod-2\"]/force/@period",
+                  equalTo("")
+                )
+              )
+            )
+        );
 
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1001/2/1001-02-01/1/deu/regelungstext-1")
-                  .accept(MediaType.APPLICATION_XML))
-          .andExpect(status().isOk())
-          .andExpect(
-              xpath(
-                      "//textualMod[@eId=\"meta-1_analysis-1_activemod-1_textualmod-1\"]/force/@period")
-                  .string("#meta-1_geltzeiten-1_geltungszeitgr-2"))
-          .andExpect(
-              xpath(
-                      "//textualMod[@eId=\"meta-1_analysis-1_activemod-1_textualmod-2\"]/force/@period")
-                  .string(""));
+        .perform(
+          get("/api/v1/norms/eli/bund/bgbl-1/1001/2/1001-02-01/1/deu/regelungstext-1")
+            .accept(MediaType.APPLICATION_XML)
+        )
+        .andExpect(status().isOk())
+        .andExpect(
+          xpath("//textualMod[@eId=\"meta-1_analysis-1_activemod-1_textualmod-1\"]/force/@period")
+            .string("#meta-1_geltzeiten-1_geltungszeitgr-2")
+        )
+        .andExpect(
+          xpath("//textualMod[@eId=\"meta-1_analysis-1_activemod-1_textualmod-2\"]/force/@period")
+            .string("")
+        );
     }
 
     @Test
@@ -1079,53 +1252,67 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
       // When
       normRepository.save(NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithMods.xml")));
       normRepository.save(
-          NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml")));
+        NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml"))
+      );
       normRepository.save(
-          NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithPassiveModifications.xml")));
+        NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithPassiveModifications.xml"))
+      );
 
       // When
       mockMvc
-          .perform(
-              patch(
-                      "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/mods?dryRun=true")
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      """
-                              {
-                                "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1": {
-                                  "timeBoundaryEid": "meta-1_geltzeiten-1_geltungszeitgr-2"
-                                }
-                              }
-                          """))
-          // Then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("amendingNormXml", notNullValue()))
-          .andExpect(
-              jsonPath("amendingNormXml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//textualMod[@eId=\"meta-1_analysis-1_activemod-1_textualmod-1\"]/force/@period",
-                              equalTo("#meta-1_geltzeiten-1_geltungszeitgr-2")))))
-          .andExpect(
-              jsonPath("targetNormZf0Xml")
-                  .value(
-                      XmlMatcher.xml(
-                          hasXPath(
-                              "//textualMod[@eId=\"meta-1_analysis-1_pasmod-1_textualmod-1\"]/force/@period",
-                              equalTo("#meta-1_geltzeiten-1_geltungszeitgr-4")))));
+        .perform(
+          patch(
+            "/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/mods?dryRun=true"
+          )
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              """
+                  {
+                    "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1": {
+                      "timeBoundaryEid": "meta-1_geltzeiten-1_geltungszeitgr-2"
+                    }
+                  }
+              """
+            )
+        )
+        // Then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("amendingNormXml", notNullValue()))
+        .andExpect(
+          jsonPath("amendingNormXml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//textualMod[@eId=\"meta-1_analysis-1_activemod-1_textualmod-1\"]/force/@period",
+                  equalTo("#meta-1_geltzeiten-1_geltungszeitgr-2")
+                )
+              )
+            )
+        )
+        .andExpect(
+          jsonPath("targetNormZf0Xml")
+            .value(
+              XmlMatcher.xml(
+                hasXPath(
+                  "//textualMod[@eId=\"meta-1_analysis-1_pasmod-1_textualmod-1\"]/force/@period",
+                  equalTo("#meta-1_geltzeiten-1_geltungszeitgr-4")
+                )
+              )
+            )
+        );
 
       // saved norm is unchanged
       mockMvc
-          .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1")
-                  .accept(MediaType.APPLICATION_XML))
-          .andExpect(status().isOk())
-          .andExpect(
-              xpath(
-                      "//textualMod[@eId=\"meta-1_analysis-1_activemod-1_textualmod-1\"]/force/@period")
-                  .string(equalTo("#meta-1_geltzeiten-1_geltungszeitgr-1")));
+        .perform(
+          get("/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1")
+            .accept(MediaType.APPLICATION_XML)
+        )
+        .andExpect(status().isOk())
+        .andExpect(
+          xpath("//textualMod[@eId=\"meta-1_analysis-1_activemod-1_textualmod-1\"]/force/@period")
+            .string(equalTo("#meta-1_geltzeiten-1_geltungszeitgr-1"))
+        );
     }
 
     @Test
@@ -1133,26 +1320,30 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
       // When
       normRepository.save(NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithMods.xml")));
       normRepository.save(
-          NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml")));
+        NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml"))
+      );
       normRepository.save(
-          NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithPassiveModifications.xml")));
+        NormMapper.mapToDto(NormFixtures.loadFromDisk("NormWithPassiveModifications.xml"))
+      );
 
       // When (the eid does not exist)
       mockMvc
-          .perform(
-              patch("/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/mods")
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      """
-                            {
-                              "hauptteil-1_art-1_abs-23_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1": {
-                                "timeBoundaryEid": "meta-1_geltzeiten-1_geltungszeitgr-1"
-                              }
-                            }
-                          """))
-          // Then
-          .andExpect(status().isUnprocessableEntity());
+        .perform(
+          patch("/api/v1/norms/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/mods")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              """
+                {
+                  "hauptteil-1_art-1_abs-23_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1": {
+                    "timeBoundaryEid": "meta-1_geltzeiten-1_geltungszeitgr-1"
+                  }
+                }
+              """
+            )
+        )
+        // Then
+        .andExpect(status().isUnprocessableEntity());
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ProprietaryControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ProprietaryControllerIntegrationTest.java
@@ -20,8 +20,11 @@ import org.springframework.test.web.servlet.MockMvc;
 
 public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
 
-  @Autowired private MockMvc mockMvc;
-  @Autowired private NormRepository normRepository;
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private NormRepository normRepository;
 
   @AfterEach
   void cleanUp() {
@@ -30,6 +33,7 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
 
   @Nested
   class getProprietaryAtDate {
+
     @Test
     void return404IfNormNotFound() throws Exception {
       // given no norm
@@ -37,11 +41,12 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
       var atDateString = "2024-06-03";
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/" + eli + "/proprietary/" + atDateString)
-                  .accept(MediaType.APPLICATION_JSON_VALUE))
-          // then
-          .andExpect(status().isNotFound());
+        .perform(
+          get("/api/v1/norms/" + eli + "/proprietary/" + atDateString)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        )
+        // then
+        .andExpect(status().isNotFound());
     }
 
     @Test
@@ -54,21 +59,22 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/" + eli + "/proprietary/" + atDateString)
-                  .accept(MediaType.APPLICATION_JSON_VALUE))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("fna").isEmpty())
-          .andExpect(jsonPath("art").isEmpty())
-          .andExpect(jsonPath("typ").isEmpty())
-          .andExpect(jsonPath("subtyp").isEmpty())
-          .andExpect(jsonPath("bezeichnungInVorlage").isEmpty())
-          .andExpect(jsonPath("artDerNorm").isEmpty())
-          .andExpect(jsonPath("staat").isEmpty())
-          .andExpect(jsonPath("beschliessendesOrgan").isEmpty())
-          .andExpect(jsonPath("qualifizierteMehrheit").isEmpty())
-          .andExpect(jsonPath("organisationsEinheit").isEmpty());
+        .perform(
+          get("/api/v1/norms/" + eli + "/proprietary/" + atDateString)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        )
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("fna").isEmpty())
+        .andExpect(jsonPath("art").isEmpty())
+        .andExpect(jsonPath("typ").isEmpty())
+        .andExpect(jsonPath("subtyp").isEmpty())
+        .andExpect(jsonPath("bezeichnungInVorlage").isEmpty())
+        .andExpect(jsonPath("artDerNorm").isEmpty())
+        .andExpect(jsonPath("staat").isEmpty())
+        .andExpect(jsonPath("beschliessendesOrgan").isEmpty())
+        .andExpect(jsonPath("qualifizierteMehrheit").isEmpty())
+        .andExpect(jsonPath("organisationsEinheit").isEmpty());
     }
 
     @Test
@@ -81,21 +87,22 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/" + eli + "/proprietary/" + atDateString)
-                  .accept(MediaType.APPLICATION_JSON_VALUE))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("fna").isEmpty())
-          .andExpect(jsonPath("art").isEmpty())
-          .andExpect(jsonPath("typ").isEmpty())
-          .andExpect(jsonPath("subtyp").isEmpty())
-          .andExpect(jsonPath("bezeichnungInVorlage").isEmpty())
-          .andExpect(jsonPath("artDerNorm").isEmpty())
-          .andExpect(jsonPath("staat").isEmpty())
-          .andExpect(jsonPath("beschliessendesOrgan").isEmpty())
-          .andExpect(jsonPath("qualifizierteMehrheit").isEmpty())
-          .andExpect(jsonPath("organisationsEinheit").isEmpty());
+        .perform(
+          get("/api/v1/norms/" + eli + "/proprietary/" + atDateString)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        )
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("fna").isEmpty())
+        .andExpect(jsonPath("art").isEmpty())
+        .andExpect(jsonPath("typ").isEmpty())
+        .andExpect(jsonPath("subtyp").isEmpty())
+        .andExpect(jsonPath("bezeichnungInVorlage").isEmpty())
+        .andExpect(jsonPath("artDerNorm").isEmpty())
+        .andExpect(jsonPath("staat").isEmpty())
+        .andExpect(jsonPath("beschliessendesOrgan").isEmpty())
+        .andExpect(jsonPath("qualifizierteMehrheit").isEmpty())
+        .andExpect(jsonPath("organisationsEinheit").isEmpty());
     }
 
     @Test
@@ -108,48 +115,52 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/" + eli + "/proprietary/" + atDateString)
-                  .accept(MediaType.APPLICATION_JSON_VALUE))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("fna").value("754-28-1"))
-          .andExpect(jsonPath("art").value("rechtsetzungsdokument"))
-          .andExpect(jsonPath("typ").value("gesetz"))
-          .andExpect(jsonPath("subtyp").value("rechtsverordnung"))
-          .andExpect(jsonPath("bezeichnungInVorlage").value("Bezeichnung gemäß Vorlage"))
-          .andExpect(jsonPath("artDerNorm").value("SN,ÄN,ÜN"))
-          .andExpect(jsonPath("staat").value("DEU"))
-          .andExpect(jsonPath("beschliessendesOrgan").value("Bundestag"))
-          .andExpect(jsonPath("qualifizierteMehrheit").value(true))
-          .andExpect(jsonPath("organisationsEinheit").value("Organisationseinheit"));
+        .perform(
+          get("/api/v1/norms/" + eli + "/proprietary/" + atDateString)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        )
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("fna").value("754-28-1"))
+        .andExpect(jsonPath("art").value("rechtsetzungsdokument"))
+        .andExpect(jsonPath("typ").value("gesetz"))
+        .andExpect(jsonPath("subtyp").value("rechtsverordnung"))
+        .andExpect(jsonPath("bezeichnungInVorlage").value("Bezeichnung gemäß Vorlage"))
+        .andExpect(jsonPath("artDerNorm").value("SN,ÄN,ÜN"))
+        .andExpect(jsonPath("staat").value("DEU"))
+        .andExpect(jsonPath("beschliessendesOrgan").value("Bundestag"))
+        .andExpect(jsonPath("qualifizierteMehrheit").value(true))
+        .andExpect(jsonPath("organisationsEinheit").value("Organisationseinheit"));
     }
   }
 
   @Nested
   class updateProprietary {
+
     @Test
     void return404IfNormNotFound() throws Exception {
       // given
       final String eli = "eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1";
       // when
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/proprietary/{date}", eli, "1990-01-01")
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "{\"fna\": \"new-fna\","
-                          + "\"art\": \"new-art\","
-                          + "\"typ\": \"new-typ\","
-                          + "\"subtyp\": \"new-subtyp\","
-                          + "\"bezeichnungInVorlage\": \"new-bezeichnungInVorlage\","
-                          + "\"artDerNorm\": \"SN,ÄN,ÜN\","
-                          + "\"staat\": \"DEU\","
-                          + "\"beschliessendesOrgan\": \"Bundestag\","
-                          + "\"qualifizierteMehrheit\": true,"
-                          + "\"organisationsEinheit\": \"Andere Organisationseinheit\"}"))
-          .andExpect(status().isNotFound());
+        .perform(
+          put("/api/v1/norms/{eli}/proprietary/{date}", eli, "1990-01-01")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "{\"fna\": \"new-fna\"," +
+              "\"art\": \"new-art\"," +
+              "\"typ\": \"new-typ\"," +
+              "\"subtyp\": \"new-subtyp\"," +
+              "\"bezeichnungInVorlage\": \"new-bezeichnungInVorlage\"," +
+              "\"artDerNorm\": \"SN,ÄN,ÜN\"," +
+              "\"staat\": \"DEU\"," +
+              "\"beschliessendesOrgan\": \"Bundestag\"," +
+              "\"qualifizierteMehrheit\": true," +
+              "\"organisationsEinheit\": \"Andere Organisationseinheit\"}"
+            )
+        )
+        .andExpect(status().isNotFound());
     }
 
     @Test
@@ -162,32 +173,34 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // when
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/proprietary/{date}", eli, date.toString())
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "{\"fna\": \"new-fna\","
-                          + "\"art\": \"new-art\","
-                          + "\"typ\": \"new-typ\","
-                          + "\"subtyp\": \"new-subtyp\","
-                          + "\"bezeichnungInVorlage\": \"new-bezeichnungInVorlage\","
-                          + "\"artDerNorm\": \"ÄN,ÜN\","
-                          + "\"staat\": \"DDR\","
-                          + "\"beschliessendesOrgan\": \"LT\","
-                          + "\"qualifizierteMehrheit\": false,"
-                          + "\"organisationsEinheit\": \"Andere Organisationseinheit\"}"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("fna").value("new-fna"))
-          .andExpect(jsonPath("art").value("new-art"))
-          .andExpect(jsonPath("typ").value("new-typ"))
-          .andExpect(jsonPath("subtyp").value("new-subtyp"))
-          .andExpect(jsonPath("bezeichnungInVorlage").value("new-bezeichnungInVorlage"))
-          .andExpect(jsonPath("artDerNorm").value("ÄN,ÜN"))
-          .andExpect(jsonPath("staat").value("DDR"))
-          .andExpect(jsonPath("beschliessendesOrgan").value("LT"))
-          .andExpect(jsonPath("qualifizierteMehrheit").value(false))
-          .andExpect(jsonPath("organisationsEinheit").value("Andere Organisationseinheit"));
+        .perform(
+          put("/api/v1/norms/{eli}/proprietary/{date}", eli, date.toString())
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "{\"fna\": \"new-fna\"," +
+              "\"art\": \"new-art\"," +
+              "\"typ\": \"new-typ\"," +
+              "\"subtyp\": \"new-subtyp\"," +
+              "\"bezeichnungInVorlage\": \"new-bezeichnungInVorlage\"," +
+              "\"artDerNorm\": \"ÄN,ÜN\"," +
+              "\"staat\": \"DDR\"," +
+              "\"beschliessendesOrgan\": \"LT\"," +
+              "\"qualifizierteMehrheit\": false," +
+              "\"organisationsEinheit\": \"Andere Organisationseinheit\"}"
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("fna").value("new-fna"))
+        .andExpect(jsonPath("art").value("new-art"))
+        .andExpect(jsonPath("typ").value("new-typ"))
+        .andExpect(jsonPath("subtyp").value("new-subtyp"))
+        .andExpect(jsonPath("bezeichnungInVorlage").value("new-bezeichnungInVorlage"))
+        .andExpect(jsonPath("artDerNorm").value("ÄN,ÜN"))
+        .andExpect(jsonPath("staat").value("DDR"))
+        .andExpect(jsonPath("beschliessendesOrgan").value("LT"))
+        .andExpect(jsonPath("qualifizierteMehrheit").value(false))
+        .andExpect(jsonPath("organisationsEinheit").value("Andere Organisationseinheit"));
 
       final Norm normLoaded = NormMapper.mapToDomain(normRepository.findByEli(eli).get());
 
@@ -195,18 +208,18 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getArt(date)).contains("new-art");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getTyp(date)).contains("new-typ");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getSubtyp(date))
-          .contains("new-subtyp");
+        .contains("new-subtyp");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getBezeichnungInVorlage(date))
-          .contains("new-bezeichnungInVorlage");
+        .contains("new-bezeichnungInVorlage");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getArtDerNorm(date))
-          .contains("ÄN,ÜN");
+        .contains("ÄN,ÜN");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getStaat(date)).contains("DDR");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getBeschliessendesOrgan(date))
-          .contains("LT");
+        .contains("LT");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getQualifizierteMehrheit(date))
-          .contains(false);
+        .contains(false);
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getOrganisationsEinheit(date))
-          .contains("Andere Organisationseinheit");
+        .contains("Andere Organisationseinheit");
     }
 
     @Test
@@ -220,50 +233,52 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
       // when
 
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/proprietary/{date}", eli, date.toString())
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "{\"fna\": null,"
-                          + "\"art\": null,"
-                          + "\"typ\": null,"
-                          + "\"subtyp\": null,"
-                          + "\"bezeichnungInVorlage\": null,"
-                          + "\"artDerNorm\": null,"
-                          + "\"staat\": null,"
-                          + "\"beschliessendesOrgan\": null,"
-                          + "\"qualifizierteMehrheit\": null,"
-                          + "\"organisationsEinheit\": null}"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("fna").value("754-28-1"))
-          .andExpect(jsonPath("art").value("rechtsetzungsdokument"))
-          .andExpect(jsonPath("typ").value("gesetz"))
-          .andExpect(jsonPath("subtyp").isEmpty())
-          .andExpect(jsonPath("bezeichnungInVorlage").isEmpty())
-          .andExpect(jsonPath("artDerNorm").isEmpty())
-          .andExpect(jsonPath("staat").isEmpty())
-          .andExpect(jsonPath("beschliessendesOrgan").isEmpty())
-          .andExpect(jsonPath("qualifizierteMehrheit").isEmpty())
-          .andExpect(jsonPath("organisationsEinheit").isEmpty());
+        .perform(
+          put("/api/v1/norms/{eli}/proprietary/{date}", eli, date.toString())
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "{\"fna\": null," +
+              "\"art\": null," +
+              "\"typ\": null," +
+              "\"subtyp\": null," +
+              "\"bezeichnungInVorlage\": null," +
+              "\"artDerNorm\": null," +
+              "\"staat\": null," +
+              "\"beschliessendesOrgan\": null," +
+              "\"qualifizierteMehrheit\": null," +
+              "\"organisationsEinheit\": null}"
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("fna").value("754-28-1"))
+        .andExpect(jsonPath("art").value("rechtsetzungsdokument"))
+        .andExpect(jsonPath("typ").value("gesetz"))
+        .andExpect(jsonPath("subtyp").isEmpty())
+        .andExpect(jsonPath("bezeichnungInVorlage").isEmpty())
+        .andExpect(jsonPath("artDerNorm").isEmpty())
+        .andExpect(jsonPath("staat").isEmpty())
+        .andExpect(jsonPath("beschliessendesOrgan").isEmpty())
+        .andExpect(jsonPath("qualifizierteMehrheit").isEmpty())
+        .andExpect(jsonPath("organisationsEinheit").isEmpty());
 
       final Norm normLoaded = NormMapper.mapToDomain(normRepository.findByEli(eli).get());
 
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getFna(date)).contains("754-28-1");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getArt(date))
-          .contains("rechtsetzungsdokument");
+        .contains("rechtsetzungsdokument");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getTyp(date)).contains("gesetz");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getSubtyp(date)).isEmpty();
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getBezeichnungInVorlage(date))
-          .isEmpty();
+        .isEmpty();
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getArtDerNorm(date)).isEmpty();
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getStaat(date)).isEmpty();
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getBeschliessendesOrgan(date))
-          .isEmpty();
+        .isEmpty();
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getQualifizierteMehrheit(date))
-          .isEmpty();
+        .isEmpty();
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getOrganisationsEinheit(date))
-          .isEmpty();
+        .isEmpty();
     }
 
     @Test
@@ -277,50 +292,52 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
       // when
 
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/proprietary/{date}", eli, date.toString())
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "{\"fna\": \"\","
-                          + "\"art\": \"\","
-                          + "\"typ\": \"\","
-                          + "\"subtyp\": \"\","
-                          + "\"bezeichnungInVorlage\": \"\","
-                          + "\"artDerNorm\": \"\","
-                          + "\"staat\": \"\","
-                          + "\"beschliessendesOrgan\": \"\","
-                          + "\"qualifizierteMehrheit\": false,"
-                          + "\"organisationsEinheit\": \"\"}"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("fna").value("754-28-1"))
-          .andExpect(jsonPath("art").value("rechtsetzungsdokument"))
-          .andExpect(jsonPath("typ").value("gesetz"))
-          .andExpect(jsonPath("subtyp").isEmpty())
-          .andExpect(jsonPath("bezeichnungInVorlage").isEmpty())
-          .andExpect(jsonPath("artDerNorm").isEmpty())
-          .andExpect(jsonPath("staat").isEmpty())
-          .andExpect(jsonPath("beschliessendesOrgan").isEmpty())
-          .andExpect(jsonPath("qualifizierteMehrheit").isEmpty())
-          .andExpect(jsonPath("organisationsEinheit").isEmpty());
+        .perform(
+          put("/api/v1/norms/{eli}/proprietary/{date}", eli, date.toString())
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "{\"fna\": \"\"," +
+              "\"art\": \"\"," +
+              "\"typ\": \"\"," +
+              "\"subtyp\": \"\"," +
+              "\"bezeichnungInVorlage\": \"\"," +
+              "\"artDerNorm\": \"\"," +
+              "\"staat\": \"\"," +
+              "\"beschliessendesOrgan\": \"\"," +
+              "\"qualifizierteMehrheit\": false," +
+              "\"organisationsEinheit\": \"\"}"
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("fna").value("754-28-1"))
+        .andExpect(jsonPath("art").value("rechtsetzungsdokument"))
+        .andExpect(jsonPath("typ").value("gesetz"))
+        .andExpect(jsonPath("subtyp").isEmpty())
+        .andExpect(jsonPath("bezeichnungInVorlage").isEmpty())
+        .andExpect(jsonPath("artDerNorm").isEmpty())
+        .andExpect(jsonPath("staat").isEmpty())
+        .andExpect(jsonPath("beschliessendesOrgan").isEmpty())
+        .andExpect(jsonPath("qualifizierteMehrheit").isEmpty())
+        .andExpect(jsonPath("organisationsEinheit").isEmpty());
 
       final Norm normLoaded = NormMapper.mapToDomain(normRepository.findByEli(eli).get());
 
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getFna(date)).contains("754-28-1");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getArt(date))
-          .contains("rechtsetzungsdokument");
+        .contains("rechtsetzungsdokument");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getTyp(date)).contains("gesetz");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getSubtyp(date)).isEmpty();
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getBezeichnungInVorlage(date))
-          .isEmpty();
+        .isEmpty();
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getArtDerNorm(date)).isEmpty();
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getStaat(date)).isEmpty();
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getBeschliessendesOrgan(date))
-          .isEmpty();
+        .isEmpty();
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getQualifizierteMehrheit(date))
-          .isEmpty();
+        .isEmpty();
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getOrganisationsEinheit(date))
-          .isEmpty();
+        .isEmpty();
     }
 
     @Test
@@ -328,42 +345,44 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
       // given
       final String eli = "eli/bund/bgbl-1/2002/s1181/2019-11-22/1/deu/rechtsetzungsdokument-1";
       final LocalDate date = LocalDate.parse("2003-01-01");
-      final Norm norm =
-          NormFixtures.loadFromDisk("NormWithProprietaryAndMultipleTimeBoundaries.xml");
+      final Norm norm = NormFixtures.loadFromDisk(
+        "NormWithProprietaryAndMultipleTimeBoundaries.xml"
+      );
       normRepository.save(NormMapper.mapToDto(norm));
 
       // when
 
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/proprietary/{date}", eli, date.toString())
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "{\"fna\": \"new-fna\"," // no change
-                          + "\"art\": \"new-art\"," // no change
-                          + "\"typ\": \"new-typ\"," // no change
-                          + "\"subtyp\": \"new-subtyp\"," // no change
-                          + "\"bezeichnungInVorlage\": \"new-bezeichnungInVorlage\"," // no change
-                          + "\"artDerNorm\": \"ÄN,ÜN\"," // no change
-                          + "\"staat\": \"DDR\"," // no change
-                          + "\"beschliessendesOrgan\": \"\"," // this will remove the...
-                          + "\"qualifizierteMehrheit\": null," // ...qualifizierteMehrheit attr
-                          + "\"organisationsEinheit\": \"Andere Organisationseinheit\"}")) // no
-          // change
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("fna").value("new-fna"))
-          .andExpect(jsonPath("art").value("new-art"))
-          .andExpect(jsonPath("typ").value("new-typ"))
-          .andExpect(jsonPath("subtyp").value("new-subtyp"))
-          .andExpect(jsonPath("bezeichnungInVorlage").value("new-bezeichnungInVorlage"))
-          .andExpect(jsonPath("artDerNorm").value("ÄN,ÜN"))
-          .andExpect(jsonPath("staat").value("DDR"))
-          .andExpect(jsonPath("beschliessendesOrgan").isEmpty())
-          .andExpect(
-              jsonPath("qualifizierteMehrheit")
-                  .isEmpty()) // meaning json "qualifizierteMehrheit":null
-          .andExpect(jsonPath("organisationsEinheit").value("Andere Organisationseinheit"));
+        .perform(
+          put("/api/v1/norms/{eli}/proprietary/{date}", eli, date.toString())
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "{\"fna\": \"new-fna\"," +
+              "\"art\": \"new-art\"," + // no change
+              // no change
+              "\"typ\": \"new-typ\"," + // no change
+              "\"subtyp\": \"new-subtyp\"," + // no change
+              "\"bezeichnungInVorlage\": \"new-bezeichnungInVorlage\"," + // no change
+              "\"artDerNorm\": \"ÄN,ÜN\"," + // no change
+              "\"staat\": \"DDR\"," + // no change
+              "\"beschliessendesOrgan\": \"\"," + // this will remove the...
+              "\"qualifizierteMehrheit\": null," + // ...qualifizierteMehrheit attr
+              "\"organisationsEinheit\": \"Andere Organisationseinheit\"}"
+            )
+        ) // no
+        // change
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("fna").value("new-fna"))
+        .andExpect(jsonPath("art").value("new-art"))
+        .andExpect(jsonPath("typ").value("new-typ"))
+        .andExpect(jsonPath("subtyp").value("new-subtyp"))
+        .andExpect(jsonPath("bezeichnungInVorlage").value("new-bezeichnungInVorlage"))
+        .andExpect(jsonPath("artDerNorm").value("ÄN,ÜN"))
+        .andExpect(jsonPath("staat").value("DDR"))
+        .andExpect(jsonPath("beschliessendesOrgan").isEmpty())
+        .andExpect(jsonPath("qualifizierteMehrheit").isEmpty()) // meaning json "qualifizierteMehrheit":null
+        .andExpect(jsonPath("organisationsEinheit").value("Andere Organisationseinheit"));
 
       final Norm normLoaded = NormMapper.mapToDomain(normRepository.findByEli(eli).get());
 
@@ -371,18 +390,18 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getArt(date)).contains("new-art");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getTyp(date)).contains("new-typ");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getSubtyp(date))
-          .contains("new-subtyp");
+        .contains("new-subtyp");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getBezeichnungInVorlage(date))
-          .contains("new-bezeichnungInVorlage");
+        .contains("new-bezeichnungInVorlage");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getArtDerNorm(date))
-          .contains("ÄN,ÜN");
+        .contains("ÄN,ÜN");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getStaat(date)).contains("DDR");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getBeschliessendesOrgan(date))
-          .isEmpty();
+        .isEmpty();
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getQualifizierteMehrheit(date))
-          .isEmpty();
+        .isEmpty();
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getOrganisationsEinheit(date))
-          .contains("Andere Organisationseinheit");
+        .contains("Andere Organisationseinheit");
     }
 
     @Test
@@ -395,32 +414,34 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // when
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/proprietary/{date}", eli, date.toString())
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "{\"fna\": \"new-fna\","
-                          + "\"art\": \"new-art\","
-                          + "\"typ\": \"new-typ\","
-                          + "\"subtyp\": \"new-subtyp\","
-                          + "\"bezeichnungInVorlage\": \"new-bezeichnungInVorlage\","
-                          + "\"artDerNorm\": \"SN,ÄN,ÜN\","
-                          + "\"staat\": \"DEU\","
-                          + "\"beschliessendesOrgan\": \"Bundestag\","
-                          + "\"qualifizierteMehrheit\": true,"
-                          + "\"organisationsEinheit\": \"Organisationseinheit\"}"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("fna").value("new-fna"))
-          .andExpect(jsonPath("art").value("new-art"))
-          .andExpect(jsonPath("typ").value("new-typ"))
-          .andExpect(jsonPath("subtyp").value("new-subtyp"))
-          .andExpect(jsonPath("bezeichnungInVorlage").value("new-bezeichnungInVorlage"))
-          .andExpect(jsonPath("artDerNorm").value("SN,ÄN,ÜN"))
-          .andExpect(jsonPath("staat").value("DEU"))
-          .andExpect(jsonPath("beschliessendesOrgan").value("Bundestag"))
-          .andExpect(jsonPath("qualifizierteMehrheit").value(true))
-          .andExpect(jsonPath("organisationsEinheit").value("Organisationseinheit"));
+        .perform(
+          put("/api/v1/norms/{eli}/proprietary/{date}", eli, date.toString())
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "{\"fna\": \"new-fna\"," +
+              "\"art\": \"new-art\"," +
+              "\"typ\": \"new-typ\"," +
+              "\"subtyp\": \"new-subtyp\"," +
+              "\"bezeichnungInVorlage\": \"new-bezeichnungInVorlage\"," +
+              "\"artDerNorm\": \"SN,ÄN,ÜN\"," +
+              "\"staat\": \"DEU\"," +
+              "\"beschliessendesOrgan\": \"Bundestag\"," +
+              "\"qualifizierteMehrheit\": true," +
+              "\"organisationsEinheit\": \"Organisationseinheit\"}"
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("fna").value("new-fna"))
+        .andExpect(jsonPath("art").value("new-art"))
+        .andExpect(jsonPath("typ").value("new-typ"))
+        .andExpect(jsonPath("subtyp").value("new-subtyp"))
+        .andExpect(jsonPath("bezeichnungInVorlage").value("new-bezeichnungInVorlage"))
+        .andExpect(jsonPath("artDerNorm").value("SN,ÄN,ÜN"))
+        .andExpect(jsonPath("staat").value("DEU"))
+        .andExpect(jsonPath("beschliessendesOrgan").value("Bundestag"))
+        .andExpect(jsonPath("qualifizierteMehrheit").value(true))
+        .andExpect(jsonPath("organisationsEinheit").value("Organisationseinheit"));
 
       final Norm normLoaded = NormMapper.mapToDomain(normRepository.findByEli(eli).get());
 
@@ -428,18 +449,18 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getArt(date)).contains("new-art");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getTyp(date)).contains("new-typ");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getSubtyp(date))
-          .contains("new-subtyp");
+        .contains("new-subtyp");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getBezeichnungInVorlage(date))
-          .contains("new-bezeichnungInVorlage");
+        .contains("new-bezeichnungInVorlage");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getArtDerNorm(date))
-          .contains("SN,ÄN,ÜN");
+        .contains("SN,ÄN,ÜN");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getStaat(date)).contains("DEU");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getBeschliessendesOrgan(date))
-          .contains("Bundestag");
+        .contains("Bundestag");
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getQualifizierteMehrheit(date))
-          .contains(true);
+        .contains(true);
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getOrganisationsEinheit(date))
-          .contains("Organisationseinheit");
+        .contains("Organisationseinheit");
     }
   }
 
@@ -454,11 +475,12 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
       var atDateString = "2024-06-03";
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/" + eli + "/proprietary/" + eid + "/" + atDateString)
-                  .accept(MediaType.APPLICATION_JSON_VALUE))
-          // then
-          .andExpect(status().isNotFound());
+        .perform(
+          get("/api/v1/norms/" + eli + "/proprietary/" + eid + "/" + atDateString)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        )
+        // then
+        .andExpect(status().isNotFound());
     }
 
     @Test
@@ -472,12 +494,13 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/" + eli + "/proprietary/" + eid + "/" + atDateString)
-                  .accept(MediaType.APPLICATION_JSON_VALUE))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("artDerNorm").isEmpty());
+        .perform(
+          get("/api/v1/norms/" + eli + "/proprietary/" + eid + "/" + atDateString)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        )
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("artDerNorm").isEmpty());
     }
 
     @Test
@@ -491,12 +514,13 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/" + eli + "/proprietary/" + eid + "/" + atDateString)
-                  .accept(MediaType.APPLICATION_JSON_VALUE))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("artDerNorm").isEmpty());
+        .perform(
+          get("/api/v1/norms/" + eli + "/proprietary/" + eid + "/" + atDateString)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        )
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("artDerNorm").isEmpty());
     }
 
     @Test
@@ -510,12 +534,13 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // when
       mockMvc
-          .perform(
-              get("/api/v1/norms/" + eli + "/proprietary/" + eid + "/" + atDateString)
-                  .accept(MediaType.APPLICATION_JSON_VALUE))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("artDerNorm").value("SN"));
+        .perform(
+          get("/api/v1/norms/" + eli + "/proprietary/" + eid + "/" + atDateString)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+        )
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("artDerNorm").value("SN"));
     }
   }
 
@@ -530,13 +555,14 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
       var atDateString = "2024-06-03";
       // when
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/proprietary/{eid}/{atDateString}", eli, eid, atDateString)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content("{\"artDerNorm\": \"SN\"}"))
-          // then
-          .andExpect(status().isNotFound());
+        .perform(
+          put("/api/v1/norms/{eli}/proprietary/{eid}/{atDateString}", eli, eid, atDateString)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"artDerNorm\": \"SN\"}")
+        )
+        // then
+        .andExpect(status().isNotFound());
     }
 
     @Test
@@ -550,14 +576,15 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // when
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/proprietary/{eid}/{atDateString}", eli, eid, atDateString)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content("{\"artDerNorm\": \"SN\"}"))
-          // then
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("artDerNorm").value("SN"));
+        .perform(
+          put("/api/v1/norms/{eli}/proprietary/{eid}/{atDateString}", eli, eid, atDateString)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"artDerNorm\": \"SN\"}")
+        )
+        // then
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("artDerNorm").value("SN"));
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ReferenceControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ReferenceControllerIntegrationTest.java
@@ -17,9 +17,11 @@ import org.springframework.test.web.servlet.MockMvc;
 
 class ReferenceControllerIntegrationTest extends BaseIntegrationTest {
 
-  @Autowired private MockMvc mockMvc;
+  @Autowired
+  private MockMvc mockMvc;
 
-  @Autowired private NormRepository normRepository;
+  @Autowired
+  private NormRepository normRepository;
 
   @AfterEach
   void cleanUp() {
@@ -33,8 +35,8 @@ class ReferenceControllerIntegrationTest extends BaseIntegrationTest {
 
     // When // Then
     mockMvc
-        .perform(post("/api/v1/references/{eli}", eli).accept(MediaType.APPLICATION_XML))
-        .andExpect(status().isNotFound());
+      .perform(post("/api/v1/references/{eli}", eli).accept(MediaType.APPLICATION_XML))
+      .andExpect(status().isNotFound());
   }
 
   @Test
@@ -46,9 +48,9 @@ class ReferenceControllerIntegrationTest extends BaseIntegrationTest {
 
     // When // Then
     mockMvc
-        .perform(post("/api/v1/references/{eli}", eli).accept(MediaType.APPLICATION_XML))
-        .andExpect(status().isOk())
-        .andExpect(content().xml(XmlMapper.toString(norm.getDocument())));
+      .perform(post("/api/v1/references/{eli}", eli).accept(MediaType.APPLICATION_XML))
+      .andExpect(status().isOk())
+      .andExpect(content().xml(XmlMapper.toString(norm.getDocument())));
   }
 
   @Test
@@ -60,32 +62,40 @@ class ReferenceControllerIntegrationTest extends BaseIntegrationTest {
 
     // When // Then
     mockMvc
-        .perform(post("/api/v1/references/{eli}", eli).accept(MediaType.APPLICATION_XML))
-        .andExpect(status().isOk())
-        .andExpect(
-            xpath("//quotedStructure//heading[@eId='hauptteil-1_para-2_überschrift-1']/ref[1]/@eId")
-                .string("hauptteil-1_para-2_überschrift-1_ref-1"))
-        .andExpect(
-            xpath(
-                    "//quotedStructure//heading[@eId='hauptteil-1_para-2_überschrift-1']/ref[1]/text()")
-                .string("§ 5"))
-        .andExpect(
-            xpath("//quotedStructure//heading[@eId='hauptteil-1_para-2_überschrift-1']/ref[2]/@eId")
-                .string("hauptteil-1_para-2_überschrift-1_ref-2"))
-        .andExpect(
-            xpath(
-                    "//quotedStructure//heading[@eId='hauptteil-1_para-2_überschrift-1']/ref[2]/text()")
-                .string(
-                    "Verordnung (EG) Nr.\n"
-                        + "                                                        1035/2001"))
-        .andExpect(
-            xpath(
-                    "//quotedText[@eId='hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2']/ref/@eId")
-                .string(
-                    "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2_ref-1"))
-        .andExpect(
-            xpath(
-                    "//quotedText[@eId='hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2']/ref/text()")
-                .string("§ 9 Absatz 1 Satz 2"));
+      .perform(post("/api/v1/references/{eli}", eli).accept(MediaType.APPLICATION_XML))
+      .andExpect(status().isOk())
+      .andExpect(
+        xpath("//quotedStructure//heading[@eId='hauptteil-1_para-2_überschrift-1']/ref[1]/@eId")
+          .string("hauptteil-1_para-2_überschrift-1_ref-1")
+      )
+      .andExpect(
+        xpath("//quotedStructure//heading[@eId='hauptteil-1_para-2_überschrift-1']/ref[1]/text()")
+          .string("§ 5")
+      )
+      .andExpect(
+        xpath("//quotedStructure//heading[@eId='hauptteil-1_para-2_überschrift-1']/ref[2]/@eId")
+          .string("hauptteil-1_para-2_überschrift-1_ref-2")
+      )
+      .andExpect(
+        xpath("//quotedStructure//heading[@eId='hauptteil-1_para-2_überschrift-1']/ref[2]/text()")
+          .string(
+            "Verordnung (EG) Nr.\n" +
+            "                                                        1035/2001"
+          )
+      )
+      .andExpect(
+        xpath(
+          "//quotedText[@eId='hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2']/ref/@eId"
+        )
+          .string(
+            "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2_ref-1"
+          )
+      )
+      .andExpect(
+        xpath(
+          "//quotedText[@eId='hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-2']/ref/text()"
+        )
+          .string("§ 9 Absatz 1 Satz 2")
+      );
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/RenderingControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/RenderingControllerIntegrationTest.java
@@ -19,9 +19,11 @@ import org.springframework.test.web.servlet.MockMvc;
 
 class RenderingControllerIntegrationTest extends BaseIntegrationTest {
 
-  @Autowired private MockMvc mockMvc;
+  @Autowired
+  private MockMvc mockMvc;
 
-  @Autowired private NormRepository normRepository;
+  @Autowired
+  private NormRepository normRepository;
 
   @AfterEach
   void cleanUp() {
@@ -30,31 +32,36 @@ class RenderingControllerIntegrationTest extends BaseIntegrationTest {
 
   @Nested
   class getHtmlPreviewWithCustomNorms {
+
     @Test
     void itReturnsRender() throws Exception {
       // Given
       var jsonPayload = new JsonObject();
       jsonPayload.addProperty(
-          "norm",
-          XmlMapper.toString(
-              NormFixtures.loadFromDisk("NormWithPassiveModifications.xml").getDocument()));
+        "norm",
+        XmlMapper.toString(
+          NormFixtures.loadFromDisk("NormWithPassiveModifications.xml").getDocument()
+        )
+      );
       var customNormsJson = new JsonArray();
       customNormsJson.add(
-          XmlMapper.toString(NormFixtures.loadFromDisk("NormWithMods.xml").getDocument()));
+        XmlMapper.toString(NormFixtures.loadFromDisk("NormWithMods.xml").getDocument())
+      );
       jsonPayload.add("customNorms", customNormsJson);
 
       // When // Then
       mockMvc
-          .perform(
-              post("/api/v1/renderings?atIsoDate=2024-01-01T00:00:00.0Z")
-                  .accept(MediaType.TEXT_HTML)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(jsonPayload.toString()))
-          .andExpect(status().isOk())
-          .andExpect(
-              xpath(
-                      "//*[@data-eId='hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1']")
-                  .string(containsString("§ 9 Absatz 1 Satz 2, Absatz 2 oder 3")));
+        .perform(
+          post("/api/v1/renderings?atIsoDate=2024-01-01T00:00:00.0Z")
+            .accept(MediaType.TEXT_HTML)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(jsonPayload.toString())
+        )
+        .andExpect(status().isOk())
+        .andExpect(
+          xpath("//*[@data-eId='hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1']")
+            .string(containsString("§ 9 Absatz 1 Satz 2, Absatz 2 oder 3"))
+        );
     }
 
     @Test
@@ -62,57 +69,79 @@ class RenderingControllerIntegrationTest extends BaseIntegrationTest {
       // Given
       var jsonPayload = new JsonObject();
       jsonPayload.addProperty(
-          "norm",
-          XmlMapper.toString(
-              NormFixtures.loadFromDisk("NormWithPassiveModsQuotedStructure.xml").getDocument()));
+        "norm",
+        XmlMapper.toString(
+          NormFixtures.loadFromDisk("NormWithPassiveModsQuotedStructure.xml").getDocument()
+        )
+      );
       var customNormsJson = new JsonArray();
       customNormsJson.add(
-          XmlMapper.toString(
-              NormFixtures.loadFromDisk("NormWithQuotedStructureMods.xml").getDocument()));
+        XmlMapper.toString(
+          NormFixtures.loadFromDisk("NormWithQuotedStructureMods.xml").getDocument()
+        )
+      );
       jsonPayload.add("customNorms", customNormsJson);
 
       // When // Then
       mockMvc
-          .perform(
-              post("/api/v1/renderings?atIsoDate=1002-11-01T00:00:00.0Z")
-                  .accept(MediaType.TEXT_HTML)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(jsonPayload.toString()))
-          .andExpect(status().isOk())
-          .andExpect(
-              xpath("//*[@data-eId='einleitung-1_doktitel-1_text-1_doctitel-1']")
-                  .string(
-                      containsString(
-                          "Fiktives Beispielgesetz für das Ersetzen von Strukturen und Gliederungseinheiten mit\n"
-                              + "                  Änderungsbefehlen")))
-          .andExpect(
-              xpath("//*[@data-eId='preambel-1_ernormen-1_ernorm-1_text-1']")
-                  .string(
-                      containsString(
-                          "Aufgrund der Spezifikation von Änderungsbefehlen können Strukturen und Gliederungseinheiten\n"
-                              + "                  ersetzt werden.")))
-          .andExpect(
-              xpath("//*[@data-eId='preambel-1_präambeln-1_präambelinh-1_text-1']")
-                  .string(
-                      containsString(
-                          "Im Bewusstsein der Herausforderungen bei der Umsetzung von Änderungsbefehlen hat der\n"
-                              + "                  Deutsche Bundestag das nachstehende Gesetz beschlossen.")))
-          .andExpect(
-              xpath("//*[@data-eId='preambel-1_blockcontainer-1_inhuebs-1_eintrag-1_span-1']")
-                  .string(containsString("Neue Inhaltsübersicht.")))
-          .andExpect(
-              xpath("//*[@data-eId='hauptteil-1_para-2_abs-1_inhalt-1_text-1']")
-                  .string(
-                      containsString(
-                          "Dieses Gesetz findet Anwendung auf fast alle definierten Struktur und Gliederungsebenen.")))
-          .andExpect(
-              xpath(
-                      "//*[@data-eId='hauptteil-1_para-2_abs-3_untergl-1_listenelem-2_untergl-1_listenelem-b_inhalt-1_text-1']")
-                  .string(containsString("Zeilen,")))
-          .andExpect(
-              xpath(
-                      "//*[@data-eId='hauptteil-1_para-2_abs-3_untergl-1_listenelem-2_untergl-1_listenelem-c_inhalt-1_text-1']")
-                  .string(containsString("oder Zellen.")));
+        .perform(
+          post("/api/v1/renderings?atIsoDate=1002-11-01T00:00:00.0Z")
+            .accept(MediaType.TEXT_HTML)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(jsonPayload.toString())
+        )
+        .andExpect(status().isOk())
+        .andExpect(
+          xpath("//*[@data-eId='einleitung-1_doktitel-1_text-1_doctitel-1']")
+            .string(
+              containsString(
+                "Fiktives Beispielgesetz für das Ersetzen von Strukturen und Gliederungseinheiten mit\n" +
+                "                  Änderungsbefehlen"
+              )
+            )
+        )
+        .andExpect(
+          xpath("//*[@data-eId='preambel-1_ernormen-1_ernorm-1_text-1']")
+            .string(
+              containsString(
+                "Aufgrund der Spezifikation von Änderungsbefehlen können Strukturen und Gliederungseinheiten\n" +
+                "                  ersetzt werden."
+              )
+            )
+        )
+        .andExpect(
+          xpath("//*[@data-eId='preambel-1_präambeln-1_präambelinh-1_text-1']")
+            .string(
+              containsString(
+                "Im Bewusstsein der Herausforderungen bei der Umsetzung von Änderungsbefehlen hat der\n" +
+                "                  Deutsche Bundestag das nachstehende Gesetz beschlossen."
+              )
+            )
+        )
+        .andExpect(
+          xpath("//*[@data-eId='preambel-1_blockcontainer-1_inhuebs-1_eintrag-1_span-1']")
+            .string(containsString("Neue Inhaltsübersicht."))
+        )
+        .andExpect(
+          xpath("//*[@data-eId='hauptteil-1_para-2_abs-1_inhalt-1_text-1']")
+            .string(
+              containsString(
+                "Dieses Gesetz findet Anwendung auf fast alle definierten Struktur und Gliederungsebenen."
+              )
+            )
+        )
+        .andExpect(
+          xpath(
+            "//*[@data-eId='hauptteil-1_para-2_abs-3_untergl-1_listenelem-2_untergl-1_listenelem-b_inhalt-1_text-1']"
+          )
+            .string(containsString("Zeilen,"))
+        )
+        .andExpect(
+          xpath(
+            "//*[@data-eId='hauptteil-1_para-2_abs-3_untergl-1_listenelem-2_untergl-1_listenelem-c_inhalt-1_text-1']"
+          )
+            .string(containsString("oder Zellen."))
+        );
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/TimeBoundaryControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/TimeBoundaryControllerIntegrationTest.java
@@ -21,9 +21,11 @@ import org.springframework.test.web.servlet.MockMvc;
 
 public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
 
-  @Autowired private MockMvc mockMvc;
+  @Autowired
+  private MockMvc mockMvc;
 
-  @Autowired private NormRepository normRepository;
+  @Autowired
+  private NormRepository normRepository;
 
   @AfterEach
   void cleanUp() {
@@ -32,6 +34,7 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
 
   @Nested
   class GetTimeBoundaries {
+
     @Test
     void itCallsGetTimeBoundariesAndReturns404() throws Exception {
       // Given
@@ -39,9 +42,8 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/{eli}/timeBoundaries", eli).accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isNotFound());
+        .perform(get("/api/v1/norms/{eli}/timeBoundaries", eli).accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
     }
 
     @Test
@@ -49,43 +51,42 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
       // Given
       final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
       final String xml =
-          """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                              <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                 <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                    <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                    <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                                    <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                                    <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                                 </akn:FRBRExpression>
-                             </akn:identification>
-                               <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-01-01"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                               </akn:lifecycle>
-                               <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                           <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                              <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                           </akn:temporalGroup>
-                                           <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
-                                              <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
-                                           </akn:temporalGroup>
-                               </akn:temporalData>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """
-              .strip();
+        """
+          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+             <akn:act name="regelungstext">
+                <!-- Metadaten -->
+                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                  <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                     <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                        <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                     </akn:FRBRExpression>
+                 </akn:identification>
+                   <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-01-01"
+                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                   </akn:lifecycle>
+                   <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                               <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                                  <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                               </akn:temporalGroup>
+                               <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
+                                  <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
+                               </akn:temporalGroup>
+                   </akn:temporalData>
+                </akn:meta>
+             </akn:act>
+          </akn:akomaNtoso>
+        """.strip();
 
       // When
       var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
@@ -93,19 +94,19 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/{eli}/timeBoundaries", eli).accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$", hasSize(2)))
-          .andExpect(jsonPath("$[0].date", is("2023-12-30")))
-          .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")))
-          .andExpect(jsonPath("$[1].date", is("2024-01-01")))
-          .andExpect(jsonPath("$[1].eventRefEid", is("meta-1_lebzykl-1_ereignis-3")));
+        .perform(get("/api/v1/norms/{eli}/timeBoundaries", eli).accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(2)))
+        .andExpect(jsonPath("$[0].date", is("2023-12-30")))
+        .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")))
+        .andExpect(jsonPath("$[1].date", is("2024-01-01")))
+        .andExpect(jsonPath("$[1].eventRefEid", is("meta-1_lebzykl-1_ereignis-3")));
     }
   }
 
   @Nested
   class GetTimeBoundariesAmendedBy {
+
     @Test
     void itCallsGetTimeBoundariesAmendedByAndReturns404() throws Exception {
       // Given
@@ -114,10 +115,11 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/{eli}/timeBoundaries?amendedBy={amendedBy}", eli, amendedBy)
-                  .accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isNotFound());
+        .perform(
+          get("/api/v1/norms/{eli}/timeBoundaries?amendedBy={amendedBy}", eli, amendedBy)
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isNotFound());
     }
 
     @Test
@@ -126,79 +128,82 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
       final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
       var amendedBy = "eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/non-in-norm";
 
-      var norm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                                    <?xml version="1.0" encoding="UTF-8"?>
-                                    <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                                    <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                                                                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                                       <akn:act name="regelungstext">
-                                          <!-- Metadaten -->
-                                          <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                             <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                               <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                                  <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                                  <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                                                  <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                                                  <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                                               </akn:FRBRExpression>
-                                            </akn:identification>
-                                             <akn:analysis eId="meta-1_analysis-1" GUID="5a5d264e-431e-4dc1-b971-4bd81af8a0f4" source="attributsemantik-noch-undefiniert">
-                                                <akn:passiveModifications eId="meta-1_analysis-1_pasmod-1" GUID="77aae58f-06c9-4189-af80-a5f3ada6432c">
-                                                   <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-1" GUID="06fb52c3-fce1-4be8-accc-3035452378ff" type="substitution">
-                                                      <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-1_source-1" GUID="5384f580-110b-4f8a-8794-8b85c29aabdf" href="eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1.xml" />
-                                                      <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-1_destination-1" GUID="2c26512f-fb04-45f2-8283-660274e52fdb" href="#para-9_abs-3" />
-                                                      <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-1_gelzeitnachw-1" GUID="45331583-4386-4e3f-b68f-5af327347874" period="#meta-1_geltzeiten-1_geltungszeitgr-2" />
-                                                   </akn:textualMod>
-                                                   <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-2" GUID="26b091d0-1bb9-4c83-b940-f6788b2922f2" type="substitution">
-                                                      <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-2_source-1" GUID="a5e43d31-65e1-4d99-a1aa-fb4695a94cf5" href="eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml" />
-                                                      <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-2_destination-1" GUID="8c0418f1-b6fa-4110-8820-cf0db752c5bd" href="#para-20_abs-1/100-126" />
-                                                      <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-2_gelzeitnachw-1" GUID="e5962d3b-9bb8-4eb0-8d8f-131a5114fddb" period="#meta-1_geltzeiten-1_geltungszeitgr-3" />
-                                                   </akn:textualMod>
-                                                   <!-- Passive mod from different amending law -->
-                                                   <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-2" GUID="26b091d0-1bb9-4c83-b940-f6788b2922f2" type="substitution">
-                                                      <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-2_source-1" GUID="a5e43d31-65e1-4d99-a1aa-fb4695a94cf5" href="eli/bund/bgbl-1/2024/120/2024-06-28/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml" />
-                                                      <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-2_destination-1" GUID="8c0418f1-b6fa-4110-8820-cf0db752c5bd" href="#para-20_abs-1/100-126" />
-                                                      <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-2_gelzeitnachw-1" GUID="e5962d3b-9bb8-4eb0-8d8f-131a5114fddb" period="#meta-1_geltzeiten-1_geltungszeitgr-4" />
-                                                   </akn:textualMod>
-                                                </akn:passiveModifications>
-                                             </akn:analysis>
-                                             <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29" source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-01-01" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-4" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-02-28" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                             </akn:lifecycle>
-                                             <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                                <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                                   <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                                </akn:temporalGroup>
-                                                <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
-                                                   <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
-                                                </akn:temporalGroup>
-                                                <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-3" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
-                                                   <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4" />
-                                                </akn:temporalGroup>
-                                                <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-4" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
-                                                   <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-4_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4" />
-                                                </akn:temporalGroup>
-                                             </akn:temporalData>
-                                          </akn:meta>
-                                       </akn:act>
-                                    </akn:akomaNtoso>
-                                    """))
-              .build();
+      var norm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                                                                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+               <akn:act name="regelungstext">
+                  <!-- Metadaten -->
+                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                       <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                          <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                          <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                          <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                          <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                       </akn:FRBRExpression>
+                    </akn:identification>
+                     <akn:analysis eId="meta-1_analysis-1" GUID="5a5d264e-431e-4dc1-b971-4bd81af8a0f4" source="attributsemantik-noch-undefiniert">
+                        <akn:passiveModifications eId="meta-1_analysis-1_pasmod-1" GUID="77aae58f-06c9-4189-af80-a5f3ada6432c">
+                           <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-1" GUID="06fb52c3-fce1-4be8-accc-3035452378ff" type="substitution">
+                              <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-1_source-1" GUID="5384f580-110b-4f8a-8794-8b85c29aabdf" href="eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1.xml" />
+                              <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-1_destination-1" GUID="2c26512f-fb04-45f2-8283-660274e52fdb" href="#para-9_abs-3" />
+                              <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-1_gelzeitnachw-1" GUID="45331583-4386-4e3f-b68f-5af327347874" period="#meta-1_geltzeiten-1_geltungszeitgr-2" />
+                           </akn:textualMod>
+                           <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-2" GUID="26b091d0-1bb9-4c83-b940-f6788b2922f2" type="substitution">
+                              <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-2_source-1" GUID="a5e43d31-65e1-4d99-a1aa-fb4695a94cf5" href="eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml" />
+                              <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-2_destination-1" GUID="8c0418f1-b6fa-4110-8820-cf0db752c5bd" href="#para-20_abs-1/100-126" />
+                              <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-2_gelzeitnachw-1" GUID="e5962d3b-9bb8-4eb0-8d8f-131a5114fddb" period="#meta-1_geltzeiten-1_geltungszeitgr-3" />
+                           </akn:textualMod>
+                           <!-- Passive mod from different amending law -->
+                           <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-2" GUID="26b091d0-1bb9-4c83-b940-f6788b2922f2" type="substitution">
+                              <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-2_source-1" GUID="a5e43d31-65e1-4d99-a1aa-fb4695a94cf5" href="eli/bund/bgbl-1/2024/120/2024-06-28/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml" />
+                              <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-2_destination-1" GUID="8c0418f1-b6fa-4110-8820-cf0db752c5bd" href="#para-20_abs-1/100-126" />
+                              <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-2_gelzeitnachw-1" GUID="e5962d3b-9bb8-4eb0-8d8f-131a5114fddb" period="#meta-1_geltzeiten-1_geltungszeitgr-4" />
+                           </akn:textualMod>
+                        </akn:passiveModifications>
+                     </akn:analysis>
+                     <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                        <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29" source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                        <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                        <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-01-01" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                        <akn:eventRef eId="meta-1_lebzykl-1_ereignis-4" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-02-28" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                     </akn:lifecycle>
+                     <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                        <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                           <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                        </akn:temporalGroup>
+                        <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
+                           <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
+                        </akn:temporalGroup>
+                        <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-3" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
+                           <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4" />
+                        </akn:temporalGroup>
+                        <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-4" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
+                           <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-4_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4" />
+                        </akn:temporalGroup>
+                     </akn:temporalData>
+                  </akn:meta>
+               </akn:act>
+            </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
       normRepository.save(NormMapper.mapToDto(norm));
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/{eli}/timeBoundaries?amendedBy={amendedBy}", eli, amendedBy)
-                  .accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$", hasSize(0)));
+        .perform(
+          get("/api/v1/norms/{eli}/timeBoundaries?amendedBy={amendedBy}", eli, amendedBy)
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(0)));
     }
 
     @Test
@@ -207,126 +212,129 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
       final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
       var amendedBy = "eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/regelungstext-1";
 
-      var norm =
-          Norm.builder()
-              .document(
-                  XmlMapper.toDocument(
-                      """
-                                     <?xml version="1.0" encoding="UTF-8"?>
-                                     <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                                     <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                                                                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                                        <akn:act name="regelungstext">
-                                           <!-- Metadaten -->
-                                           <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                              <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                                <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                                   <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                                   <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                                                   <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                                                   <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                                                </akn:FRBRExpression>
-                                             </akn:identification>
-                                              <akn:analysis eId="meta-1_analysis-1" GUID="5a5d264e-431e-4dc1-b971-4bd81af8a0f4" source="attributsemantik-noch-undefiniert">
-                                                 <akn:passiveModifications eId="meta-1_analysis-1_pasmod-1" GUID="77aae58f-06c9-4189-af80-a5f3ada6432c">
-                                                    <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-1" GUID="06fb52c3-fce1-4be8-accc-3035452378ff" type="substitution">
-                                                       <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-1_source-1" GUID="5384f580-110b-4f8a-8794-8b85c29aabdf" href="eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1.xml" />
-                                                       <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-1_destination-1" GUID="2c26512f-fb04-45f2-8283-660274e52fdb" href="#para-9_abs-3" />
-                                                       <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-1_gelzeitnachw-1" GUID="45331583-4386-4e3f-b68f-5af327347874" period="#meta-1_geltzeiten-1_geltungszeitgr-2" />
-                                                    </akn:textualMod>
-                                                    <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-2" GUID="26b091d0-1bb9-4c83-b940-f6788b2922f2" type="substitution">
-                                                       <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-2_source-1" GUID="a5e43d31-65e1-4d99-a1aa-fb4695a94cf5" href="eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml" />
-                                                       <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-2_destination-1" GUID="8c0418f1-b6fa-4110-8820-cf0db752c5bd" href="#para-20_abs-1/100-126" />
-                                                       <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-2_gelzeitnachw-1" GUID="e5962d3b-9bb8-4eb0-8d8f-131a5114fddb" period="#meta-1_geltzeiten-1_geltungszeitgr-3" />
-                                                    </akn:textualMod>
-                                                    <!-- Passive mod from different amending law -->
-                                                    <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-2" GUID="26b091d0-1bb9-4c83-b940-f6788b2922f2" type="substitution">
-                                                       <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-2_source-1" GUID="a5e43d31-65e1-4d99-a1aa-fb4695a94cf5" href="eli/bund/bgbl-1/2024/120/2024-06-28/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml" />
-                                                       <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-2_destination-1" GUID="8c0418f1-b6fa-4110-8820-cf0db752c5bd" href="#para-20_abs-1/100-126" />
-                                                       <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-2_gelzeitnachw-1" GUID="e5962d3b-9bb8-4eb0-8d8f-131a5114fddb" period="#meta-1_geltzeiten-1_geltungszeitgr-4" />
-                                                    </akn:textualMod>
-                                                 </akn:passiveModifications>
-                                              </akn:analysis>
-                                              <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                                 <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29" source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                                 <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                                 <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-01-01" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                                 <akn:eventRef eId="meta-1_lebzykl-1_ereignis-4" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-02-28" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                              </akn:lifecycle>
-                                              <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                                 <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                                 </akn:temporalGroup>
-                                                 <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
-                                                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
-                                                 </akn:temporalGroup>
-                                                 <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-3" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
-                                                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4" />
-                                                 </akn:temporalGroup>
-                                                 <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-4" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
-                                                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-4_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4" />
-                                                 </akn:temporalGroup>
-                                              </akn:temporalData>
-                                           </akn:meta>
-                                        </akn:act>
-                                     </akn:akomaNtoso>
-                                     """))
-              .build();
+      var norm = Norm
+        .builder()
+        .document(
+          XmlMapper.toDocument(
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                                                                        http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+               <akn:act name="regelungstext">
+                  <!-- Metadaten -->
+                  <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                     <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                       <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                          <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                          <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                          <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                          <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                       </akn:FRBRExpression>
+                    </akn:identification>
+                     <akn:analysis eId="meta-1_analysis-1" GUID="5a5d264e-431e-4dc1-b971-4bd81af8a0f4" source="attributsemantik-noch-undefiniert">
+                        <akn:passiveModifications eId="meta-1_analysis-1_pasmod-1" GUID="77aae58f-06c9-4189-af80-a5f3ada6432c">
+                           <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-1" GUID="06fb52c3-fce1-4be8-accc-3035452378ff" type="substitution">
+                              <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-1_source-1" GUID="5384f580-110b-4f8a-8794-8b85c29aabdf" href="eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1.xml" />
+                              <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-1_destination-1" GUID="2c26512f-fb04-45f2-8283-660274e52fdb" href="#para-9_abs-3" />
+                              <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-1_gelzeitnachw-1" GUID="45331583-4386-4e3f-b68f-5af327347874" period="#meta-1_geltzeiten-1_geltungszeitgr-2" />
+                           </akn:textualMod>
+                           <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-2" GUID="26b091d0-1bb9-4c83-b940-f6788b2922f2" type="substitution">
+                              <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-2_source-1" GUID="a5e43d31-65e1-4d99-a1aa-fb4695a94cf5" href="eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml" />
+                              <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-2_destination-1" GUID="8c0418f1-b6fa-4110-8820-cf0db752c5bd" href="#para-20_abs-1/100-126" />
+                              <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-2_gelzeitnachw-1" GUID="e5962d3b-9bb8-4eb0-8d8f-131a5114fddb" period="#meta-1_geltzeiten-1_geltungszeitgr-3" />
+                           </akn:textualMod>
+                           <!-- Passive mod from different amending law -->
+                           <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-2" GUID="26b091d0-1bb9-4c83-b940-f6788b2922f2" type="substitution">
+                              <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-2_source-1" GUID="a5e43d31-65e1-4d99-a1aa-fb4695a94cf5" href="eli/bund/bgbl-1/2024/120/2024-06-28/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml" />
+                              <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-2_destination-1" GUID="8c0418f1-b6fa-4110-8820-cf0db752c5bd" href="#para-20_abs-1/100-126" />
+                              <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-2_gelzeitnachw-1" GUID="e5962d3b-9bb8-4eb0-8d8f-131a5114fddb" period="#meta-1_geltzeiten-1_geltungszeitgr-4" />
+                           </akn:textualMod>
+                        </akn:passiveModifications>
+                     </akn:analysis>
+                     <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                        <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29" source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                        <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                        <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-01-01" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                        <akn:eventRef eId="meta-1_lebzykl-1_ereignis-4" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-02-28" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                     </akn:lifecycle>
+                     <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                        <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                           <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                        </akn:temporalGroup>
+                        <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
+                           <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
+                        </akn:temporalGroup>
+                        <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-3" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
+                           <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4" />
+                        </akn:temporalGroup>
+                        <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-4" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
+                           <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-4_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4" />
+                        </akn:temporalGroup>
+                     </akn:temporalData>
+                  </akn:meta>
+               </akn:act>
+            </akn:akomaNtoso>
+            """
+          )
+        )
+        .build();
       normRepository.save(NormMapper.mapToDto(norm));
 
       // When // Then
       mockMvc
-          .perform(
-              get("/api/v1/norms/{eli}/timeBoundaries?amendedBy={amendedBy}", eli, amendedBy)
-                  .accept(MediaType.APPLICATION_JSON))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$", hasSize(2)))
-          .andExpect(jsonPath("$[0].date", is("2024-01-01")))
-          .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-3")))
-          .andExpect(jsonPath("$[0].temporalGroupEid", is("meta-1_geltzeiten-1_geltungszeitgr-2")))
-          .andExpect(jsonPath("$[1].date", is("2024-02-28")))
-          .andExpect(jsonPath("$[1].eventRefEid", is("meta-1_lebzykl-1_ereignis-4")))
-          .andExpect(jsonPath("$[1].temporalGroupEid", is("meta-1_geltzeiten-1_geltungszeitgr-3")));
+        .perform(
+          get("/api/v1/norms/{eli}/timeBoundaries?amendedBy={amendedBy}", eli, amendedBy)
+            .accept(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(2)))
+        .andExpect(jsonPath("$[0].date", is("2024-01-01")))
+        .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-3")))
+        .andExpect(jsonPath("$[0].temporalGroupEid", is("meta-1_geltzeiten-1_geltungszeitgr-2")))
+        .andExpect(jsonPath("$[1].date", is("2024-02-28")))
+        .andExpect(jsonPath("$[1].eventRefEid", is("meta-1_lebzykl-1_ereignis-4")))
+        .andExpect(jsonPath("$[1].temporalGroupEid", is("meta-1_geltzeiten-1_geltungszeitgr-3")));
     }
   }
 
   @Nested
   class UpdateTimeBoundaries {
+
     @Test
     void itCallsUpdateTimeBoundaries() throws Exception {
       final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
       final String xml =
-          """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                              <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                 <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                    <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                    <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                                    <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                                    <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                                 </akn:FRBRExpression>
-                             </akn:identification>
-                               <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                               </akn:lifecycle>
-                               <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                           <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                              <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                           </akn:temporalGroup>
-                               </akn:temporalData>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """
-              .strip();
+        """
+          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+             <akn:act name="regelungstext">
+                <!-- Metadaten -->
+                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                  <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                     <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                        <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                     </akn:FRBRExpression>
+                 </akn:identification>
+                   <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                   </akn:lifecycle>
+                   <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                               <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                                  <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                               </akn:temporalGroup>
+                   </akn:temporalData>
+                </akn:meta>
+             </akn:act>
+          </akn:akomaNtoso>
+        """.strip();
 
       // When
       var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
@@ -334,60 +342,59 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/timeBoundaries", eli)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "[{\"date\": \"2023-12-30\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-2\"},{\"date\": \"2024-01-01\", \"eventRefEid\": null}]"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$", hasSize(2)))
-
-          // still there
-          .andExpect(jsonPath("$[0].date", is("2023-12-30")))
-          .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")))
-
-          // expect new
-          .andExpect(jsonPath("$[1].date", is("2024-01-01")))
-          .andExpect(jsonPath("$[1].eventRefEid", is("meta-1_lebzykl-1_ereignis-3")));
+        .perform(
+          put("/api/v1/norms/{eli}/timeBoundaries", eli)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "[{\"date\": \"2023-12-30\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-2\"},{\"date\": \"2024-01-01\", \"eventRefEid\": null}]"
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(2)))
+        // still there
+        .andExpect(jsonPath("$[0].date", is("2023-12-30")))
+        .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")))
+        // expect new
+        .andExpect(jsonPath("$[1].date", is("2024-01-01")))
+        .andExpect(jsonPath("$[1].eventRefEid", is("meta-1_lebzykl-1_ereignis-3")));
     }
 
     @Test
     void itCallsUpdateTimeBoundariesDateNull() throws Exception {
       final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
       final String xml =
-          """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                 <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                    <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                    <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                                    <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                                    <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                                 </akn:FRBRExpression>
-                               </akn:identification>
-                               <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                               </akn:lifecycle>
-                               <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                   <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                      <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                   </akn:temporalGroup>
-                               </akn:temporalData>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """
-              .strip();
+        """
+          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+             <akn:act name="regelungstext">
+                <!-- Metadaten -->
+                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                     <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                        <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                     </akn:FRBRExpression>
+                   </akn:identification>
+                   <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                   </akn:lifecycle>
+                   <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                       <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                       </akn:temporalGroup>
+                   </akn:temporalData>
+                </akn:meta>
+             </akn:act>
+          </akn:akomaNtoso>
+        """.strip();
 
       // When
       var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
@@ -395,50 +402,50 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/timeBoundaries", eli)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content("[{\"date\": null, \"eventRefEid\": null}]"))
-          .andExpect(status().isBadRequest());
+        .perform(
+          put("/api/v1/norms/{eli}/timeBoundaries", eli)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("[{\"date\": null, \"eventRefEid\": null}]")
+        )
+        .andExpect(status().isBadRequest());
     }
 
     @Test
     void itCallsUpdateTimeBoundariesDateMalformed() throws Exception {
       final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
       final String xml =
-          """
-                      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                         <akn:act name="regelungstext">
-                            <!-- Metadaten -->
-                            <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                               <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                 <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                    <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                    <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                                    <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                                    <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                                 </akn:FRBRExpression>
-                               </akn:identification>
-                               <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                  <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                                      source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                               </akn:lifecycle>
-                               <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                   <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                      <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                   </akn:temporalGroup>
-                               </akn:temporalData>
-                            </akn:meta>
-                         </akn:act>
-                      </akn:akomaNtoso>
-                    """
-              .strip();
+        """
+          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+             <akn:act name="regelungstext">
+                <!-- Metadaten -->
+                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                     <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                        <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                     </akn:FRBRExpression>
+                   </akn:identification>
+                   <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                   </akn:lifecycle>
+                   <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                       <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                       </akn:temporalGroup>
+                   </akn:temporalData>
+                </akn:meta>
+             </akn:act>
+          </akn:akomaNtoso>
+        """.strip();
 
       // When
       var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
@@ -446,50 +453,50 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/timeBoundaries", eli)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content("[{\"date\": \"THISISNODATE\", \"eventRefEid\": null}]"))
-          .andExpect(status().isBadRequest());
+        .perform(
+          put("/api/v1/norms/{eli}/timeBoundaries", eli)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("[{\"date\": \"THISISNODATE\", \"eventRefEid\": null}]")
+        )
+        .andExpect(status().isBadRequest());
     }
 
     @Test
     void itCallsUpdateTimeBoundariesMultipleSameDates() throws Exception {
       final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
       final String xml =
-          """
-                          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                             <akn:act name="regelungstext">
-                                <!-- Metadaten -->
-                                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                  <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                     <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                                        <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                                     </akn:FRBRExpression>
-                                 </akn:identification>
-                                   <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                   </akn:lifecycle>
-                                   <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                               <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                                  <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                               </akn:temporalGroup>
-                                   </akn:temporalData>
-                                </akn:meta>
-                             </akn:act>
-                          </akn:akomaNtoso>
-                        """
-              .strip();
+        """
+          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                 http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+             <akn:act name="regelungstext">
+                <!-- Metadaten -->
+                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                  <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                     <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                        <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                     </akn:FRBRExpression>
+                 </akn:identification>
+                   <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                   </akn:lifecycle>
+                   <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                               <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                                  <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                               </akn:temporalGroup>
+                   </akn:temporalData>
+                </akn:meta>
+             </akn:act>
+          </akn:akomaNtoso>
+        """.strip();
 
       // When
       var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
@@ -497,60 +504,61 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/timeBoundaries", eli)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "["
-                          + "{\"date\": \"2023-12-30\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-2\"},"
-                          + "{\"date\": \"2024-01-01\", \"eventRefEid\": null},"
-                          + "{\"date\": \"2024-01-01\", \"eventRefEid\": null}"
-                          + "]"))
-          .andExpect(status().isBadRequest());
+        .perform(
+          put("/api/v1/norms/{eli}/timeBoundaries", eli)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "[" +
+              "{\"date\": \"2023-12-30\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-2\"}," +
+              "{\"date\": \"2024-01-01\", \"eventRefEid\": null}," +
+              "{\"date\": \"2024-01-01\", \"eventRefEid\": null}" +
+              "]"
+            )
+        )
+        .andExpect(status().isBadRequest());
     }
 
     @Test
     void itCallsUpdateTimeBoundariesDelete() throws Exception {
       final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
       final String xml =
-          """
-                <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                       http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                   <akn:act name="regelungstext">
-                      <!-- Metadaten -->
-                      <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                        <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                           <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                              <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                              <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                              <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                              <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                           </akn:FRBRExpression>
-                       </akn:identification>
-                         <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                            <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                            <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                                source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                            <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="860d4338-04a0-419f-a3d1-e7dbefd36d8b" date="2024-12-01"
-                                source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                         </akn:lifecycle>
-                         <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                             <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                             </akn:temporalGroup>
-                             <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="f49f536c-57e9-4c5e-9edd-4b827340279e">
-                                <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="63eedd45-6a2c-4213-bbc4-27596255c1b7" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
-                             </akn:temporalGroup>
-                         </akn:temporalData>
-                      </akn:meta>
-                   </akn:act>
-                </akn:akomaNtoso>
-                """
-              .strip();
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                   <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                      <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                      <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                   </akn:FRBRExpression>
+               </akn:identification>
+                 <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="860d4338-04a0-419f-a3d1-e7dbefd36d8b" date="2024-12-01"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                 </akn:lifecycle>
+                 <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                     <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                     </akn:temporalGroup>
+                     <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="f49f536c-57e9-4c5e-9edd-4b827340279e">
+                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="63eedd45-6a2c-4213-bbc4-27596255c1b7" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
+                     </akn:temporalGroup>
+                 </akn:temporalData>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+        """.strip();
 
       // When
       var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
@@ -558,56 +566,56 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/timeBoundaries", eli)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "[{\"date\": \"2023-12-30\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-2\"}]"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$", hasSize(1)))
-
-          // still there
-          .andExpect(jsonPath("$[0].date", is("2023-12-30")))
-          .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")));
+        .perform(
+          put("/api/v1/norms/{eli}/timeBoundaries", eli)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "[{\"date\": \"2023-12-30\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-2\"}]"
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(1)))
+        // still there
+        .andExpect(jsonPath("$[0].date", is("2023-12-30")))
+        .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")));
     }
 
     @Test
     void itCallsUpdateTimeBoundariesAddAndDelete() throws Exception {
       final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
       final String xml =
-          """
-                <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                       http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                   <akn:act name="regelungstext">
-                      <!-- Metadaten -->
-                      <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                        <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                           <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                              <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                              <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                              <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                              <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                           </akn:FRBRExpression>
-                       </akn:identification>
-                         <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                            <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                            <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                                source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                         </akn:lifecycle>
-                         <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                             <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                             </akn:temporalGroup>
-                         </akn:temporalData>
-                      </akn:meta>
-                   </akn:act>
-                </akn:akomaNtoso>
-                """
-              .strip();
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                   <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                      <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                      <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                   </akn:FRBRExpression>
+               </akn:identification>
+                 <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                 </akn:lifecycle>
+                 <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                     <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                     </akn:temporalGroup>
+                 </akn:temporalData>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+        """.strip();
 
       // When
       var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
@@ -615,60 +623,59 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/timeBoundaries", eli)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content("[{\"date\": \"2024-01-01\", \"eventRefEid\": null}]"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$", hasSize(1)))
-
-          // expect new
-          .andExpect(jsonPath("$[0].date", is("2024-01-01")))
-          .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")));
+        .perform(
+          put("/api/v1/norms/{eli}/timeBoundaries", eli)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("[{\"date\": \"2024-01-01\", \"eventRefEid\": null}]")
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(1)))
+        // expect new
+        .andExpect(jsonPath("$[0].date", is("2024-01-01")))
+        .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")));
     }
 
     @Test
     void itCallsUpdateTimeBoundariesAddAndDeleteWithTwo() throws Exception {
       final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
       final String xml =
-          """
-                <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                       http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                   <akn:act name="regelungstext">
-                      <!-- Metadaten -->
-                      <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                        <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                           <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                              <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                              <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                              <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                              <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                           </akn:FRBRExpression>
-                       </akn:identification>
-                         <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                            <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                                source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                            <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                                source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                            <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="860d4338-04a0-419f-a3d1-e7dbefd36d8b" date="2024-12-01"
-                                source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                         </akn:lifecycle>
-                         <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                             <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                             </akn:temporalGroup>
-                             <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="f49f536c-57e9-4c5e-9edd-4b827340279e">
-                                <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="63eedd45-6a2c-4213-bbc4-27596255c1b7" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
-                             </akn:temporalGroup>
-                         </akn:temporalData>
-                      </akn:meta>
-                   </akn:act>
-                </akn:akomaNtoso>
-                """
-              .strip();
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                   <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                      <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                      <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                   </akn:FRBRExpression>
+               </akn:identification>
+                 <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="860d4338-04a0-419f-a3d1-e7dbefd36d8b" date="2024-12-01"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                 </akn:lifecycle>
+                 <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                     <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                     </akn:temporalGroup>
+                     <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="f49f536c-57e9-4c5e-9edd-4b827340279e">
+                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="63eedd45-6a2c-4213-bbc4-27596255c1b7" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
+                     </akn:temporalGroup>
+                 </akn:temporalData>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+        """.strip();
 
       // When
       var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
@@ -676,27 +683,26 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/timeBoundaries", eli)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "[{\"date\": \"2023-12-30\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-2\"},{\"date\": \"2024-01-01\", \"eventRefEid\": null}]"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$", hasSize(2)))
-
-          // still there
-          .andExpect(jsonPath("$[0].date", is("2023-12-30")))
-          .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")))
-
-          // expect new
-          .andExpect(jsonPath("$[1].date", is("2024-01-01")))
-          .andExpect(jsonPath("$[1].eventRefEid", is("meta-1_lebzykl-1_ereignis-3")));
+        .perform(
+          put("/api/v1/norms/{eli}/timeBoundaries", eli)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "[{\"date\": \"2023-12-30\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-2\"},{\"date\": \"2024-01-01\", \"eventRefEid\": null}]"
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(2)))
+        // still there
+        .andExpect(jsonPath("$[0].date", is("2023-12-30")))
+        .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")))
+        // expect new
+        .andExpect(jsonPath("$[1].date", is("2024-01-01")))
+        .andExpect(jsonPath("$[1].eventRefEid", is("meta-1_lebzykl-1_ereignis-3")));
     }
 
     @Test
     void itCallsUpdateTimeBoundariesAddAndDeleteAndEdit() throws Exception {
-
       // the existing ones:
       // meta-1_lebzykl-1_ereignis-1: 2019-01-01 (ignored ausfertigung)
       // meta-1_lebzykl-1_ereignis-2: 2020-01-01 (nothing should change)
@@ -725,63 +731,62 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
 
       final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
       final String xml =
-          """
-                    <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                    <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                       xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                           http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                       <akn:act name="regelungstext">
-                          <!-- Metadaten -->
-                          <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                            <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                               <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                  <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                  <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                                  <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                                  <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                               </akn:FRBRExpression>
-                           </akn:identification>
-                             <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2019-01-01"
-                                    source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2020-01-01"
-                                    source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="860d4338-04a0-419f-a3d1-e7dbefd36d8b" date="2021-01-01"
-                                    source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-4" GUID="fb4a8755-3b1d-4f51-8eba-334a79928af0" date="2022-01-01"
-                                    source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-5" GUID="1c2d67f6-8cc3-4b26-b75d-fc6ae884544f" date="2023-01-01"
-                                    source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-6" GUID="c528e88a-e95e-4e14-ac4e-0b40bebb9372" date="2024-01-01"
-                                    source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-7" GUID="e2dc04db-efce-4df8-90f4-e346a9ff86f5" date="2025-01-01"
-                                    source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                             </akn:lifecycle>
-                             <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                                 <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                                 </akn:temporalGroup>
-                                 <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="f49f536c-57e9-4c5e-9edd-4b827340279e">
-                                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="63eedd45-6a2c-4213-bbc4-27596255c1b7" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
-                                 </akn:temporalGroup>
-                                 <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-3" GUID="5825f7f8-f37b-4c82-878a-765524bb8e90">
-                                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1" GUID="4c42fb23-c6a7-417b-a796-e60e2074b899" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4" />
-                                 </akn:temporalGroup>
-                                 <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-4" GUID="c64c7836-a11b-4ed7-950b-194c66c2fa7a">
-                                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-4_gelzeitintervall-1" GUID="0c88efce-9d07-441e-935d-464981634675" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-5" />
-                                 </akn:temporalGroup>
-                                 <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-5" GUID="80ff1429-f8b5-4415-894b-38e342ea889e">
-                                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-5_gelzeitintervall-1" GUID="5f3af344-137b-41a1-835f-2d939e258860" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-6" />
-                                 </akn:temporalGroup>
-                                 <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-6" GUID="81e4dc31-7279-41f8-8be0-3d5e2507a7d6">
-                                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-6_gelzeitintervall-1" GUID="5fae86fb-4e8a-458d-a3b7-66c3971e4ec2" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-7" />
-                                 </akn:temporalGroup>
-                             </akn:temporalData>
-                          </akn:meta>
-                       </akn:act>
-                    </akn:akomaNtoso>
-                    """
-              .strip();
+        """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                   <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                      <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
+                      <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
+                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+                   </akn:FRBRExpression>
+               </akn:identification>
+                 <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2019-01-01"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2020-01-01"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="860d4338-04a0-419f-a3d1-e7dbefd36d8b" date="2021-01-01"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-4" GUID="fb4a8755-3b1d-4f51-8eba-334a79928af0" date="2022-01-01"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-5" GUID="1c2d67f6-8cc3-4b26-b75d-fc6ae884544f" date="2023-01-01"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-6" GUID="c528e88a-e95e-4e14-ac4e-0b40bebb9372" date="2024-01-01"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-7" GUID="e2dc04db-efce-4df8-90f4-e346a9ff86f5" date="2025-01-01"
+                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
+                 </akn:lifecycle>
+                 <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
+                     <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
+                     </akn:temporalGroup>
+                     <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="f49f536c-57e9-4c5e-9edd-4b827340279e">
+                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="63eedd45-6a2c-4213-bbc4-27596255c1b7" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
+                     </akn:temporalGroup>
+                     <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-3" GUID="5825f7f8-f37b-4c82-878a-765524bb8e90">
+                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1" GUID="4c42fb23-c6a7-417b-a796-e60e2074b899" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4" />
+                     </akn:temporalGroup>
+                     <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-4" GUID="c64c7836-a11b-4ed7-950b-194c66c2fa7a">
+                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-4_gelzeitintervall-1" GUID="0c88efce-9d07-441e-935d-464981634675" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-5" />
+                     </akn:temporalGroup>
+                     <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-5" GUID="80ff1429-f8b5-4415-894b-38e342ea889e">
+                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-5_gelzeitintervall-1" GUID="5f3af344-137b-41a1-835f-2d939e258860" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-6" />
+                     </akn:temporalGroup>
+                     <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-6" GUID="81e4dc31-7279-41f8-8be0-3d5e2507a7d6">
+                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-6_gelzeitintervall-1" GUID="5fae86fb-4e8a-458d-a3b7-66c3971e4ec2" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-7" />
+                     </akn:temporalGroup>
+                 </akn:temporalData>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+        """.strip();
 
       // When
       var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
@@ -789,45 +794,41 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // Then
       mockMvc
-          .perform(
-              put("/api/v1/norms/{eli}/timeBoundaries", eli)
-                  .accept(MediaType.APPLICATION_JSON)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(
-                      "["
-                          + "{\"date\": \"2020-01-01\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-2\"},"
-                          + "{\"date\": \"2022-01-01\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-4\"},"
-                          + "{\"date\": \"2024-01-01\", \"eventRefEid\": null},"
-                          + "{\"date\": \"2023-06-06\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-5\"},"
-                          + "{\"date\": \"2025-01-01\", \"eventRefEid\": null},"
-                          + "{\"date\": \"2025-09-09\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-7\"}"
-                          + "]"))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$", hasSize(6)))
-
-          // still there
-          .andExpect(jsonPath("$[0].date", is("2020-01-01")))
-          .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")))
-
-          // still there
-          .andExpect(jsonPath("$[1].date", is("2022-01-01")))
-          .andExpect(jsonPath("$[1].eventRefEid", is("meta-1_lebzykl-1_ereignis-3")))
-
-          // expect new
-          .andExpect(jsonPath("$[2].date", is("2023-06-06")))
-          .andExpect(jsonPath("$[2].eventRefEid", is("meta-1_lebzykl-1_ereignis-4")))
-
-          // expect new
-          .andExpect(jsonPath("$[3].date", is("2025-09-09")))
-          .andExpect(jsonPath("$[3].eventRefEid", is("meta-1_lebzykl-1_ereignis-5")))
-
-          // expect new
-          .andExpect(jsonPath("$[4].date", is("2024-01-01")))
-          .andExpect(jsonPath("$[4].eventRefEid", is("meta-1_lebzykl-1_ereignis-6")))
-
-          // expect new
-          .andExpect(jsonPath("$[5].date", is("2025-01-01")))
-          .andExpect(jsonPath("$[5].eventRefEid", is("meta-1_lebzykl-1_ereignis-7")));
+        .perform(
+          put("/api/v1/norms/{eli}/timeBoundaries", eli)
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+              "[" +
+              "{\"date\": \"2020-01-01\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-2\"}," +
+              "{\"date\": \"2022-01-01\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-4\"}," +
+              "{\"date\": \"2024-01-01\", \"eventRefEid\": null}," +
+              "{\"date\": \"2023-06-06\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-5\"}," +
+              "{\"date\": \"2025-01-01\", \"eventRefEid\": null}," +
+              "{\"date\": \"2025-09-09\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-7\"}" +
+              "]"
+            )
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(6)))
+        // still there
+        .andExpect(jsonPath("$[0].date", is("2020-01-01")))
+        .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")))
+        // still there
+        .andExpect(jsonPath("$[1].date", is("2022-01-01")))
+        .andExpect(jsonPath("$[1].eventRefEid", is("meta-1_lebzykl-1_ereignis-3")))
+        // expect new
+        .andExpect(jsonPath("$[2].date", is("2023-06-06")))
+        .andExpect(jsonPath("$[2].eventRefEid", is("meta-1_lebzykl-1_ereignis-4")))
+        // expect new
+        .andExpect(jsonPath("$[3].date", is("2025-09-09")))
+        .andExpect(jsonPath("$[3].eventRefEid", is("meta-1_lebzykl-1_ereignis-5")))
+        // expect new
+        .andExpect(jsonPath("$[4].date", is("2024-01-01")))
+        .andExpect(jsonPath("$[4].eventRefEid", is("meta-1_lebzykl-1_ereignis-6")))
+        // expect new
+        .andExpect(jsonPath("$[5].date", is("2025-01-01")))
+        .andExpect(jsonPath("$[5].eventRefEid", is("meta-1_lebzykl-1_ereignis-7")));
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/DBServiceIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/DBServiceIntegrationTest.java
@@ -22,11 +22,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 class DBServiceIntegrationTest extends BaseIntegrationTest {
 
-  @Autowired private DBService dbService;
+  @Autowired
+  private DBService dbService;
 
-  @Autowired private AnnouncementRepository announcementRepository;
+  @Autowired
+  private AnnouncementRepository announcementRepository;
 
-  @Autowired private NormRepository normRepository;
+  @Autowired
+  private NormRepository normRepository;
 
   @AfterEach
   void cleanUp() {
@@ -38,35 +41,35 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
   void itFindsNormOnDB() {
     // Given
     final String xml =
-        """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01" />
-                          </akn:FRBRExpression>
-                      </akn:identification>
-                    </akn:meta>
-                 </akn:act>
-              </akn:akomaNtoso>
-            """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01" />
+                    </akn:FRBRExpression>
+                </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
 
     // When
     var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
     normRepository.save(NormMapper.mapToDto(norm));
 
     // When
-    final Optional<Norm> normOptional =
-        dbService.loadNorm(
-            new LoadNormPort.Command("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"));
+    final Optional<Norm> normOptional = dbService.loadNorm(
+      new LoadNormPort.Command("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+    );
 
     // Then
     assertThat(normOptional).isPresent().satisfies(normDb -> assertThat(normDb).contains(norm));
@@ -76,36 +79,35 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
   void itFindsNormByGuidOnDB() {
     // Given
     final String xml =
-        """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01" />
-                          </akn:FRBRExpression>
-                      </akn:identification>
-                    </akn:meta>
-                 </akn:act>
-              </akn:akomaNtoso>
-            """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01" />
+                    </akn:FRBRExpression>
+                </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
 
     // When
     var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
     normRepository.save(NormMapper.mapToDto(norm));
 
     // When
-    final Optional<Norm> normOptional =
-        dbService.loadNormByGuid(
-            new LoadNormByGuidPort.Command(
-                UUID.fromString("931577e5-66ba-48f5-a6eb-db40bcfd6b87")));
+    final Optional<Norm> normOptional = dbService.loadNormByGuid(
+      new LoadNormByGuidPort.Command(UUID.fromString("931577e5-66ba-48f5-a6eb-db40bcfd6b87"))
+    );
 
     // Then
     assertThat(normOptional).isPresent().contains(norm);
@@ -115,41 +117,42 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
   void itFindsAnnouncementOnDB() {
     // Given
     final String xml =
-        """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01" />
-                          </akn:FRBRExpression>
-                      </akn:identification>
-                    </akn:meta>
-                 </akn:act>
-              </akn:akomaNtoso>
-            """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01" />
+                    </akn:FRBRExpression>
+                </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
 
     // When
     var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
-    var announcement =
-        Announcement.builder()
-            .releasedByDocumentalistAt(Instant.parse("2024-01-02T10:20:30.00Z"))
-            .norm(norm)
-            .build();
+    var announcement = Announcement
+      .builder()
+      .releasedByDocumentalistAt(Instant.parse("2024-01-02T10:20:30.00Z"))
+      .norm(norm)
+      .build();
     announcementRepository.save(AnnouncementMapper.mapToDto(announcement));
 
     // When
-    final Optional<Announcement> announcementOptional =
-        dbService.loadAnnouncementByNormEli(
-            new LoadAnnouncementByNormEliPort.Command(
-                "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"));
+    final Optional<Announcement> announcementOptional = dbService.loadAnnouncementByNormEli(
+      new LoadAnnouncementByNormEliPort.Command(
+        "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"
+      )
+    );
 
     // Then
     assertThat(announcementOptional).isPresent().contains(announcement);
@@ -159,71 +162,71 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
   void itLoadsAllAnnouncementsFromDB() {
     // Given
     final String xml1 =
-        """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                            <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
-                            <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
-                            <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
-                          </akn:FRBRWork>
-                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01" />
-                          </akn:FRBRExpression>
-                      </akn:identification>
-                    </akn:meta>
-                 </akn:act>
-              </akn:akomaNtoso>
-            """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                      <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="s593" />
+                      <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                      <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="1964-08-05" name="verkuendungsfassung" />
+                    </akn:FRBRWork>
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01" />
+                    </akn:FRBRExpression>
+                </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
 
     final String xml2 =
-        """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                            <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="413" />
-                            <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
-                            <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="2023-12-29" name="verkuendungsfassung" />
-                          </akn:FRBRWork>
-                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                          </akn:FRBRExpression>
-                      </akn:identification>
-                    </akn:meta>
-                 </akn:act>
-              </akn:akomaNtoso>
-            """;
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
+                      <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="413" />
+                      <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
+                      <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="2023-12-29" name="verkuendungsfassung" />
+                    </akn:FRBRWork>
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                    </akn:FRBRExpression>
+                </akn:identification>
+              </akn:meta>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
 
     // When
-    var announcement1 =
-        Announcement.builder()
-            .releasedByDocumentalistAt(Instant.parse("2024-01-01T10:20:30.00Z"))
-            .norm(Norm.builder().document(XmlMapper.toDocument(xml1)).build())
-            .build();
+    var announcement1 = Announcement
+      .builder()
+      .releasedByDocumentalistAt(Instant.parse("2024-01-01T10:20:30.00Z"))
+      .norm(Norm.builder().document(XmlMapper.toDocument(xml1)).build())
+      .build();
     announcementRepository.save(AnnouncementMapper.mapToDto(announcement1));
-    var announcement2 =
-        Announcement.builder()
-            .releasedByDocumentalistAt(Instant.parse("2024-01-02T10:20:30.00Z"))
-            .norm(Norm.builder().document(XmlMapper.toDocument(xml2)).build())
-            .build();
+    var announcement2 = Announcement
+      .builder()
+      .releasedByDocumentalistAt(Instant.parse("2024-01-02T10:20:30.00Z"))
+      .norm(Norm.builder().document(XmlMapper.toDocument(xml2)).build())
+      .build();
     announcementRepository.save(AnnouncementMapper.mapToDto(announcement2));
 
     // When
@@ -237,78 +240,78 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
   void itUpdatesNorm() {
     // Given
     final String oldXml =
-        """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                          </akn:FRBRExpression>
-                      </akn:identification>
-                    </akn:meta>
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                    </akn:FRBRExpression>
+                </akn:identification>
+              </akn:meta>
 
-                    <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
-                       <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
-                          <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
-                             <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Verkündungsfassung</akn:docStage>
-                             <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Gesetz zum ersten Teil der
-                                Reform des Nachrichtendienstrechts</akn:docTitle>
-                          </akn:p>
-                       </akn:longTitle>
-                       <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
-                          <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="2023-12-29">Vom
-                             29.12.2023</akn:date>
-                       </akn:block>
-                    </akn:preface>
-                 </akn:act>
-              </akn:akomaNtoso>
-            """;
+              <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                 <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                    <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                       <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Verkündungsfassung</akn:docStage>
+                       <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Gesetz zum ersten Teil der
+                          Reform des Nachrichtendienstrechts</akn:docTitle>
+                    </akn:p>
+                 </akn:longTitle>
+                 <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                    <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="2023-12-29">Vom
+                       29.12.2023</akn:date>
+                 </akn:block>
+              </akn:preface>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
     var oldNorm = Norm.builder().document(XmlMapper.toDocument(oldXml)).build();
     normRepository.save(NormMapper.mapToDto(oldNorm));
 
     final String newXml =
-        """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                          </akn:FRBRExpression>
-                       </akn:identification>
-                    </akn:meta>
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                    </akn:FRBRExpression>
+                 </akn:identification>
+              </akn:meta>
 
-                    <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
-                       <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
-                          <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
-                             <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Verkündungsfassung</akn:docStage>
-                             <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Gesetz zum zweiten Teil der
-                                Reform des Nachrichtendienstrechts</akn:docTitle>
-                          </akn:p>
-                       </akn:longTitle>
-                       <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
-                          <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="2024-02-01">Vom
-                             01.02.2024</akn:date>
-                       </akn:block>
-                    </akn:preface>
-                 </akn:act>
-              </akn:akomaNtoso>
-            """;
+              <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                 <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                    <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                       <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Verkündungsfassung</akn:docStage>
+                       <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Gesetz zum zweiten Teil der
+                          Reform des Nachrichtendienstrechts</akn:docTitle>
+                    </akn:p>
+                 </akn:longTitle>
+                 <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                    <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="2024-02-01">Vom
+                       01.02.2024</akn:date>
+                 </akn:block>
+              </akn:preface>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
     var newNorm = Norm.builder().document(XmlMapper.toDocument(newXml)).build();
 
     // When
@@ -322,57 +325,58 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
   void itUpdatesAnnouncement() {
     // Given
     final String xml =
-        """
-              <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                 <akn:act name="regelungstext">
-                    <!-- Metadaten -->
-                    <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                       <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                          <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                             <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                             <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                          </akn:FRBRExpression>
-                      </akn:identification>
-                    </akn:meta>
+      """
+        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+        <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+           <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="vorgaenger-version-id" value="123577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
+                       <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
+                    </akn:FRBRExpression>
+                </akn:identification>
+              </akn:meta>
 
-                    <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
-                       <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
-                          <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
-                             <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Verkündungsfassung</akn:docStage>
-                             <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Gesetz zum ersten Teil der
-                                Reform des Nachrichtendienstrechts</akn:docTitle>
-                          </akn:p>
-                       </akn:longTitle>
-                       <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
-                          <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="2023-12-29">Vom
-                             29.12.2023</akn:date>
-                       </akn:block>
-                    </akn:preface>
-                 </akn:act>
-              </akn:akomaNtoso>
-            """;
+              <akn:preface eId="einleitung-1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+                 <akn:longTitle eId="einleitung-1_doktitel-1" GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+                    <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+                       <akn:docStage eId="einleitung-1_doktitel-1_text-1_docstadium-1" GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Verkündungsfassung</akn:docStage>
+                       <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Gesetz zum ersten Teil der
+                          Reform des Nachrichtendienstrechts</akn:docTitle>
+                    </akn:p>
+                 </akn:longTitle>
+                 <akn:block eId="einleitung-1_block-1" GUID="a0973d49-d628-42f7-a1da-b004bc980a44" name="attributsemantik-noch-undefiniert">
+                    <akn:date eId="einleitung-1_block-1_datum-1" GUID="f20d437a-3058-4747-8b8b-9b1e06c17273" refersTo="ausfertigung-datum" date="2023-12-29">Vom
+                       29.12.2023</akn:date>
+                 </akn:block>
+              </akn:preface>
+           </akn:act>
+        </akn:akomaNtoso>
+      """;
     var norm = Norm.builder().document(XmlMapper.toDocument(xml)).build();
-    var announcement =
-        Announcement.builder()
-            .norm(norm)
-            .releasedByDocumentalistAt(Instant.parse("2024-01-02T10:20:30.0Z"))
-            .build();
+    var announcement = Announcement
+      .builder()
+      .norm(norm)
+      .releasedByDocumentalistAt(Instant.parse("2024-01-02T10:20:30.0Z"))
+      .build();
     announcementRepository.save(AnnouncementMapper.mapToDto(announcement));
 
-    var newAnnouncement =
-        Announcement.builder()
-            .norm(norm)
-            .releasedByDocumentalistAt(Instant.parse("2024-02-03T10:20:30.0Z"))
-            .build();
+    var newAnnouncement = Announcement
+      .builder()
+      .norm(norm)
+      .releasedByDocumentalistAt(Instant.parse("2024-02-03T10:20:30.0Z"))
+      .build();
 
     // When
-    var announcementFromDatabase =
-        dbService.updateAnnouncement(new UpdateAnnouncementPort.Command(newAnnouncement));
+    var announcementFromDatabase = dbService.updateAnnouncement(
+      new UpdateAnnouncementPort.Command(newAnnouncement)
+    );
 
     // Then
     assertThat(announcementFromDatabase).contains(newAnnouncement);

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/utils/DocumentUtilsTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/utils/DocumentUtilsTest.java
@@ -6,11 +6,12 @@ import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 
 class DocumentUtilsTest {
+
   @Test
   void cloneDocument() {
-    Document document =
-        XmlMapper.toDocument(
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><test>applied-passive-modification</test>");
+    Document document = XmlMapper.toDocument(
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?><test>applied-passive-modification</test>"
+    );
     Document clone = DocumentUtils.cloneDocument(document);
     assertThat(clone.isEqualNode(document)).isTrue();
   }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/utils/EidConsistencyGuardianTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/utils/EidConsistencyGuardianTest.java
@@ -12,22 +12,21 @@ class EidConsistencyGuardianTest {
 
   @Test
   void itDoesNotCorrectAnything() {
-
     var sampleXml =
-        """
-                <root>
-            <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1">
-                     <akn:p eId="meta-1_text-1">
-                         <akn:ref eId="meta-1_text-1_ref-1"></akn:ref>
-                         <akn:ref eId="meta-1_text-1_ref-2"></akn:ref>
-                     </akn:p>
-                     <akn:p eId="meta-1_text-2">
-                         <akn:ref eId="meta-1_text-2_ref-1"></akn:ref>
-                         <akn:ref eId="meta-1_text-2_ref-2"></akn:ref>
-                     </akn:p>
-                  </akn:meta>
-                </root>
-                """;
+      """
+          <root>
+      <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1">
+               <akn:p eId="meta-1_text-1">
+                   <akn:ref eId="meta-1_text-1_ref-1"></akn:ref>
+                   <akn:ref eId="meta-1_text-1_ref-2"></akn:ref>
+               </akn:p>
+               <akn:p eId="meta-1_text-2">
+                   <akn:ref eId="meta-1_text-2_ref-1"></akn:ref>
+                   <akn:ref eId="meta-1_text-2_ref-2"></akn:ref>
+               </akn:p>
+            </akn:meta>
+          </root>
+          """;
 
     // When
     final Document document = XmlMapper.toDocument(sampleXml);
@@ -35,32 +34,31 @@ class EidConsistencyGuardianTest {
     EidConsistencyGuardian.correctEids(correctedDocument);
 
     // Then
-    final Diff diff =
-        DiffBuilder.compare(Input.from(correctedDocument))
-            .withTest(Input.from(document))
-            .ignoreWhitespace()
-            .build();
+    final Diff diff = DiffBuilder
+      .compare(Input.from(correctedDocument))
+      .withTest(Input.from(document))
+      .ignoreWhitespace()
+      .build();
     assertThat(diff.hasDifferences()).isFalse();
   }
 
   @Test
   void itCorrectsEidGaps() {
-
     var sampleXml =
-        """
-                <root>
-            <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1">
-                     <akn:p eId="meta-1_text-1">
-                         <akn:ref eId="meta-1_text-1_ref-1"></akn:ref>
-                         <akn:ref eId="meta-1_text-1_ref-2"></akn:ref>
-                     </akn:p>
-                     <akn:p eId="meta-1_text-3">
-                         <akn:ref eId="meta-1_text-3_ref-1"></akn:ref>
-                         <akn:ref eId="meta-1_text-3_ref-4"></akn:ref>
-                     </akn:p>
-                  </akn:meta>
-                </root>
-                """;
+      """
+          <root>
+      <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1">
+               <akn:p eId="meta-1_text-1">
+                   <akn:ref eId="meta-1_text-1_ref-1"></akn:ref>
+                   <akn:ref eId="meta-1_text-1_ref-2"></akn:ref>
+               </akn:p>
+               <akn:p eId="meta-1_text-3">
+                   <akn:ref eId="meta-1_text-3_ref-1"></akn:ref>
+                   <akn:ref eId="meta-1_text-3_ref-4"></akn:ref>
+               </akn:p>
+            </akn:meta>
+          </root>
+          """;
 
     // When
     final Document correctedDocument = XmlMapper.toDocument(sampleXml);
@@ -68,47 +66,46 @@ class EidConsistencyGuardianTest {
 
     // Then
     var expectedXml =
-        """
-                <root>
-            <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1">
-                     <akn:p eId="meta-1_text-1">
-                         <akn:ref eId="meta-1_text-1_ref-1"></akn:ref>
-                         <akn:ref eId="meta-1_text-1_ref-2"></akn:ref>
-                     </akn:p>
-                     <akn:p eId="meta-1_text-2">
-                         <akn:ref eId="meta-1_text-2_ref-1"></akn:ref>
-                         <akn:ref eId="meta-1_text-2_ref-2"></akn:ref>
-                     </akn:p>
-                  </akn:meta>
-                </root>
-                """;
+      """
+          <root>
+      <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1">
+               <akn:p eId="meta-1_text-1">
+                   <akn:ref eId="meta-1_text-1_ref-1"></akn:ref>
+                   <akn:ref eId="meta-1_text-1_ref-2"></akn:ref>
+               </akn:p>
+               <akn:p eId="meta-1_text-2">
+                   <akn:ref eId="meta-1_text-2_ref-1"></akn:ref>
+                   <akn:ref eId="meta-1_text-2_ref-2"></akn:ref>
+               </akn:p>
+            </akn:meta>
+          </root>
+          """;
 
-    final Diff diff =
-        DiffBuilder.compare(Input.from(correctedDocument))
-            .withTest(Input.from(XmlMapper.toDocument(expectedXml)))
-            .ignoreWhitespace()
-            .build();
+    final Diff diff = DiffBuilder
+      .compare(Input.from(correctedDocument))
+      .withTest(Input.from(XmlMapper.toDocument(expectedXml)))
+      .ignoreWhitespace()
+      .build();
     assertThat(diff.hasDifferences()).isFalse();
   }
 
   @Test
   void itCorrectsEidOrder() {
-
     var sampleXml =
-        """
-                    <root>
-            <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1">
-                         <akn:p eId="meta-1_text-2">
-                             <akn:ref eId="meta-1_text-2_ref-1"></akn:ref>
-                             <akn:ref eId="meta-1_text-2_ref-2"></akn:ref>
-                         </akn:p>
-                         <akn:p eId="meta-1_text-1">
-                           <akn:ref eId="meta-1_text-1_ref-1"></akn:ref>
-                           <akn:ref eId="meta-1_text-1_ref-2"></akn:ref>
-                         </akn:p>
-                      </akn:meta>
-                    </root>
-                    """;
+      """
+              <root>
+      <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1">
+                   <akn:p eId="meta-1_text-2">
+                       <akn:ref eId="meta-1_text-2_ref-1"></akn:ref>
+                       <akn:ref eId="meta-1_text-2_ref-2"></akn:ref>
+                   </akn:p>
+                   <akn:p eId="meta-1_text-1">
+                     <akn:ref eId="meta-1_text-1_ref-1"></akn:ref>
+                     <akn:ref eId="meta-1_text-1_ref-2"></akn:ref>
+                   </akn:p>
+                </akn:meta>
+              </root>
+              """;
 
     // When
     final Document correctedDocument = XmlMapper.toDocument(sampleXml);
@@ -116,44 +113,43 @@ class EidConsistencyGuardianTest {
 
     // Then
     var expectedXml =
-        """
-                    <root>
-            <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1">
-                         <akn:p eId="meta-1_text-1">
-                             <akn:ref eId="meta-1_text-1_ref-1"></akn:ref>
-                             <akn:ref eId="meta-1_text-1_ref-2"></akn:ref>
-                         </akn:p>
-                         <akn:p eId="meta-1_text-2">
-                             <akn:ref eId="meta-1_text-2_ref-1"></akn:ref>
-                             <akn:ref eId="meta-1_text-2_ref-2"></akn:ref>
-                         </akn:p>
-                      </akn:meta>
-                    </root>
-                    """;
+      """
+              <root>
+      <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1">
+                   <akn:p eId="meta-1_text-1">
+                       <akn:ref eId="meta-1_text-1_ref-1"></akn:ref>
+                       <akn:ref eId="meta-1_text-1_ref-2"></akn:ref>
+                   </akn:p>
+                   <akn:p eId="meta-1_text-2">
+                       <akn:ref eId="meta-1_text-2_ref-1"></akn:ref>
+                       <akn:ref eId="meta-1_text-2_ref-2"></akn:ref>
+                   </akn:p>
+                </akn:meta>
+              </root>
+              """;
 
-    final Diff diff =
-        DiffBuilder.compare(Input.from(correctedDocument))
-            .withTest(Input.from(XmlMapper.toDocument(expectedXml)))
-            .ignoreWhitespace()
-            .build();
+    final Diff diff = DiffBuilder
+      .compare(Input.from(correctedDocument))
+      .withTest(Input.from(XmlMapper.toDocument(expectedXml)))
+      .ignoreWhitespace()
+      .build();
 
     assertThat(diff.hasDifferences()).isFalse();
   }
 
   @Test
   void itCorrectsEidTypes() {
-
     var sampleXml =
-        """
-                    <root>
-            <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1">
-                         <akn:p eId="meta-1_text-1">
-                             <akn:ref eId="meta-1_text-1_text-1"></akn:ref>
-                             <akn:ref eId="meta-1_text-1_text-2"></akn:ref>
-                         </akn:p>
-                      </akn:meta>
-                    </root>
-                    """;
+      """
+              <root>
+      <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1">
+                   <akn:p eId="meta-1_text-1">
+                       <akn:ref eId="meta-1_text-1_text-1"></akn:ref>
+                       <akn:ref eId="meta-1_text-1_text-2"></akn:ref>
+                   </akn:p>
+                </akn:meta>
+              </root>
+              """;
 
     // When
     final Document correctedDocument = XmlMapper.toDocument(sampleXml);
@@ -161,40 +157,39 @@ class EidConsistencyGuardianTest {
 
     // Then
     var expectedXml =
-        """
-                    <root>
-            <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1">
-                         <akn:p eId="meta-1_text-1">
-                             <akn:ref eId="meta-1_text-1_ref-1"></akn:ref>
-                             <akn:ref eId="meta-1_text-1_ref-2"></akn:ref>
-                         </akn:p>
-                      </akn:meta>
-                    </root>
-                    """;
+      """
+              <root>
+      <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1">
+                   <akn:p eId="meta-1_text-1">
+                       <akn:ref eId="meta-1_text-1_ref-1"></akn:ref>
+                       <akn:ref eId="meta-1_text-1_ref-2"></akn:ref>
+                   </akn:p>
+                </akn:meta>
+              </root>
+              """;
 
-    final Diff diff =
-        DiffBuilder.compare(Input.from(correctedDocument))
-            .withTest(Input.from(XmlMapper.toDocument(expectedXml)))
-            .ignoreWhitespace()
-            .build();
+    final Diff diff = DiffBuilder
+      .compare(Input.from(correctedDocument))
+      .withTest(Input.from(XmlMapper.toDocument(expectedXml)))
+      .ignoreWhitespace()
+      .build();
 
     assertThat(diff.hasDifferences()).isFalse();
   }
 
   @Test
   void itCorrectsMissingEids() {
-
     var sampleXml =
-        """
-                    <root>
-            <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1">
-                         <akn:p>
-                             <akn:ref></akn:ref>
-                             <akn:ref></akn:ref>
-                         </akn:p>
-                      </akn:meta>
-                    </root>
-                    """;
+      """
+              <root>
+      <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1">
+                   <akn:p>
+                       <akn:ref></akn:ref>
+                       <akn:ref></akn:ref>
+                   </akn:p>
+                </akn:meta>
+              </root>
+              """;
 
     // When
     final Document correctedDocument = XmlMapper.toDocument(sampleXml);
@@ -202,22 +197,22 @@ class EidConsistencyGuardianTest {
 
     // Then
     var expectedXml =
-        """
-                    <root>
-            <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1">
-                         <akn:p eId="meta-1_text-1">
-                             <akn:ref eId="meta-1_text-1_ref-1"></akn:ref>
-                             <akn:ref eId="meta-1_text-1_ref-2"></akn:ref>
-                         </akn:p>
-                      </akn:meta>
-                    </root>
-                    """;
+      """
+              <root>
+      <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1">
+                   <akn:p eId="meta-1_text-1">
+                       <akn:ref eId="meta-1_text-1_ref-1"></akn:ref>
+                       <akn:ref eId="meta-1_text-1_ref-2"></akn:ref>
+                   </akn:p>
+                </akn:meta>
+              </root>
+              """;
 
-    final Diff diff =
-        DiffBuilder.compare(Input.from(correctedDocument))
-            .withTest(Input.from(XmlMapper.toDocument(expectedXml)))
-            .ignoreWhitespace()
-            .build();
+    final Diff diff = DiffBuilder
+      .compare(Input.from(correctedDocument))
+      .withTest(Input.from(XmlMapper.toDocument(expectedXml)))
+      .ignoreWhitespace()
+      .build();
 
     assertThat(diff.hasDifferences()).isFalse();
   }
@@ -226,58 +221,58 @@ class EidConsistencyGuardianTest {
   void itCorrectComplexLDML() {
     // Given
     var text =
-        """
-                <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                                                         http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                    <akn:act name="regelungstext">
-                        <!-- Metadaten -->
-                        <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                            <akn:lifecycle eId="meta-1_lebzykl-1" GUID="a1ce9b04-8071-43c2-be56-10e7049ab500" source="attributsemantik-noch-undefiniert">
-                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="e3ac3efd-b9fc-4e84-b494-f28937a89855" date="1964-08-05" source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung"/>
-                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="7174df87-6418-4d47-ac4e-5fb87c2caa50" date="1964-09-21" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten"/>
-                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="c271d75e-bd26-4f5a-8544-0eea1c410fbf" date="2017-03-15" source="attributsemantik-noch-undefiniert" type="amendment" refersTo="ausfertigung"/>
-                                <!-- ereignis-4 removed -->
-                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-5" GUID="d0acc7c7-3c5e-44fa-bcb7-0fe2788876ea" date="2019-03-03" source="attributsemantik-noch-undefiniert" type="repeal" refersTo="ausserkrafttreten"/>
-                                <akn:eventRef eId="meta-1_lebzykl-1_ereignis-6" GUID="a20f1fcc-fd43-403d-ab8f-8d950fafa633" date="1964-09-01" source="attributsemantik-noch-undefiniert" type="amendment" refersTo="inkrafttreten"/>
-                            </akn:lifecycle>
-                            <akn:temporalData eId="meta-1_geltzeiten-1" GUID="33875608-d668-4be0-a830-8ec5d0a421c8" source="attributsemantik-noch-undefiniert">
-                                <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="1a5d8eba-b899-4152-852d-91a7df39e3d9">
-                                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="6fc42c43-6598-4c95-ac57-da132b047ec1" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2"/>
-                                </akn:temporalGroup>
-                                <!-- ereignis-4 removed -->
-                                <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-3" GUID="08308b59-4541-4643-8d55-f7950e515553">
-                                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1" GUID="b382ce1b-7b4f-4bb6-a878-7a37c11c3854" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-5"/>
-                                </akn:temporalGroup>
-                                <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-4" GUID="b4392765-b70b-4d6a-be2d-6e971acb6c8a">
-                                    <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-4_gelzeitintervall-1" GUID="c7b1d9de-a146-4748-8e60-c2e08beab5d7" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-6"/>
-                                </akn:temporalGroup>
-                            </akn:temporalData>
-                            <akn:analysis eId="meta-1_analysis-1" GUID="5a5d264e-431e-4dc1-b971-4bd81af8a0f4" source="attributsemantik-noch-undefiniert">
-                                <akn:passiveModifications eId="meta-1_analysis-1_pasmod-1" GUID="77aae58f-06c9-4189-af80-a5f3ada6432c">
-                                    <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-1" GUID="06fb52c3-fce1-4be8-accc-3035452378ff" type="substitution">
-                                        <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-1_source-1" GUID="5384f580-110b-4f8a-8794-8b85c29aabdf" href="eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1.xml"/>
-                                        <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-1_destination-1" GUID="2c26512f-fb04-45f2-8283-660274e52fdb" href="#para-9_abs-3"/>
-                                        <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-1_gelzeitnachw-1" GUID="45331583-4386-4e3f-b68f-5af327347874" period="#meta-1_geltzeiten-1_geltungszeitgr-2"/>
-                                    </akn:textualMod>
-                                    <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-2" GUID="26b091d0-1bb9-4c83-b940-f6788b2922f2" type="substitution">
-                                        <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-2_source-1" GUID="a5e43d31-65e1-4d99-a1aa-fb4695a94cf5" href="eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"/>
-                                        <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-2_destination-1" GUID="8c0418f1-b6fa-4110-8820-cf0db752c5bd" href="#para-20_abs-1/100-126"/>
-                                        <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-2_gelzeitnachw-1" GUID="e5962d3b-9bb8-4eb0-8d8f-131a5114fddb" period="#meta-1_geltzeiten-1_geltungszeitgr-3"/>
-                                    </akn:textualMod>
-                                </akn:passiveModifications>
-                            </akn:analysis>
-                                                                    <akn:proprietary source="attributsemantik-noch-undefiniert" eId="meta-1_proprietary-2" GUID="d03c4c44-85ae-4f95-9d3e-063d9feba23f">
-                                            <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                                <meta:celex start="non-existing-id-1">celex number</meta:celex>
-                                                <meta:subtyp start="non-existing-id-2">SN</meta:subtyp>
-                                                <meta:aktenzeichen start="meta-1_lebzykl-1_ereignis-2">123456</meta:aktenzeichen>
-                                            </meta:legalDocML.de_metadaten_ds>
-                                        </akn:proprietary>
-                        </akn:meta>
-                    </akn:act>
-                </akn:akomaNtoso>
-                """;
+      """
+      <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                                                               http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+          <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                  <akn:lifecycle eId="meta-1_lebzykl-1" GUID="a1ce9b04-8071-43c2-be56-10e7049ab500" source="attributsemantik-noch-undefiniert">
+                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="e3ac3efd-b9fc-4e84-b494-f28937a89855" date="1964-08-05" source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung"/>
+                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="7174df87-6418-4d47-ac4e-5fb87c2caa50" date="1964-09-21" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten"/>
+                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="c271d75e-bd26-4f5a-8544-0eea1c410fbf" date="2017-03-15" source="attributsemantik-noch-undefiniert" type="amendment" refersTo="ausfertigung"/>
+                      <!-- ereignis-4 removed -->
+                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-5" GUID="d0acc7c7-3c5e-44fa-bcb7-0fe2788876ea" date="2019-03-03" source="attributsemantik-noch-undefiniert" type="repeal" refersTo="ausserkrafttreten"/>
+                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-6" GUID="a20f1fcc-fd43-403d-ab8f-8d950fafa633" date="1964-09-01" source="attributsemantik-noch-undefiniert" type="amendment" refersTo="inkrafttreten"/>
+                  </akn:lifecycle>
+                  <akn:temporalData eId="meta-1_geltzeiten-1" GUID="33875608-d668-4be0-a830-8ec5d0a421c8" source="attributsemantik-noch-undefiniert">
+                      <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="1a5d8eba-b899-4152-852d-91a7df39e3d9">
+                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="6fc42c43-6598-4c95-ac57-da132b047ec1" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2"/>
+                      </akn:temporalGroup>
+                      <!-- ereignis-4 removed -->
+                      <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-3" GUID="08308b59-4541-4643-8d55-f7950e515553">
+                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1" GUID="b382ce1b-7b4f-4bb6-a878-7a37c11c3854" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-5"/>
+                      </akn:temporalGroup>
+                      <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-4" GUID="b4392765-b70b-4d6a-be2d-6e971acb6c8a">
+                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-4_gelzeitintervall-1" GUID="c7b1d9de-a146-4748-8e60-c2e08beab5d7" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-6"/>
+                      </akn:temporalGroup>
+                  </akn:temporalData>
+                  <akn:analysis eId="meta-1_analysis-1" GUID="5a5d264e-431e-4dc1-b971-4bd81af8a0f4" source="attributsemantik-noch-undefiniert">
+                      <akn:passiveModifications eId="meta-1_analysis-1_pasmod-1" GUID="77aae58f-06c9-4189-af80-a5f3ada6432c">
+                          <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-1" GUID="06fb52c3-fce1-4be8-accc-3035452378ff" type="substitution">
+                              <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-1_source-1" GUID="5384f580-110b-4f8a-8794-8b85c29aabdf" href="eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1.xml"/>
+                              <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-1_destination-1" GUID="2c26512f-fb04-45f2-8283-660274e52fdb" href="#para-9_abs-3"/>
+                              <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-1_gelzeitnachw-1" GUID="45331583-4386-4e3f-b68f-5af327347874" period="#meta-1_geltzeiten-1_geltungszeitgr-2"/>
+                          </akn:textualMod>
+                          <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-2" GUID="26b091d0-1bb9-4c83-b940-f6788b2922f2" type="substitution">
+                              <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-2_source-1" GUID="a5e43d31-65e1-4d99-a1aa-fb4695a94cf5" href="eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"/>
+                              <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-2_destination-1" GUID="8c0418f1-b6fa-4110-8820-cf0db752c5bd" href="#para-20_abs-1/100-126"/>
+                              <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-2_gelzeitnachw-1" GUID="e5962d3b-9bb8-4eb0-8d8f-131a5114fddb" period="#meta-1_geltzeiten-1_geltungszeitgr-3"/>
+                          </akn:textualMod>
+                      </akn:passiveModifications>
+                  </akn:analysis>
+                                                          <akn:proprietary source="attributsemantik-noch-undefiniert" eId="meta-1_proprietary-2" GUID="d03c4c44-85ae-4f95-9d3e-063d9feba23f">
+                                  <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                                      <meta:celex start="non-existing-id-1">celex number</meta:celex>
+                                      <meta:subtyp start="non-existing-id-2">SN</meta:subtyp>
+                                      <meta:aktenzeichen start="meta-1_lebzykl-1_ereignis-2">123456</meta:aktenzeichen>
+                                  </meta:legalDocML.de_metadaten_ds>
+                              </akn:proprietary>
+              </akn:meta>
+          </akn:act>
+      </akn:akomaNtoso>
+      """;
 
     // When
     final Document correctedDocument = XmlMapper.toDocument(text);
@@ -286,62 +281,62 @@ class EidConsistencyGuardianTest {
 
     // Then
     var exectedResult =
-        """
-                <?xml version="1.0" encoding="UTF-8"?><?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                                                                          http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                    <akn:act name="regelungstext">
-                        <!-- Metadaten -->
-                        <akn:meta GUID="82a65581-0ea7-4525-9190-35ff86c977af" eId="meta-1">
-                            <akn:lifecycle GUID="a1ce9b04-8071-43c2-be56-10e7049ab500" eId="meta-1_lebzykl-1" source="attributsemantik-noch-undefiniert">
-                                <akn:eventRef GUID="e3ac3efd-b9fc-4e84-b494-f28937a89855" date="1964-08-05" eId="meta-1_lebzykl-1_ereignis-1" refersTo="ausfertigung" source="attributsemantik-noch-undefiniert" type="generation"/>
-                                <akn:eventRef GUID="7174df87-6418-4d47-ac4e-5fb87c2caa50" date="1964-09-21" eId="meta-1_lebzykl-1_ereignis-2" refersTo="inkrafttreten" source="attributsemantik-noch-undefiniert" type="generation"/>
-                                <akn:eventRef GUID="c271d75e-bd26-4f5a-8544-0eea1c410fbf" date="2017-03-15" eId="meta-1_lebzykl-1_ereignis-3" refersTo="ausfertigung" source="attributsemantik-noch-undefiniert" type="amendment"/>
-                                <!-- ereignis-4 removed -->
-                                <akn:eventRef GUID="d0acc7c7-3c5e-44fa-bcb7-0fe2788876ea" date="2019-03-03" eId="meta-1_lebzykl-1_ereignis-4" refersTo="ausserkrafttreten" source="attributsemantik-noch-undefiniert" type="repeal"/>
-                                <akn:eventRef GUID="a20f1fcc-fd43-403d-ab8f-8d950fafa633" date="1964-09-01" eId="meta-1_lebzykl-1_ereignis-5" refersTo="inkrafttreten" source="attributsemantik-noch-undefiniert" type="amendment"/>
-                            </akn:lifecycle>
-                            <akn:temporalData GUID="33875608-d668-4be0-a830-8ec5d0a421c8" eId="meta-1_geltzeiten-1" source="attributsemantik-noch-undefiniert">
-                                <akn:temporalGroup GUID="1a5d8eba-b899-4152-852d-91a7df39e3d9" eId="meta-1_geltzeiten-1_geltungszeitgr-1">
-                                    <akn:timeInterval GUID="6fc42c43-6598-4c95-ac57-da132b047ec1" eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2"/>
-                                </akn:temporalGroup>
-                                <!-- ereignis-4 removed -->
-                                <akn:temporalGroup GUID="08308b59-4541-4643-8d55-f7950e515553" eId="meta-1_geltzeiten-1_geltungszeitgr-2">
-                                    <akn:timeInterval GUID="b382ce1b-7b4f-4bb6-a878-7a37c11c3854" eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4"/>
-                                </akn:temporalGroup>
-                                <akn:temporalGroup GUID="b4392765-b70b-4d6a-be2d-6e971acb6c8a" eId="meta-1_geltzeiten-1_geltungszeitgr-3">
-                                    <akn:timeInterval GUID="c7b1d9de-a146-4748-8e60-c2e08beab5d7" eId="meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-5"/>
-                                </akn:temporalGroup>
-                            </akn:temporalData>
-                            <akn:analysis GUID="5a5d264e-431e-4dc1-b971-4bd81af8a0f4" eId="meta-1_analysis-1" source="attributsemantik-noch-undefiniert">
-                                <akn:passiveModifications GUID="77aae58f-06c9-4189-af80-a5f3ada6432c" eId="meta-1_analysis-1_pasmod-1">
-                                    <akn:textualMod GUID="06fb52c3-fce1-4be8-accc-3035452378ff" eId="meta-1_analysis-1_pasmod-1_textualmod-1" type="substitution">
-                                        <akn:source GUID="5384f580-110b-4f8a-8794-8b85c29aabdf" eId="meta-1_analysis-1_pasmod-1_textualmod-1_source-1" href="eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1.xml"/>
-                                        <akn:destination GUID="2c26512f-fb04-45f2-8283-660274e52fdb" eId="meta-1_analysis-1_pasmod-1_textualmod-1_destination-1" href="#para-9_abs-3"/>
-                                        <akn:force GUID="45331583-4386-4e3f-b68f-5af327347874" eId="meta-1_analysis-1_pasmod-1_textualmod-1_gelzeitnachw-1" period=""/>
-                                    </akn:textualMod>
-                                    <akn:textualMod GUID="26b091d0-1bb9-4c83-b940-f6788b2922f2" eId="meta-1_analysis-1_pasmod-1_textualmod-2" type="substitution">
-                                        <akn:source GUID="a5e43d31-65e1-4d99-a1aa-fb4695a94cf5" eId="meta-1_analysis-1_pasmod-1_textualmod-2_source-1" href="eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"/>
-                                        <akn:destination GUID="8c0418f1-b6fa-4110-8820-cf0db752c5bd" eId="meta-1_analysis-1_pasmod-1_textualmod-2_destination-1" href="#para-20_abs-1/100-126"/>
-                                        <akn:force GUID="e5962d3b-9bb8-4eb0-8d8f-131a5114fddb" eId="meta-1_analysis-1_pasmod-1_textualmod-2_gelzeitnachw-1" period="#meta-1_geltzeiten-1_geltungszeitgr-2"/>
-                                    </akn:textualMod>
-                                </akn:passiveModifications>
-                            </akn:analysis>
-                                        <akn:proprietary source="attributsemantik-noch-undefiniert" eId="meta-1_proprietary-1" GUID="d03c4c44-85ae-4f95-9d3e-063d9feba23f">
-                                            <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
-                                                <meta:celex start="">celex number</meta:celex>
-                                                <meta:subtyp start="">SN</meta:subtyp>
-                                                <meta:aktenzeichen start="meta-1_lebzykl-1_ereignis-2">123456</meta:aktenzeichen>
-                                            </meta:legalDocML.de_metadaten_ds>
-                                        </akn:proprietary>
-                        </akn:meta>
-                    </akn:act>
-                </akn:akomaNtoso>
-                """;
-    final Diff diff =
-        DiffBuilder.compare(Input.from(correctedDocument))
-            .withTest(Input.from(XmlMapper.toDocument(exectedResult)))
-            .ignoreWhitespace()
-            .build();
+      """
+      <?xml version="1.0" encoding="UTF-8"?><?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                                                                          http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+          <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta GUID="82a65581-0ea7-4525-9190-35ff86c977af" eId="meta-1">
+                  <akn:lifecycle GUID="a1ce9b04-8071-43c2-be56-10e7049ab500" eId="meta-1_lebzykl-1" source="attributsemantik-noch-undefiniert">
+                      <akn:eventRef GUID="e3ac3efd-b9fc-4e84-b494-f28937a89855" date="1964-08-05" eId="meta-1_lebzykl-1_ereignis-1" refersTo="ausfertigung" source="attributsemantik-noch-undefiniert" type="generation"/>
+                      <akn:eventRef GUID="7174df87-6418-4d47-ac4e-5fb87c2caa50" date="1964-09-21" eId="meta-1_lebzykl-1_ereignis-2" refersTo="inkrafttreten" source="attributsemantik-noch-undefiniert" type="generation"/>
+                      <akn:eventRef GUID="c271d75e-bd26-4f5a-8544-0eea1c410fbf" date="2017-03-15" eId="meta-1_lebzykl-1_ereignis-3" refersTo="ausfertigung" source="attributsemantik-noch-undefiniert" type="amendment"/>
+                      <!-- ereignis-4 removed -->
+                      <akn:eventRef GUID="d0acc7c7-3c5e-44fa-bcb7-0fe2788876ea" date="2019-03-03" eId="meta-1_lebzykl-1_ereignis-4" refersTo="ausserkrafttreten" source="attributsemantik-noch-undefiniert" type="repeal"/>
+                      <akn:eventRef GUID="a20f1fcc-fd43-403d-ab8f-8d950fafa633" date="1964-09-01" eId="meta-1_lebzykl-1_ereignis-5" refersTo="inkrafttreten" source="attributsemantik-noch-undefiniert" type="amendment"/>
+                  </akn:lifecycle>
+                  <akn:temporalData GUID="33875608-d668-4be0-a830-8ec5d0a421c8" eId="meta-1_geltzeiten-1" source="attributsemantik-noch-undefiniert">
+                      <akn:temporalGroup GUID="1a5d8eba-b899-4152-852d-91a7df39e3d9" eId="meta-1_geltzeiten-1_geltungszeitgr-1">
+                          <akn:timeInterval GUID="6fc42c43-6598-4c95-ac57-da132b047ec1" eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2"/>
+                      </akn:temporalGroup>
+                      <!-- ereignis-4 removed -->
+                      <akn:temporalGroup GUID="08308b59-4541-4643-8d55-f7950e515553" eId="meta-1_geltzeiten-1_geltungszeitgr-2">
+                          <akn:timeInterval GUID="b382ce1b-7b4f-4bb6-a878-7a37c11c3854" eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4"/>
+                      </akn:temporalGroup>
+                      <akn:temporalGroup GUID="b4392765-b70b-4d6a-be2d-6e971acb6c8a" eId="meta-1_geltzeiten-1_geltungszeitgr-3">
+                          <akn:timeInterval GUID="c7b1d9de-a146-4748-8e60-c2e08beab5d7" eId="meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-5"/>
+                      </akn:temporalGroup>
+                  </akn:temporalData>
+                  <akn:analysis GUID="5a5d264e-431e-4dc1-b971-4bd81af8a0f4" eId="meta-1_analysis-1" source="attributsemantik-noch-undefiniert">
+                      <akn:passiveModifications GUID="77aae58f-06c9-4189-af80-a5f3ada6432c" eId="meta-1_analysis-1_pasmod-1">
+                          <akn:textualMod GUID="06fb52c3-fce1-4be8-accc-3035452378ff" eId="meta-1_analysis-1_pasmod-1_textualmod-1" type="substitution">
+                              <akn:source GUID="5384f580-110b-4f8a-8794-8b85c29aabdf" eId="meta-1_analysis-1_pasmod-1_textualmod-1_source-1" href="eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1.xml"/>
+                              <akn:destination GUID="2c26512f-fb04-45f2-8283-660274e52fdb" eId="meta-1_analysis-1_pasmod-1_textualmod-1_destination-1" href="#para-9_abs-3"/>
+                              <akn:force GUID="45331583-4386-4e3f-b68f-5af327347874" eId="meta-1_analysis-1_pasmod-1_textualmod-1_gelzeitnachw-1" period=""/>
+                          </akn:textualMod>
+                          <akn:textualMod GUID="26b091d0-1bb9-4c83-b940-f6788b2922f2" eId="meta-1_analysis-1_pasmod-1_textualmod-2" type="substitution">
+                              <akn:source GUID="a5e43d31-65e1-4d99-a1aa-fb4695a94cf5" eId="meta-1_analysis-1_pasmod-1_textualmod-2_source-1" href="eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml"/>
+                              <akn:destination GUID="8c0418f1-b6fa-4110-8820-cf0db752c5bd" eId="meta-1_analysis-1_pasmod-1_textualmod-2_destination-1" href="#para-20_abs-1/100-126"/>
+                              <akn:force GUID="e5962d3b-9bb8-4eb0-8d8f-131a5114fddb" eId="meta-1_analysis-1_pasmod-1_textualmod-2_gelzeitnachw-1" period="#meta-1_geltzeiten-1_geltungszeitgr-2"/>
+                          </akn:textualMod>
+                      </akn:passiveModifications>
+                  </akn:analysis>
+                              <akn:proprietary source="attributsemantik-noch-undefiniert" eId="meta-1_proprietary-1" GUID="d03c4c44-85ae-4f95-9d3e-063d9feba23f">
+                                  <meta:legalDocML.de_metadaten_ds xmlns:meta="http://DS.Metadaten.LegalDocML.de/1.6/">
+                                      <meta:celex start="">celex number</meta:celex>
+                                      <meta:subtyp start="">SN</meta:subtyp>
+                                      <meta:aktenzeichen start="meta-1_lebzykl-1_ereignis-2">123456</meta:aktenzeichen>
+                                  </meta:legalDocML.de_metadaten_ds>
+                              </akn:proprietary>
+              </akn:meta>
+          </akn:act>
+      </akn:akomaNtoso>
+      """;
+    final Diff diff = DiffBuilder
+      .compare(Input.from(correctedDocument))
+      .withTest(Input.from(XmlMapper.toDocument(exectedResult)))
+      .ignoreWhitespace()
+      .build();
     assertThat(diff.hasDifferences()).isFalse();
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/utils/NodeCreatorTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/utils/NodeCreatorTest.java
@@ -13,32 +13,34 @@ class NodeCreatorTest {
   @Test
   void createElement() {
     // given
-    final Document document =
-        XmlMapper.toDocument(
-            """
-                                                          <root>
-                                                              <test>test value</test>
-                                                          </root>""");
+    final Document document = XmlMapper.toDocument(
+      """
+      <root>
+          <test>test value</test>
+      </root>"""
+    );
     final Node testNode = NodeParser.getMandatoryNodeFromExpression("//test", document);
 
     // when
     final Element newElement = NodeCreator.createElement("childTest", testNode);
 
     // Then
-    final Node childTestNode =
-        NodeParser.getMandatoryNodeFromExpression("//test/childTest", document);
+    final Node childTestNode = NodeParser.getMandatoryNodeFromExpression(
+      "//test/childTest",
+      document
+    );
     assertThat(childTestNode).isEqualTo(newElement);
   }
 
   @Test
   void createElementWithEidAndGuid() {
     // given
-    final Document document =
-        XmlMapper.toDocument(
-            """
-                                                          <root>
-                    <akn:p eId="text-1">test value</akn:p>
-                                                          </root>""");
+    final Document document = XmlMapper.toDocument(
+      """
+                                            <root>
+      <akn:p eId="text-1">test value</akn:p>
+                                            </root>"""
+    );
     final Node testNode = NodeParser.getMandatoryNodeFromExpression("//*/p", document);
 
     // when
@@ -49,31 +51,35 @@ class NodeCreatorTest {
     assertThat(childTestNode).isEqualTo(newElement);
     assertThat(childTestNode.getAttributes().getNamedItem("GUID")).isNotNull();
     assertThat(childTestNode.getAttributes().getNamedItem("eId").getNodeValue())
-        .isEqualTo("text-1_ref-1");
+      .isEqualTo("text-1_ref-1");
   }
 
   @Test
   void createElementWithStaticEidAndGuidNoAppend() {
     // given
-    final Document document =
-        XmlMapper.toDocument(
-            """
-                                                                  <root>
-                                                                      <test eId="test-1">test value</test>
-                                                                  </root>""");
+    final Document document = XmlMapper.toDocument(
+      """
+      <root>
+          <test eId="test-1">test value</test>
+      </root>"""
+    );
     final Node testNode = NodeParser.getMandatoryNodeFromExpression("//test", document);
 
     // when
-    final Element newElement =
-        NodeCreator.createElementWithStaticEidAndGuidNoAppend(
-            "childTest", "child-test-1", testNode);
+    final Element newElement = NodeCreator.createElementWithStaticEidAndGuidNoAppend(
+      "childTest",
+      "child-test-1",
+      testNode
+    );
 
     // Then
-    final Optional<Node> childTestNode =
-        NodeParser.getNodeFromExpression("//test/childTest", document);
+    final Optional<Node> childTestNode = NodeParser.getNodeFromExpression(
+      "//test/childTest",
+      document
+    );
     assertThat(childTestNode).isEmpty();
     assertThat(newElement.getAttributes().getNamedItem("GUID")).isNotNull();
     assertThat(newElement.getAttributes().getNamedItem("eId").getNodeValue())
-        .isEqualTo("test-1_child-test-1");
+      .isEqualTo("test-1_child-test-1");
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/utils/NodeParserTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/utils/NodeParserTest.java
@@ -68,9 +68,9 @@ class NodeParserTest {
 
   @Test
   void nodeListToListMultipleElements() {
-    Node node =
-        XmlMapper.toDocument("<foo><test>testValue</test><test>testValue2</test></foo>")
-            .getFirstChild();
+    Node node = XmlMapper
+      .toDocument("<foo><test>testValue</test><test>testValue2</test></foo>")
+      .getFirstChild();
     var nodes = NodeParser.nodeListToList(node.getChildNodes());
     assertThat(nodes).hasSize(2);
   }


### PR DESCRIPTION
RISDEV-0000

---

As discussed in our dev channel + weekly, I had a look at ways to improve the automatic formatting of our Java code. The issues we want to fix are:

- Consistent indentation; currently our code has a mix of 2, 4 and 8 spaces
- When chaining method calls, each call should have its own line
- Parameters also should each have their own line if they don't fit into one

Our goal initially was to achieve this by configuring our current formatter, rather than switching formatters.

However, it turns out that our [Spotless](https://github.com/diffplug/spotless/tree/main/plugin-gradle) config was using [google-java-format](https://github.com/google/google-java-format) which intentionally cannot be configured:

> **Note:** There is no configurability as to the formatter's algorithm for formatting. This is a deliberate design decision to unify our code formatting on a single format.

Besides google-java-format, Spotless also has out of the box support for other formatters, among them [Prettier](https://prettier.io/) and [palantir-java-format](https://github.com/palantir/palantir-java-format).

**palantir-java-format** is a fork of google-java-format. Therefore it is close to what we're already using, but it has improvements especially around how lambdas are laid out. It also can't be configured. I tried it and while it is an improvement over the Google formatter, it does not solve any of our issues. In addition, it seems to be using spaces for indentation even more liberally, making the already verbose Java code take up even more space.

For this reason I decided to configure Prettier and format our code with that. I left the settings at default, apart from slightly increasing print width from 80 to 100 (again, because Java is so verbose). IMO this is vastly more readable and fixes all 3 issues mentioned above, while not really changing anything else (as far as I can tell).

Using Prettier has the additional benefit that we're using one formatter for basically our entire code base (FE + BE). This means that our code looks very consistent across the entire stack. It also doesn't require any new dependencies because it is already used in other places in our Spotless config, so it is there anyways.