### PR TITLE
Types and basic mapping for error handling frontend implementation

### DIFF
--- a/frontend/src/lib/errorMessages.ts
+++ b/frontend/src/lib/errorMessages.ts
@@ -1,0 +1,19 @@
+import { ErrorResponse, ErrorResponseMapping } from "@/types/errorResponse"
+
+export const errorMessages = {
+  // TODO: These are currently just examples for testing
+
+  __fallback__: () => "Ein unbekannter Fehler ist aufgetreten.",
+
+  "/errors/article-not-found": (e: ErrorResponse<{ eid: string }>) => ({
+    title: `Article with eID ${e.eid} not found`,
+  }),
+
+  "/errors/article-of-type-not-found": (
+    e: ErrorResponse<{ eli: string; types: string[] }>,
+  ) =>
+    `Norm with eli ${e.eli} does not include articles of type ${e.types?.join(",")}`,
+
+  "/errors/norm-not-found": (e: ErrorResponse) =>
+    `Norm with ELI ${e.instance} not found`,
+} satisfies ErrorResponseMapping

--- a/frontend/src/lib/errorResponseMapper.spec.ts
+++ b/frontend/src/lib/errorResponseMapper.spec.ts
@@ -1,5 +1,67 @@
-import { describe } from "vitest"
+import { ErrorResponse } from "@/types/errorResponse"
+import { describe, expect, test, vi } from "vitest"
+import { isErrorResponse, mapErrorResponse } from "./errorResponseMapper"
 
-describe.todo("isErrorResponse", () => {})
+vi.mock("@/lib/errorMessages", () => ({
+  errorMessages: {
+    __fallback__: () => "The fallback message",
 
-describe.todo("mapErrorResponse", () => {})
+    "/errors/foo": (e: ErrorResponse) => `Error of type ${e.type}`,
+
+    "/errors/bar": (e: ErrorResponse<{ example: string }>) => ({
+      title: "Bar",
+      message: `Example: ${e.example}`,
+    }),
+  },
+}))
+
+describe("isErrorResponse", () => {
+  test("returns true if the candidate's type exists in the mapping", () => {
+    const candidate = { type: "/errors/foo" }
+    const result = isErrorResponse(candidate)
+    expect(result).toBe(true)
+  })
+
+  test("returns false if the candidate's type does not exist in the mapping", () => {
+    const candidate = { type: "/errors/non-existing-type" }
+    const result = isErrorResponse(candidate)
+    expect(result).toBe(false)
+  })
+
+  test("returns false if the candidate has no type", () => {
+    const candidate = { foo: "bar" }
+    const result = isErrorResponse(candidate)
+    expect(result).toBe(false)
+  })
+
+  test("returns false if the candidate is not an object", () => {
+    const candidate = "example"
+    const result = isErrorResponse(candidate)
+    expect(result).toBe(false)
+  })
+})
+
+describe("mapErrorResponse", () => {
+  test("returns a mapped response from a string", () => {
+    const e: ErrorResponse = { type: "/errors/foo" }
+    const result = mapErrorResponse(e)
+    expect(result).toEqual({ title: "Error of type /errors/foo" })
+  })
+
+  test("returns a mapped response from an object", () => {
+    const e: ErrorResponse<{ example: string }> = {
+      type: "/errors/bar",
+      example: "Example",
+    }
+
+    const result = mapErrorResponse(e)
+
+    expect(result).toEqual({ title: "Bar", message: "Example: Example" })
+  })
+
+  test("returns the fallback response if the type has no mapping", () => {
+    const e: ErrorResponse = { type: "/errors/non-existing-type" }
+    const result = mapErrorResponse(e)
+    expect(result).toEqual({ title: "The fallback message" })
+  })
+})

--- a/frontend/src/lib/errorResponseMapper.spec.ts
+++ b/frontend/src/lib/errorResponseMapper.spec.ts
@@ -1,0 +1,5 @@
+import { describe } from "vitest"
+
+describe.todo("isErrorResponse", () => {})
+
+describe.todo("mapErrorResponse", () => {})

