### PR TITLE
Treat eId as mandatory value

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ArticleController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ArticleController.java
@@ -157,7 +157,7 @@ public class ArticleController {
 
     final var foundArticle =
         norm.getArticles().stream()
-            .filter(article -> article.getEid().isPresent() && article.getEid().get().equals(eid))
+            .filter(article -> article.getEid().equals(eid))
             .findFirst()
             .orElseThrow(() -> new ArticleNotFoundException(eliValue, eid));
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ArticleResponseMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ArticleResponseMapper.java
@@ -24,7 +24,7 @@ public class ArticleResponseMapper {
       final Article article, final @Nullable Norm targetLawZf0) {
     return new ArticleResponseSchema(
         article.getEnumeration().orElse(null),
-        article.getEid().orElse(null),
+        article.getEid(),
         article.getHeading().orElse(null),
         article.getAffectedDocumentEli().orElse(null),
         Optional.ofNullable(targetLawZf0).map(Norm::getEli).orElse(null));

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ElementResponseMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ElementResponseMapper.java
@@ -52,7 +52,7 @@ public class ElementResponseMapper {
   public static ElementResponseSchema fromElementNode(final Node node) {
     return ElementResponseSchema.builder()
         .title(getNodeTitle(node))
-        .eid(EId.fromNode(node).map(EId::value).orElseThrow())
+        .eid(EId.fromNode(node).value())
         .type(getNodeType(node))
         .build();
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/TimeBoundaryMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/TimeBoundaryMapper.java
@@ -19,8 +19,8 @@ public class TimeBoundaryMapper {
   public static TimeBoundarySchema fromUseCaseData(final TimeBoundary timeBoundary) {
     return TimeBoundarySchema.builder()
         .date(timeBoundary.getEventRef().getDate().orElse(null))
-        .eventRefEid(timeBoundary.getEventRefEid().orElse(null))
-        .temporalGroupEid(timeBoundary.getTemporalGroupEid().orElse(null))
+        .eventRefEid(timeBoundary.getEventRefEid())
+        .temporalGroupEid(timeBoundary.getTemporalGroupEid())
         .build();
   }
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/ArticleService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/ArticleService.java
@@ -47,8 +47,7 @@ public class ArticleService
     }
 
     return norm.getArticles().stream()
-        .filter(
-            article -> article.getEid().isPresent() && article.getEid().get().equals(query.eid()))
+        .filter(article -> article.getEid().equals(query.eid()))
         .findFirst()
         .map(article -> XmlMapper.toString(article.getNode()))
         .map(
@@ -152,6 +151,6 @@ public class ArticleService
                     // Modifications can be either on the article itself or anywhere
                     // inside the article, hence the "contains" rather than exact
                     // matching.
-                    destinationEid.contains(article.getEid().orElseThrow()));
+                    destinationEid.contains(article.getEid()));
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/ElementService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/ElementService.java
@@ -158,7 +158,7 @@ public class ElementService
               // no amending law -> all elements are fine
               if (query.amendedBy() == null) return true;
 
-              var eId = EId.fromNode(element).map(EId::value).orElseThrow();
+              var eId = EId.fromNode(element).value();
               return passiveModsDestinationEids.stream().anyMatch(modEid -> modEid.contains(eId));
             })
         .toList();

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/NormService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/NormService.java
@@ -113,7 +113,7 @@ public class NormService
 
     final Mod selectedMod =
         amendingNorm.getMods().stream()
-            .filter(m -> m.getEid().isPresent() && m.getEid().get().equals(eId))
+            .filter(m -> m.getEid().equals(eId))
             .findFirst()
             .orElseThrow(
                 () ->

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/SingleModValidator.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/SingleModValidator.java
@@ -63,7 +63,7 @@ public class SingleModValidator {
       throws ValidationException {
 
     final Href destinationHref = passivemod.getDestinationHref().orElseThrow();
-    final String passiveModEid = passivemod.getEid().orElseThrow();
+    final String passiveModEid = passivemod.getEid();
     final CharacterRange characterRange =
         destinationHref
             .getCharacterRange()

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeBoundaryService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeBoundaryService.java
@@ -69,7 +69,7 @@ public class TimeBoundaryService
 
     final List<TemporalGroup> temporalGroups =
         norm.getMeta().getTemporalData().getTemporalGroups().stream()
-            .filter(f -> temporalGroupEidAmendedBy.contains(f.getEid().orElseThrow()))
+            .filter(f -> temporalGroupEidAmendedBy.contains(f.getEid()))
             .toList();
     return norm.getTimeBoundaries(temporalGroups);
   }
@@ -117,20 +117,19 @@ public class TimeBoundaryService
 
     List<TimeBoundary> timeBoundariesToUpdate =
         norm.getTimeBoundaries().stream()
-            .filter(tb -> tb.getEventRefEid().isPresent())
             .filter(
                 tb ->
                     datesToUpdate.stream()
                         .map(TimeBoundaryChangeData::eid)
                         .toList()
-                        .contains(tb.getEventRefEid().get()))
+                        .contains(tb.getEventRefEid()))
             .toList();
 
     timeBoundariesToUpdate.forEach(
         tb -> {
           LocalDate newDate =
               datesToUpdate.stream()
-                  .filter(date -> date.eid().equals(tb.getEventRefEid().get()))
+                  .filter(date -> date.eid().equals(tb.getEventRefEid()))
                   .map(TimeBoundaryChangeData::date)
                   .findFirst()
                   .orElse(LocalDate.MIN);
@@ -143,11 +142,7 @@ public class TimeBoundaryService
   private void logChangeDataWithoutCorrespondingEidInXml(
       Norm norm, List<TimeBoundaryChangeData> datesToUpdate) {
     List<String> timeBoundaryEids =
-        norm.getTimeBoundaries().stream()
-            .map(TimeBoundary::getEventRefEid)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .toList();
+        norm.getTimeBoundaries().stream().map(TimeBoundary::getEventRefEid).toList();
 
     List<TimeBoundaryChangeData> timeBoundariesListedButNotUpdated =
         datesToUpdate.stream()
@@ -179,8 +174,6 @@ public class TimeBoundaryService
     List<String> allEventRefEidsToDelete =
         norm.getTimeBoundaries().stream()
             .map(TimeBoundary::getEventRefEid)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
             .filter(eid -> !allChangeDateEids.contains(eid))
             .toList();
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineService.java
@@ -91,7 +91,7 @@ public class TimeMachineService implements ApplyPassiveModificationsUseCase {
                                   ValidationException.ErrorType.SOURCE_HREF_IN_META_MOD_MISSING,
                                   Pair.of(
                                       ValidationException.FieldName.EID,
-                                      passiveModification.getEid().orElse(""))));
+                                      passiveModification.getEid())));
 
               Norm amendingLaw;
               if (customNorms.containsKey(sourceEli)) {
@@ -102,7 +102,7 @@ public class TimeMachineService implements ApplyPassiveModificationsUseCase {
 
               var sourceEid = passiveModification.getSourceHref().flatMap(Href::getEId);
               return amendingLaw.getMods().stream()
-                  .filter(mod -> mod.getEid().equals(sourceEid))
+                  .filter(mod -> sourceEid.isPresent() && sourceEid.get().equals(mod.getEid()))
                   .map(
                       mod ->
                           new ModData(

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/UpdateNormService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/UpdateNormService.java
@@ -38,7 +38,7 @@ public class UpdateNormService
                     .equals(Optional.of(sourceNormEli)))
         .forEach(
             passiveModification -> {
-              norm.deleteByEId(passiveModification.getEid().orElseThrow());
+              norm.deleteByEId(passiveModification.getEid());
 
               final var temporalGroup =
                   passiveModification
@@ -95,7 +95,7 @@ public class UpdateNormService
               final var temporalGroup =
                   norm.addTimeBoundary(startDate.get(), EventRefType.AMENDMENT);
               amendingNormTemporalGroupEidsToNormTemporalGroupEids.put(
-                  forcePeriodEid, temporalGroup.getEid().orElseThrow());
+                  forcePeriodEid, temporalGroup.getEid());
             });
 
     // create the passive modifications
@@ -165,7 +165,7 @@ public class UpdateNormService
 
     // Edit mod in meta
     amendingNorm.getMods().stream()
-        .filter(mod -> mod.getEid().isPresent() && mod.getEid().get().equals(query.eId()))
+        .filter(mod -> mod.getEid().equals(query.eId()))
         .findFirst()
         .ifPresent(
             inTextMod -> {

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Article.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Article.java
@@ -44,17 +44,8 @@ public class Article {
    *
    * @return The eId of the article
    */
-  public Optional<String> getEid() {
-    return EId.fromNode(getNode()).map(EId::value);
-  }
-
-  /**
-   * Returns the eId as {@link String} from a {@link Node} in a {@link Norm}.
-   *
-   * @return The eId of the article
-   */
-  public String getMandatoryEid() {
-    return EId.fromMandatoryNode(getNode()).value();
+  public String getEid() {
+    return EId.fromNode(getNode()).value();
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/EventRef.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/EventRef.java
@@ -16,7 +16,7 @@ public class EventRef {
   private final Node node;
 
   public EId getEid() {
-    return EId.fromNode(node).orElseThrow();
+    return EId.fromNode(node);
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Mod.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Mod.java
@@ -32,8 +32,8 @@ public class Mod {
    *
    * @return The eId of the mod
    */
-  public Optional<String> getEid() {
-    return EId.fromNode(getNode()).map(EId::value);
+  public String getEid() {
+    return EId.fromNode(getNode()).value();
   }
 
   /**
@@ -239,7 +239,7 @@ public class Mod {
     final Node refNode = NodeParser.getNodeFromExpression(REF_XPATH, this.node).orElseThrow();
 
     final Element rrefElement = NodeCreator.createElement("akn:rref", this.node);
-    rrefElement.setAttribute("eId", EId.fromMandatoryNode(refNode).value());
+    rrefElement.setAttribute("eId", EId.fromNode(refNode).value());
     rrefElement.setAttribute("from", destinationFrom);
     rrefElement.setAttribute("upTo", destinationUpTo);
 
@@ -258,7 +258,7 @@ public class Mod {
     final Node rrefNode = NodeParser.getNodeFromExpression(RREF_XPATH, this.node).orElseThrow();
 
     final Element refElement = NodeCreator.createElement("akn:ref", this.node);
-    refElement.setAttribute("eId", EId.fromMandatoryNode(rrefNode).value());
+    refElement.setAttribute("eId", EId.fromNode(rrefNode).value());
     refElement.setAttribute("href", destinationHref);
 
     refElement.setTextContent(rrefNode.getTextContent());

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Norm.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Norm.java
@@ -129,7 +129,7 @@ public class Norm {
               final String eventRefEId = timeInterval.getEventRefEId().orElseThrow();
               final EventRef eventRef =
                   getMeta().getLifecycle().getEventRefs().stream()
-                      .filter(f -> Objects.equals(f.getEid().value(), eventRefEId))
+                      .filter(er -> Objects.equals(er.getEid().value(), eventRefEId))
                       .findFirst()
                       .orElseThrow();
               return (TimeBoundary)
@@ -157,9 +157,7 @@ public class Norm {
    */
   public Optional<String> getStartEventRefForTemporalGroup(final String temporalGroupEid) {
     return getMeta().getTemporalData().getTemporalGroups().stream()
-        .filter(
-            temporalGroup ->
-                temporalGroup.getEid().map(eid -> eid.equals(temporalGroupEid)).orElse(false))
+        .filter(temporalGroup -> temporalGroup.getEid().equals(temporalGroupEid))
         .findFirst()
         .flatMap(m -> m.getTimeInterval().getEventRefEId());
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TemporalGroup.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TemporalGroup.java
@@ -1,7 +1,6 @@
 package de.bund.digitalservice.ris.norms.domain.entity;
 
 import de.bund.digitalservice.ris.norms.utils.NodeParser;
-import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
@@ -19,8 +18,8 @@ public class TemporalGroup {
    *
    * @return The eId of the temporal group
    */
-  public Optional<String> getEid() {
-    return EId.fromNode(getNode()).map(EId::value);
+  public String getEid() {
+    return EId.fromNode(getNode()).value();
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TextualMod.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TextualMod.java
@@ -22,8 +22,8 @@ public class TextualMod {
    *
    * @return The eId of the modification
    */
-  public Optional<String> getEid() {
-    return EId.fromNode(getNode()).map(EId::value);
+  public String getEid() {
+    return EId.fromNode(getNode()).value();
   }
 
   /**
@@ -68,10 +68,7 @@ public class TextualMod {
             () -> {
               var newElement = getNode().getOwnerDocument().createElement("akn:destination");
               newElement.setAttribute(
-                  "eId",
-                  new EId(this.getEid().orElseThrow())
-                      .addPart(new EIdPart("destination", "1"))
-                      .value());
+                  "eId", new EId(this.getEid()).addPart(new EIdPart("destination", "1")).value());
               newElement.setAttribute("GUID", UUID.randomUUID().toString());
               getNode().appendChild(newElement);
               return newElement;
@@ -119,10 +116,7 @@ public class TextualMod {
             () -> {
               var newElement = getNode().getOwnerDocument().createElement("akn:force");
               newElement.setAttribute(
-                  "eId",
-                  new EId(this.getEid().orElseThrow())
-                      .addPart(new EIdPart("gelzeitnachw", "1"))
-                      .value());
+                  "eId", new EId(this.getEid()).addPart(new EIdPart("gelzeitnachw", "1")).value());
               newElement.setAttribute("GUID", UUID.randomUUID().toString());
               getNode().appendChild(newElement);
               return newElement;

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TimeBoundary.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TimeBoundary.java
@@ -1,7 +1,6 @@
 package de.bund.digitalservice.ris.norms.domain.entity;
 
 import java.time.LocalDate;
-import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
@@ -21,8 +20,8 @@ public class TimeBoundary {
    *
    * @return The eId of the eventRef
    */
-  public Optional<String> getEventRefEid() {
-    return EId.fromNode(eventRef.getNode()).map(EId::value);
+  public String getEventRefEid() {
+    return EId.fromNode(eventRef.getNode()).value();
   }
 
   /**
@@ -30,8 +29,8 @@ public class TimeBoundary {
    *
    * @return The eId of the timeInterval
    */
-  public Optional<String> getTimeIntervalEid() {
-    return EId.fromNode(timeInterval.getNode()).map(EId::value);
+  public String getTimeIntervalEid() {
+    return EId.fromNode(timeInterval.getNode()).value();
   }
 
   /**
@@ -39,8 +38,8 @@ public class TimeBoundary {
    *
    * @return The eId of the temporal group
    */
-  public Optional<String> getTemporalGroupEid() {
-    return EId.fromNode(temporalGroup.getNode()).map(EId::value);
+  public String getTemporalGroupEid() {
+    return EId.fromNode(temporalGroup.getNode()).value();
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/utils/NodeCreator.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/utils/NodeCreator.java
@@ -37,7 +37,7 @@ public class NodeCreator {
     var newElement = parentNode.getOwnerDocument().createElement(tagName);
     newElement.setAttribute("GUID", UUID.randomUUID().toString());
     parentNode.appendChild(newElement);
-    EId.forNode(newElement).ifPresent(eId -> newElement.setAttribute("eId", eId.value()));
+    EId.createForNode(newElement).ifPresent(eId -> newElement.setAttribute("eId", eId.value()));
     return newElement;
   }
 
@@ -54,7 +54,7 @@ public class NodeCreator {
   public static Element createElementWithStaticEidAndGuidNoAppend(
       final String tagName, final String eidPartName, final Node parentNode) {
     var newElement = parentNode.getOwnerDocument().createElement(tagName);
-    newElement.setAttribute("eId", EId.fromMandatoryNode(parentNode) + "_" + eidPartName);
+    newElement.setAttribute("eId", EId.fromNode(parentNode) + "_" + eidPartName);
     newElement.setAttribute("GUID", UUID.randomUUID().toString());
     return newElement;
   }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ArticleControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ArticleControllerTest.java
@@ -169,7 +169,7 @@ class ArticleControllerTest {
       when(loadArticlesFromNormUseCase.loadArticlesFromNorm(any()))
           .thenReturn(
               norm.getArticles().stream()
-                  .filter(article -> article.getEid().get().equals("hauptteil-1_para-20"))
+                  .filter(article -> article.getEid().equals("hauptteil-1_para-20"))
                   .toList());
 
       // When
@@ -201,7 +201,7 @@ class ArticleControllerTest {
       when(loadArticlesFromNormUseCase.loadArticlesFromNorm(any()))
           .thenReturn(
               norm.getArticles().stream()
-                  .filter(article -> article.getEid().get().equals("hauptteil-1_para-1"))
+                  .filter(article -> article.getEid().equals("hauptteil-1_para-1"))
                   .toList());
 
       // When

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ElementResponseMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ElementResponseMapperTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import de.bund.digitalservice.ris.norms.utils.XmlMapper;
-import java.util.NoSuchElementException;
 import org.junit.jupiter.api.Test;
 
 class ElementResponseMapperTest {
@@ -448,6 +447,6 @@ class ElementResponseMapperTest {
 
     // When
     assertThatThrownBy(() -> ElementResponseMapper.fromElementNode(node))
-        .isInstanceOf(NoSuchElementException.class);
+        .isInstanceOf(NullPointerException.class);
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/NormServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/NormServiceTest.java
@@ -568,11 +568,9 @@ class NormServiceTest {
           amendingNorm.getMods().stream()
               .filter(
                   m ->
-                      m.getEid().isPresent()
-                          && m.getEid()
-                              .get()
-                              .equals(
-                                  "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"))
+                      m.getEid()
+                          .equals(
+                              "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"))
               .findFirst()
               .orElseThrow();
       Norm targetNorm = NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml");
@@ -702,11 +700,9 @@ class NormServiceTest {
           amendingNorm.getMods().stream()
               .filter(
                   m ->
-                      m.getEid().isPresent()
-                          && m.getEid()
-                              .get()
-                              .equals(
-                                  "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"))
+                      m.getEid()
+                          .equals(
+                              "hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"))
               .findFirst()
               .orElseThrow();
       Norm targetNorm = NormFixtures.loadFromDisk("NormWithoutPassiveModifications.xml");

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeBoundaryServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeBoundaryServiceTest.java
@@ -90,7 +90,7 @@ class TimeBoundaryServiceTest {
       // handle 1st time boundary
       assertThat(timeBoundaries.getFirst().getEventRef().getDate())
           .contains(LocalDate.parse("2023-12-30"));
-      assertThat(timeBoundaries.getFirst().getEventRefEid().get())
+      assertThat(timeBoundaries.getFirst().getEventRefEid())
           .contains("meta-1_lebzykl-1_ereignis-2");
       assertThat(
               timeBoundaries
@@ -112,7 +112,7 @@ class TimeBoundaryServiceTest {
                   .getNamedItem("GUID")
                   .getNodeValue())
           .contains("ac311ee1-33d3-4b9b-a974-776e55a88396");
-      assertThat(timeBoundaries.getFirst().getTimeIntervalEid().get())
+      assertThat(timeBoundaries.getFirst().getTimeIntervalEid())
           .contains("meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1");
       assertThat(
               timeBoundaries
@@ -140,13 +140,12 @@ class TimeBoundaryServiceTest {
                   .getAttributes()
                   .getNamedItem("start")
                   .getNodeValue())
-          .contains("#" + timeBoundaries.get(0).getEventRefEid().get());
+          .contains("#" + timeBoundaries.get(0).getEventRefEid());
 
       // handle 2nd time boundary
       assertThat(timeBoundaries.get(1).getEventRef().getDate())
           .contains(LocalDate.parse("2024-01-01"));
-      assertThat(timeBoundaries.get(1).getEventRefEid().get())
-          .contains("meta-1_lebzykl-1_ereignis-3");
+      assertThat(timeBoundaries.get(1).getEventRefEid()).contains("meta-1_lebzykl-1_ereignis-3");
       assertThat(
               timeBoundaries
                   .get(1)
@@ -167,7 +166,7 @@ class TimeBoundaryServiceTest {
                   .getNamedItem("GUID")
                   .getNodeValue())
           .contains("fdfaeef0-0300-4e5b-9e8b-14d2162bfb00");
-      assertThat(timeBoundaries.get(1).getTimeIntervalEid().get())
+      assertThat(timeBoundaries.get(1).getTimeIntervalEid())
           .contains("meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1");
       assertThat(
               timeBoundaries
@@ -195,7 +194,7 @@ class TimeBoundaryServiceTest {
                   .getAttributes()
                   .getNamedItem("start")
                   .getNodeValue())
-          .contains("#" + timeBoundaries.get(1).getEventRefEid().get());
+          .contains("#" + timeBoundaries.get(1).getEventRefEid());
     }
 
     @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/UpdateNormServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/UpdateNormServiceTest.java
@@ -297,7 +297,7 @@ class UpdateNormServiceTest {
       assertThat(activeModifications.getForcePeriodEid()).contains(newTimeBoundaryEid);
       final Mod mod =
           updatedAmendingNorm.getMods().stream()
-              .filter(f -> f.getEid().orElseThrow().equals(eId))
+              .filter(f -> f.getEid().equals(eId))
               .findFirst()
               .orElseThrow();
       assertThat(mod.getNewText()).contains(newContent);

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/ArticleTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/ArticleTest.java
@@ -2,14 +2,9 @@ package de.bund.digitalservice.ris.norms.domain.entity;
 
 import static de.bund.digitalservice.ris.norms.utils.XmlMapper.toNode;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import de.bund.digitalservice.ris.norms.application.port.output.LoadNormPort;
-import de.bund.digitalservice.ris.norms.utils.exceptions.MandatoryNodeNotFoundException;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class ArticleTest {
@@ -68,7 +63,7 @@ class ArticleTest {
     var expectedEid = "hauptteil-1_art-1";
 
     // when
-    var eid = article.getEid().get();
+    var eid = article.getEid();
 
     // then
     assertThat(eid).isEqualTo(expectedEid);
@@ -87,34 +82,10 @@ class ArticleTest {
     var expectedEid = "hauptteil-1_art-1";
 
     // when
-    var eid = article.getEid().orElseThrow();
+    var eid = article.getEid();
 
     // then
     assertThat(eid).isEqualTo(expectedEid);
-  }
-
-  @Test
-  void getEidOrThrowThrowsExceptionMandatoryEidIsMissing() {
-    // given
-    final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithMods.xml");
-    when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(amendingNorm));
-    amendingNorm
-        .getNodeByEId("hauptteil-1_art-1")
-        .get()
-        .getAttributes()
-        .getNamedItem("eId")
-        .setTextContent("");
-
-    var article = amendingNorm.getArticles().getFirst();
-
-    // when
-    Throwable thrown = catchThrowable(article::getMandatoryEid);
-
-    // when/then
-    assertThat(thrown)
-        .isInstanceOf(MandatoryNodeNotFoundException.class)
-        .hasMessageContaining(
-            "Element with xpath './@eId' not found in 'akn:article' of norm 'eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1'");
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/EIdTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/EIdTest.java
@@ -1,10 +1,8 @@
 package de.bund.digitalservice.ris.norms.domain.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import de.bund.digitalservice.ris.norms.utils.XmlMapper;
-import de.bund.digitalservice.ris.norms.utils.exceptions.MandatoryNodeNotFoundException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -53,32 +51,7 @@ class EIdTest {
     // when
     var eId = EId.fromNode(node);
     // then
-    assertThat(eId).isPresent();
-    assertThat(eId.get().value()).isEqualTo("hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3");
-  }
-
-  @Test
-  void fromMandatoryNode() {
-    // given
-    var node =
-        XmlMapper.toNode(
-            "<akn:mod xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\" eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3\" />");
-    // when
-    var eId = EId.fromMandatoryNode(node);
-    // then
     assertThat(eId.value()).isEqualTo("hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3");
-  }
-
-  @Test
-  void fromMandatoryNodeThrowsMandatoryNodeNotFoundException() {
-    // given
-    var node =
-        XmlMapper.toNode(
-            "<akn:mod xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\" eId=\"\" />");
-
-    // when/then
-    assertThatThrownBy(() -> EId.fromMandatoryNode(node))
-        .isInstanceOf(MandatoryNodeNotFoundException.class);
   }
 
   @Nested
@@ -95,13 +68,9 @@ class EIdTest {
     void itShouldProvideEIdForNode(String xml, String expectedEId) {
       var node = XmlMapper.toNode(xml);
       // when
-      var optionalEId = EId.forNode(node);
+      var eId = EId.createForNode(node);
       // then
-      assertThat(optionalEId)
-          .hasValueSatisfying(
-              eId -> {
-                assertThat(eId.value()).isEqualTo(expectedEId);
-              });
+      assertThat(eId.get().value()).isEqualTo(expectedEId);
     }
 
     @Test
@@ -110,14 +79,11 @@ class EIdTest {
           XmlMapper.toNode(
               "<akn:mod xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\" eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3\"><akn:p>Some text</akn:p></akn:mod>");
       // when
-      var optionalEId = EId.forNode(node.getFirstChild());
+      var eId = EId.createForNode(node.getFirstChild());
+
       // then
-      assertThat(optionalEId)
-          .hasValueSatisfying(
-              eId -> {
-                assertThat(eId.value())
-                    .isEqualTo("hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3_text-1");
-              });
+      assertThat(eId.get().value())
+          .isEqualTo("hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3_text-1");
     }
 
     @Test
@@ -126,14 +92,10 @@ class EIdTest {
           XmlMapper.toNode(
               "<akn:mod xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.6/\" eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3\"><akn:p eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3_text-1\">Some text 1</akn:p><akn:ref eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3_ref-1\">Some other element</akn:ref><akn:p eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3_text-1\">Some text 2</akn:p><akn:p eId=\"hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3_text-2\">Some text 3</akn:p></akn:mod>");
       // when
-      var optionalEId = EId.forNode(node.getChildNodes().item(2));
+      var eId = EId.createForNode(node.getChildNodes().item(2));
       // then
-      assertThat(optionalEId)
-          .hasValueSatisfying(
-              eId -> {
-                assertThat(eId.value())
-                    .isEqualTo("hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3_text-2");
-              });
+      assertThat(eId.get().value())
+          .isEqualTo("hauptteil-1_abschnitt-erster_para-6_abs-3_inhalt-3_text-2");
     }
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormTest.java
@@ -918,8 +918,7 @@ class NormTest {
     // old one still there
     assertThat(timeBoundaries.get(0).getEventRef().getDate())
         .contains(LocalDate.parse("2023-12-30"));
-    assertThat(timeBoundaries.get(0).getEventRefEid().get())
-        .contains("meta-1_lebzykl-1_ereignis-2");
+    assertThat(timeBoundaries.get(0).getEventRefEid()).contains("meta-1_lebzykl-1_ereignis-2");
     assertThat(
             timeBoundaries
                 .get(0)
@@ -940,7 +939,7 @@ class NormTest {
                 .getNamedItem("GUID")
                 .getNodeValue())
         .contains("ac311ee1-33d3-4b9b-a974-776e55a88396");
-    assertThat(timeBoundaries.get(0).getTimeIntervalEid().get())
+    assertThat(timeBoundaries.get(0).getTimeIntervalEid())
         .contains("meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1");
     assertThat(
             timeBoundaries
@@ -968,13 +967,12 @@ class NormTest {
                 .getAttributes()
                 .getNamedItem("start")
                 .getNodeValue())
-        .contains("#" + timeBoundaries.get(0).getEventRefEid().get());
+        .contains("#" + timeBoundaries.get(0).getEventRefEid());
 
     // new one added
     assertThat(timeBoundaries.get(1).getEventRef().getDate())
         .contains(LocalDate.parse("2024-01-02"));
-    assertThat(timeBoundaries.get(1).getEventRefEid().get())
-        .contains("meta-1_lebzykl-1_ereignis-3");
+    assertThat(timeBoundaries.get(1).getEventRefEid()).contains("meta-1_lebzykl-1_ereignis-3");
     assertThat(
             timeBoundaries
                 .get(1)
@@ -995,7 +993,7 @@ class NormTest {
                 .getNamedItem("GUID")
                 .getNodeValue())
         .isNotEmpty();
-    assertThat(timeBoundaries.get(1).getTimeIntervalEid().get())
+    assertThat(timeBoundaries.get(1).getTimeIntervalEid())
         .contains("meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1");
     assertThat(
             timeBoundaries
@@ -1023,7 +1021,7 @@ class NormTest {
                 .getAttributes()
                 .getNamedItem("start")
                 .getNodeValue())
-        .contains("#" + timeBoundaries.get(1).getEventRefEid().get());
+        .contains("#" + timeBoundaries.get(1).getEventRefEid());
   }
 
   @Test
@@ -1071,8 +1069,7 @@ class NormTest {
     assertThat(timeBoundaries).hasSize(1);
     assertThat(timeBoundaries.get(0).getEventRef().getDate())
         .contains(LocalDate.parse("2023-12-30"));
-    assertThat(timeBoundaries.get(0).getEventRefEid().get())
-        .contains("meta-1_lebzykl-1_ereignis-2");
+    assertThat(timeBoundaries.get(0).getEventRefEid()).contains("meta-1_lebzykl-1_ereignis-2");
     assertThat(
             timeBoundaries
                 .get(0)
@@ -1093,7 +1090,7 @@ class NormTest {
                 .getNamedItem("GUID")
                 .getNodeValue())
         .contains("ac311ee1-33d3-4b9b-a974-776e55a88396");
-    assertThat(timeBoundaries.get(0).getTimeIntervalEid().get())
+    assertThat(timeBoundaries.get(0).getTimeIntervalEid())
         .contains("meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1");
     assertThat(
             timeBoundaries
@@ -1121,7 +1118,7 @@ class NormTest {
                 .getAttributes()
                 .getNamedItem("start")
                 .getNodeValue())
-        .contains("#" + timeBoundaries.get(0).getEventRefEid().get());
+        .contains("#" + timeBoundaries.get(0).getEventRefEid());
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ArticleControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ArticleControllerIntegrationTest.java
@@ -1015,10 +1015,10 @@ class ArticleControllerIntegrationTest extends BaseIntegrationTest {
       // When / Then
       mockMvc
           .perform(
-              get("/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles/hauptteil-1_para-20?atIsoDate=2017-03-01T00:00:00.000Z")
+              get("/api/v1/norms/eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/articles/hauptteil-1_para-20?atIsoDate=2025-03-01T00:00:00.000Z")
                   .accept(MediaType.TEXT_HTML))
           .andExpect(status().isOk())
-          .andExpect(content().string(containsString("§ 9 Absatz 1 Satz 2, Absatz 2 oder 3")))
+          .andExpect(content().string(containsString("§ 9 Absatz 1 Satz 2, Absatz 2, 3 oder 4")))
           .andExpect(content().string(not(containsString("§ 9 Abs. 1 Satz 2, Abs. 2"))));
     }
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/utils/EidConsistencyGuardianTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/utils/EidConsistencyGuardianTest.java
@@ -188,9 +188,9 @@ class EidConsistencyGuardianTest {
         """
                     <root>
             <akn:meta xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="meta-1">
-                         <akn:p>
-                             <akn:ref></akn:ref>
-                             <akn:ref></akn:ref>
+                         <akn:p eId="some-id">
+                             <akn:ref eId="some-id"></akn:ref>
+                             <akn:ref eId="some-id"></akn:ref>
                          </akn:p>
                       </akn:meta>
                     </root>


### PR DESCRIPTION
In the context of introducing the custom standardized error responses in the backend we had to do some refactoring so that all exceptions are handled and converted to the ProblemDetail object.

We realized that we are using in many places the default `NoSuchElementException`, which is thrown, when on a Optional the `orElseThrow()` is used. We wanted to replace this default with a custom one, like maybe using the `MandatoryNodeNotFoundException`. But we realized that many of this default usage comes when trying to get the eId of an element.

We started therefore reformating the fromNode function of the Eid class so that not an optional is returned, since we know all/many elements MUST have an eId. We could then just filter out those elements passed to that function that do not belong to the list of nodes with mandatory eId.

But we realized that firstly with LDML.de 1.7 almost every XML node will get a mandatory eId (like for example akn:meta and many children there). Therefore we park this implementation for when:

1. XSD validation after upload is in place, because we can then be sure that our DB won't have amending laws with elements without eId attribute (if they must have it)
2. We convert to LDML.de 1.7 because almost every node will need to have an eId.

We added for now an exception handler for the `NoSuchElementException` as a fallback till we go on with this work.