### PR TITLE
Return error response data instead of exception in api fetch

### DIFF
--- a/frontend/e2e/validation.spec.ts
+++ b/frontend/e2e/validation.spec.ts
@@ -20,9 +20,7 @@ test.describe("Validation errors on check modifications page", () => {
       "The character range 9-36 of passive mod with eId meta-1_analysis-1_pasmod-1_textualmod-1 within ZF0 norm with eli eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu/regelungstext-1 does not resolve to the targeted text to be replaced.",
     )
 
-    await expect(
-      page.getByText("Ein unbekannter Fehler ist aufgetreten."),
-    ).toBeVisible()
+    await expect(page.getByText("Zeichenbereich nicht korrekt")).toBeVisible()
 
     await expect(
       page.getByRole("button", {
@@ -54,9 +52,7 @@ test.describe("Validation errors on check modifications page", () => {
       "Target node with eid hauptteil-1_para-20_abs-1_untergl-1_listenelem-2_inhalt-1_text-1wrongEid not present in ZF0 norm with eli eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu/regelungstext-1.",
     )
 
-    await expect(
-      page.getByText("Ein unbekannter Fehler ist aufgetreten."),
-    ).toBeVisible()
+    await expect(page.getByText("Zielknoten nicht vorhanden")).toBeVisible()
 
     await expect(
       page.getByRole("button", {
@@ -89,7 +85,7 @@ test.describe("Validation errors on check modifications page", () => {
     )
 
     await expect(
-      page.getByText("Ein unbekannter Fehler ist aufgetreten."),
+      page.getByText("Zeichenbereich nicht innerhalb des Knotenbereichs"),
     ).toBeVisible()
 
     await expect(

--- a/frontend/src/lib/errorResponseMapper.spec.ts
+++ b/frontend/src/lib/errorResponseMapper.spec.ts
@@ -1,6 +1,10 @@
 import { ErrorResponse } from "@/types/errorResponse"
 import { describe, expect, test, vi } from "vitest"
-import { isErrorResponse, mapErrorResponse } from "./errorResponseMapper"
+import {
+  getFallbackError,
+  isErrorResponse,
+  mapErrorResponse,
+} from "./errorResponseMapper"
 
 vi.mock("@/lib/errorMessages", () => ({
   errorMessages: {
@@ -38,6 +42,12 @@ describe("isErrorResponse", () => {
     const candidate = "example"
     const result = isErrorResponse(candidate)
     expect(result).toBe(false)
+  })
+})
+
+describe("getFallbackError", () => {
+  test("returns a fallback error", () => {
+    expect(getFallbackError()).toEqual({ type: "__fallback__" })
   })
 })
 

--- a/frontend/src/lib/errorResponseMapper.ts
+++ b/frontend/src/lib/errorResponseMapper.ts
@@ -24,6 +24,15 @@ export function isErrorResponse(
 }
 
 /**
+ * Returns a fallback error message. Useful when you want to handle all errors
+ * as if they were returned from the API, even if they may come from different
+ * sources or have a different format.
+ */
+export function getFallbackError(): ErrorResponse {
+  return { type: "__fallback__" }
+}
+
+/**
  * For any backend error response, maps the technical details of that response
  * to a human-readable message in the UI.
  *

--- a/frontend/src/services/apiService.spec.ts
+++ b/frontend/src/services/apiService.spec.ts
@@ -121,4 +121,18 @@ describe("useApiFetch", () => {
       expect(error.value).toEqual({ type: "/errors/example" })
     })
   })
+
+  test("replaces the exception with a fallback error if the response does not contain data", async () => {
+    vi.spyOn(window, "fetch").mockResolvedValue(
+      new Response(null, { status: 404 }),
+    )
+
+    const { useApiFetch } = await import("@/services/apiService")
+
+    const { error } = useApiFetch("/example", { immediate: true }).json()
+
+    await vi.waitFor(() => {
+      expect(error.value).toEqual({ type: "__fallback__" })
+    })
+  })
 })

--- a/frontend/src/services/apiService.spec.ts
+++ b/frontend/src/services/apiService.spec.ts
@@ -107,4 +107,18 @@ describe("useApiFetch", () => {
     expect(fetchSpy).toHaveBeenCalled()
     expect(error.value).to.be.null
   })
+
+  test("replaces the exception in case of an error with the response data", async () => {
+    vi.spyOn(window, "fetch").mockResolvedValue(
+      new Response('{"type":"/errors/example"}', { status: 404 }),
+    )
+
+    const { useApiFetch } = await import("@/services/apiService")
+
+    const { error } = useApiFetch("/example", { immediate: true }).json()
+
+    await vi.waitFor(() => {
+      expect(error.value).toEqual({ type: "/errors/example" })
+    })
+  })
 })

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -1,3 +1,4 @@
+import { getFallbackError } from "@/lib/errorResponseMapper"
 import { createFetch, UseFetchReturn } from "@vueuse/core"
 import type { Router } from "vue-router"
 
@@ -90,7 +91,7 @@ export const useApiFetch = createFetch({
       // Since we're only ever interested in the data and never the error object,
       // we'll replace the `fetchContext.error` with the response data so we can
       // access it in the UI.
-      fetchContext.error = fetchContext.data
+      fetchContext.error = fetchContext.data ?? getFallbackError()
 
       return fetchContext
     },

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -77,6 +77,21 @@ export const useApiFetch = createFetch({
         }
       }
 
+      // In the useFetch implementation, `fetchContext.error` is the only thing
+      // that will be provided to the UI by default. This is only an error
+      // object though and access to the response data of an error is not possible.
+      //
+      // There is an option to replace the normal `data` property returned by
+      // useFetch with the error response, but that would mean that `data` can
+      // have different contents depending on the success/failure of the request,
+      // and would require lots of type checking wherever we need to access
+      // the response data.
+      //
+      // Since we're only ever interested in the data and never the error object,
+      // we'll replace the `fetchContext.error` with the response data so we can
+      // access it in the UI.
+      fetchContext.error = fetchContext.data
+
       return fetchContext
     },
   },


### PR DESCRIPTION
In the useFetch implementation, `fetchContext.error` is the only thing that will be provided to the UI by default. This is only an error object though and access to the response data of an error is not possible.

There is an option to replace the normal `data` property returned by useFetch with the error response, but that would mean that `data` can have different contents depending on the success/failure of the request, and would require lots of type checking wherever we need to access the response data.

Since we're only ever interested in the data and never the error object, we'll replace the `fetchContext.error` with the response data so we can access it in the UI.

RISDEV-4669