--- a/frontend/src/lib/errorResponseMapper.ts
+++ b/frontend/src/lib/errorResponseMapper.ts
@@ -18,8 +18,7 @@ import {
  * @returns Whether the candidate is an error response
  */
 export function isErrorResponse(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Fetch errors are always any
-  e: any,
+  e: any, // eslint-disable-line @typescript-eslint/no-explicit-any -- Fetch errors are always any
 ): e is ErrorResponse {
   return typeof e === "object" && e.type in errorMessages
 }
@@ -35,7 +34,7 @@ export function isErrorResponse(
  */
 export function mapErrorResponse(e: ErrorResponse): MappedErrorResponse {
   const mapper = (errorMessages as ErrorResponseMapping)[e.type]
-  let message = mapper?.(e) ?? errorMessages.__fallback__
+  let message = mapper?.(e) ?? errorMessages.__fallback__()
   if (typeof message === "string") message = { title: message }
   return message
 }

--- a/frontend/src/lib/errorResponseMapper.ts
+++ b/frontend/src/lib/errorResponseMapper.ts
@@ -1,6 +1,7 @@
+import { errorMessages } from "@/lib/errorMessages"
 import {
   ErrorResponse,
-  ErrorResponseMessageMapping,
+  ErrorResponseMapping,
   MappedErrorResponse,
 } from "@/types/errorResponse"
 
@@ -17,11 +18,10 @@ import {
  * @returns Whether the candidate is an error response
  */
 export function isErrorResponse(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Has to be any because fetch errors are always any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Fetch errors are always any
   e: any,
-  mapping = errorMessages,
 ): e is ErrorResponse {
-  return typeof e === "object" && e.type in mapping
+  return typeof e === "object" && e.type in errorMessages
 }
 
 /**
@@ -33,31 +33,9 @@ export function isErrorResponse(
  *  already include everything you need, this is only intended for testing.
  * @returns
  */
-export function mapErrorResponse(
-  e: ErrorResponse,
-  mapping = errorMessages,
-): MappedErrorResponse {
-  const mapper = mapping[e.type]
-  let message = mapper?.(e) ?? mapping.__fallback__
+export function mapErrorResponse(e: ErrorResponse): MappedErrorResponse {
+  const mapper = (errorMessages as ErrorResponseMapping)[e.type]
+  let message = mapper?.(e) ?? errorMessages.__fallback__
   if (typeof message === "string") message = { title: message }
   return message
-}
-
-/* -------------------------------------------------- *
- * All error messages                                 *
- * -------------------------------------------------- */
-
-const errorMessages: ErrorResponseMessageMapping = {
-  // TODO: These are currently just examples for testing
-
-  __fallback__: () => "Ein unbekannter Fehler ist aufgetreten.",
-
-  "/errors/article-not-found": (e) => ({
-    title: `Article with eID ${e.eid} not found`,
-  }),
-
-  "/errors/article-of-type-not-found": (e) =>
-    `Norm with eli ${e.eli} does not include articles of type ${e.type?.join(",")}`,
-
-  "/errors/norm-not-found": (e) => `Norm with ELI ${e.instance} not found`,
 }

--- a/frontend/src/lib/errorResponseMapper.ts
+++ b/frontend/src/lib/errorResponseMapper.ts
@@ -1,0 +1,63 @@
+import {
+  ErrorResponse,
+  ErrorResponseMessageMapping,
+  MappedErrorResponse,
+} from "@/types/errorResponse"
+
+/**
+ * Determines whether the parameter is an error response. Will return true
+ * if mapping for the error type exists. Note that this will not check if
+ * the extension properties are available for that type as that would make
+ * the check very complicated.
+ *
+ * @param e Candidate for a possible error response
+ * @param mapping Mapping to check the error response. The default mapping
+ *  should already include everything you need, this is only intended for
+ *  testing.
+ * @returns Whether the candidate is an error response
+ */
+export function isErrorResponse(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Has to be any because fetch errors are always any
+  e: any,
+  mapping = errorMessages,
+): e is ErrorResponse {
+  return typeof e === "object" && e.type in mapping
+}
+
+/**
+ * For any backend error response, maps the technical details of that response
+ * to a human-readable message in the UI.
+ *
+ * @param e Response received from the backend
+ * @param mapping Mapping to retrieve the messages from. The default mapping should
+ *  already include everything you need, this is only intended for testing.
+ * @returns
+ */
+export function mapErrorResponse(
+  e: ErrorResponse,
+  mapping = errorMessages,
+): MappedErrorResponse {
+  const mapper = mapping[e.type]
+  let message = mapper?.(e) ?? mapping.__fallback__
+  if (typeof message === "string") message = { title: message }
+  return message
+}
+
+/* -------------------------------------------------- *
+ * All error messages                                 *
+ * -------------------------------------------------- */
+
+const errorMessages: ErrorResponseMessageMapping = {
+  // TODO: These are currently just examples for testing
+
+  __fallback__: () => "Ein unbekannter Fehler ist aufgetreten.",
+
+  "/errors/article-not-found": (e) => ({
+    title: `Article with eID ${e.eid} not found`,
+  }),
+
+  "/errors/article-of-type-not-found": (e) =>
+    `Norm with eli ${e.eli} does not include articles of type ${e.type?.join(",")}`,
+
+  "/errors/norm-not-found": (e) => `Norm with ELI ${e.instance} not found`,
+}

--- a/frontend/src/services/referencesService.spec.ts
+++ b/frontend/src/services/referencesService.spec.ts
@@ -16,7 +16,7 @@ describe("useFetchReferences", () => {
       }),
     )
 
-    const { useGetReferences } = await import("../services/referencesService")
+    const { useGetReferences } = await import("./referencesService")
     const eli = "some-eli"
     const { data, isFinished } = useGetReferences(ref(eli))
 
@@ -43,7 +43,7 @@ describe("useFetchReferences", () => {
       }),
     )
 
-    const { useGetReferences } = await import("../services/referencesService")
+    const { useGetReferences } = await import("./referencesService")
     const eli = "some-eli"
     const { error, isFinished } = useGetReferences(ref(eli))
 
@@ -66,7 +66,7 @@ describe("useFetchReferences", () => {
   it("does not call the API if ELI is undefined", async () => {
     const fetchSpy = vi.spyOn(global, "fetch")
 
-    const { useGetReferences } = await import("../services/referencesService")
+    const { useGetReferences } = await import("./referencesService")
     const eli = undefined
     const { data, isFinished } = useGetReferences(ref(eli))
 

--- a/frontend/src/types/errorResponse.ts
+++ b/frontend/src/types/errorResponse.ts
@@ -1,0 +1,95 @@
+/**
+ * An error response returned by the API. This implements the error responses
+ * ADR, please refer to doc/adr/0012-error-responses.md for more information.
+ */
+export type ErrorResponse<
+  T extends keyof ErrorResponseDetail = "__fallback__",
+  Children = never,
+> = {
+  /**
+   * Type of the error.
+   */
+  type: T
+
+  /**
+   * Title of the error. This is intended for debugging purposes and should
+   * not be parsed or displayed in the UI.
+   */
+  title?: string
+
+  /**
+   * Details of the error. This is intended for debugging purposes and should
+   * not be parsed or displayed in the UI.
+   */
+  details?: string
+
+  /**
+   * Instance of the error. This can be used for matching errors to specific
+   * locations in the UI (e.g. an invalid form field).
+   */
+  instance?: string
+
+  /**
+   * Nested errors. If an error response contains multiple messages (e.g.
+   * for listing all fields that failed validation of a form), they will
+   * appear here.
+   */
+  errors?: Array<Children>
+} & {
+  // Merge the shared properties of the error response with the extension fields
+  // declared by the different error types (see below). Note that all extension
+  // fields are made optional here to encourage defensive programming as we
+  // cannot 100% guarantee all of them will always be available.
+  [K in keyof ErrorResponseDetail[T]]?: ErrorResponseDetail[T][K]
+}
+
+/**
+ * Specifies additional extension fields specific to each error type.
+ *
+ * All possible error types must be specified here in order to ensure type
+ * safety for the different error types.
+ *
+ * If an error type does not provide any extension fields, set the value for that
+ * type to `never`.
+ */
+export type ErrorResponseDetail = {
+  // TODO: These are currently just examples for testing
+
+  "/errors/norm-not-found": never
+
+  "/errors/article-not-found": { eid: string }
+
+  "/errors/article-of-type-not-found": { eli: string; type: string[] }
+
+  /**
+   * This will be used for any errors returned from the backend that haven't been
+   * translated yet or don't receive any explicit handling in the frontend.
+   */
+  __fallback__: never
+}
+
+/**
+ * Defines a configuration object that maps from an error response as returned by
+ * the API to a human-readable message that can be displayed in the UI.
+ *
+ * This is a helper that guarantees (1) that any mapping is required to provide
+ * information for all available error types, and (2) type-safety for functions
+ * that generate messages.
+ */
+export type ErrorResponseMessageMapping = {
+  [K in keyof ErrorResponseDetail]: (
+    e: ErrorResponse<K>,
+  ) => MappedErrorResponse | string
+}
+
+/**
+ * The human-readable error message that should be displayed in the UI for
+ * for each error type returned by the API.
+ */
+export type MappedErrorResponse = {
+  /** Title of the error message. */
+  title: string
+
+  /** Optional additional detail information for the error message. */
+  message?: string
+}

--- a/frontend/src/types/errorResponse.ts
+++ b/frontend/src/types/errorResponse.ts
@@ -2,14 +2,11 @@
  * An error response returned by the API. This implements the error responses
  * ADR, please refer to doc/adr/0012-error-responses.md for more information.
  */
-export type ErrorResponse<
-  T extends keyof ErrorResponseDetail = "__fallback__",
-  Children = never,
-> = {
+export type ErrorResponse<ExtensionFields extends object = object> = {
   /**
    * Type of the error.
    */
-  type: T
+  type: string
 
   /**
    * Title of the error. This is intended for debugging purposes and should
@@ -34,57 +31,26 @@ export type ErrorResponse<
    * for listing all fields that failed validation of a form), they will
    * appear here.
    */
-  errors?: Array<Children>
+  errors?: Array<ErrorResponse>
 } & {
   // Merge the shared properties of the error response with the extension fields
   // declared by the different error types (see below). Note that all extension
   // fields are made optional here to encourage defensive programming as we
   // cannot 100% guarantee all of them will always be available.
-  [K in keyof ErrorResponseDetail[T]]?: ErrorResponseDetail[T][K]
-}
-
-/**
- * Specifies additional extension fields specific to each error type.
- *
- * All possible error types must be specified here in order to ensure type
- * safety for the different error types.
- *
- * If an error type does not provide any extension fields, set the value for that
- * type to `never`.
- */
-export type ErrorResponseDetail = {
-  // TODO: These are currently just examples for testing
-
-  "/errors/norm-not-found": never
-
-  "/errors/article-not-found": { eid: string }
-
-  "/errors/article-of-type-not-found": { eli: string; type: string[] }
-
-  /**
-   * This will be used for any errors returned from the backend that haven't been
-   * translated yet or don't receive any explicit handling in the frontend.
-   */
-  __fallback__: never
+  [K in keyof ExtensionFields]?: ExtensionFields[K]
 }
 
 /**
  * Defines a configuration object that maps from an error response as returned by
  * the API to a human-readable message that can be displayed in the UI.
- *
- * This is a helper that guarantees (1) that any mapping is required to provide
- * information for all available error types, and (2) type-safety for functions
- * that generate messages.
  */
-export type ErrorResponseMessageMapping = {
-  [K in keyof ErrorResponseDetail]: (
-    e: ErrorResponse<K>,
-  ) => MappedErrorResponse | string
+export type ErrorResponseMapping = {
+  [key: string]: (e: ErrorResponse) => string | MappedErrorResponse
 }
 
 /**
  * The human-readable error message that should be displayed in the UI for
- * for each error type returned by the API.
+ * each error type returned by the API.
  */
 export type MappedErrorResponse = {
   /** Title of the error message. */


### PR DESCRIPTION
This PR adds types and basic logic for mapping error responses (as described in the [ADR](https://github.com/digitalservicebund/ris-norms/blob/main/doc/adr/0012-error-responses.md)) to human-readable messages in the frontend. I played around with a few different options until I found one I was satisfied with. There might still be things to simplify but I would already be interested in feedback on the general approach.

My goals were:

- Support for plain messages as well as interpolations (i.e. "Norm with ELI {eli} was not found"). For interpolations I wanted to not "invent" our own format and also if possible avoid adding dependencies, so template strings seemed like a good option.

- Use TypeScript as much as possible to let us know if messages are missing or the template strings need to be updated because parameters have changed. With this solution, we declare the types of errors we expect as well as any extension fields of that error in the `types/errorResponse.ts`, and TypeScript will let us know if we need to add or update existing messages.

- Support in the UI for both simple messages as well as messages with a title and additional description, hence the mapping returning an object rather than a string.

If this looks good so far, the next steps would be to:

- Add unit tests for the mapping
- Integrate with our reactive API calls
- Update components to display in the UI
- And then of course at some point add the actual mappings and types, currently these are just examples for testing
