### PR TITLE
Fix keep reference in new text

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/UpdateNormService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/UpdateNormService.java
@@ -159,7 +159,10 @@ public class UpdateNormService
       .filter(mod -> mod.getEid().isPresent() && mod.getEid().get().equals(query.eId()))
       .findFirst()
       .ifPresent(inTextMod -> {
-        if (inTextMod.usesQuotedText()) {
+        if (
+          inTextMod.usesQuotedText() &&
+          !query.newContent().equals(inTextMod.getNewText().orElse(""))
+        ) {
           inTextMod.setTargetRefHref(query.destinationHref());
           inTextMod.setNewText(query.newContent());
         }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/ModTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/ModTest.java
@@ -100,12 +100,67 @@ class ModTest {
 
   @Test
   void setNewText() {
+    final String QUOTED_TEXT_MOD_WITH_REF =
+      """
+          <akn:mod xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"
+            GUID="148c2f06-6e33-4af8-9f4a-3da67c888510"
+            refersTo="aenderungsbefehl-ersetzen">In <akn:ref eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1"
+               GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206"
+               href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml">§ 20 Absatz 1 Satz 2</akn:ref> wird
+      die Angabe <akn:quotedText eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-1"
+                      GUID="694459c4-ef66-4f87-bb78-a332054a2216"
+                      startQuote="„"
+                      endQuote="“">§ 9 Abs. 1 Satz 2, Abs. 2</akn:quotedText> durch die
+      Wörter <akn:quotedText GUID="c43a085c-536b-457c-b74f-3af9b137b62b" eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quottext-2" endQuote="“" startQuote="„">
+      <akn:ref GUID="83ea9cc4-a1b0-4b6b-8e57-49b00143f1e2" eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quottext-2_ref-1" href="some/crazy/eli">1. Beispiel</akn:ref>
+      </akn:quotedText>
+      ersetzt.</akn:mod>
+      """;
+
+    Mod quotedTextModWithRef = Mod
+      .builder()
+      .node(XmlMapper.toNode(QUOTED_TEXT_MOD_WITH_REF))
+      .build();
     // when
-    quotedTextMod.setNewText("new text");
-    var eid = quotedTextMod.getNewText();
+    quotedTextModWithRef.setNewText("new text");
+    var newText = quotedTextModWithRef.getNewText();
 
     // then
-    assertThat(eid).contains("new text");
+    assertThat(newText).contains("new text");
+  }
+
+  @Test
+  void setNewTextWithGuessedReference() {
+    final String QUOTED_TEXT_MOD_WITH_REF =
+      """
+          <akn:mod xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.6/" eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1"
+            GUID="148c2f06-6e33-4af8-9f4a-3da67c888510"
+            refersTo="aenderungsbefehl-ersetzen">In <akn:ref eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_ref-1"
+               GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206"
+               href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/para-20_abs-1/100-126.xml">§ 20 Absatz 1 Satz 2</akn:ref> wird
+      die Angabe <akn:quotedText eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1_quottext-1"
+                      GUID="694459c4-ef66-4f87-bb78-a332054a2216"
+                      startQuote="„"
+                      endQuote="“">§ 9 Abs. 1 Satz 2, Abs. 2</akn:quotedText> durch die
+      Wörter <akn:quotedText GUID="c43a085c-536b-457c-b74f-3af9b137b62b" eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quottext-2" endQuote="“" startQuote="„">
+      1. <akn:ref GUID="83ea9cc4-a1b0-4b6b-8e57-49b00143f1e2" eId="hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1_quottext-2_ref-1" href="some/crazy/eli">Beispiel</akn:ref>
+      </akn:quotedText>
+      ersetzt.</akn:mod>
+      """;
+
+    Mod quotedTextModWithRef = Mod
+      .builder()
+      .node(XmlMapper.toNode(QUOTED_TEXT_MOD_WITH_REF))
+      .build();
+    // when
+    quotedTextModWithRef.setNewText("new text");
+    var newText = quotedTextModWithRef.getNewText();
+    Node ref = quotedTextModWithRef.getSecondQuotedText().get().getFirstChild();
+
+    // then
+    assertThat(newText).contains("new text");
+    assertThat(ref).isNotNull();
+    assertThat(ref.getNodeName()).isEqualTo("akn:ref");
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/NormControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/NormControllerIntegrationTest.java
@@ -2169,7 +2169,7 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
               XmlMatcher.xml(
                 hasXPath(
                   "//body//mod/quotedText[2]",
-                  equalTo("§ 9 Absatz 1 Satz 2, Absatz 2 oder 3")
+                  containsString("§ 9 Absatz 1 Satz 2, Absatz 2 oder 3")
                 )
               )
             )

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/NormControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/NormControllerIntegrationTest.java
@@ -2168,8 +2168,8 @@ class NormControllerIntegrationTest extends BaseIntegrationTest {
             .value(
               XmlMatcher.xml(
                 hasXPath(
-                  "//body//mod/quotedText[2]",
-                  containsString("§ 9 Absatz 1 Satz 2, Absatz 2 oder 3")
+                  "normalize-space(//body//mod/quotedText[2])",
+                  equalTo("§ 9 Absatz 1 Satz 2, Absatz 2 oder 3")
                 )
               )
             )


### PR DESCRIPTION
- if nothing changes keep "Neuer Text Inhalt"
- if something changes wrap the text in the existing reference

RISDEV-4740