### PR TITLE
Ignore io.sentry:sentry in versionCatalogUpdate

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.adarshr.gradle.testlogger.theme.ThemeType
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import com.github.jk1.license.filter.DependencyFilter
 import com.github.jk1.license.filter.LicenseBundleNormalizer
 import com.github.jk1.license.render.CsvReportRenderer
@@ -144,7 +145,8 @@ tasks {
         useJUnitPlatform { excludeTags("integration") }
     }
 
-    withType(com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask::class) {
+    // Needed to ignore io.sentry:sentry in the task. Adding isStable because default config was being overriden (so that we only get stable versions)
+    withType(DependencyUpdatesTask::class) {
         fun isStable(version: String): Boolean {
             val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.uppercase().contains(it) }
             val regex = "^[0-9,.v-]+(-r)?$".toRegex()
@@ -157,7 +159,7 @@ tasks {
 
     // To avoid having the warning with org.apache.logging.log4j:log4j-core [2.17.1 -> 2.23.0]
     // See https://github.com/ben-manes/gradle-versions-plugin/issues/686#issuecomment-1225322252
-    withType(com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask::class) {
+    withType(DependencyUpdatesTask::class) {
         checkBuildEnvironmentConstraints = false
     }
 
@@ -274,6 +276,19 @@ tasks.named<Checkstyle>("checkstyleMain") {
 tasks.named<Checkstyle>("checkstyleTest") {
     source = sourceSets["test"].allJava
     configFile = rootProject.file("checkstyle/config-test.xml")
+}
+
+tasks.named<DependencyUpdatesTask>("dependencyUpdates").configure {
+    rejectVersionIf {
+        candidate.group == "io.sentry" || (isNonStable(candidate.version) && !isNonStable(currentVersion))
+    }
+}
+
+fun isNonStable(version: String): Boolean {
+    val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.uppercase().contains(it) }
+    val regex = "^[0-9,.v-]+(-r)?$".toRegex()
+    val isStable = stableKeyword || regex.matches(version)
+    return isStable.not()
 }
 
 if (System.getProperty("spring.profiles.active") == "staging") {

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -154,7 +154,7 @@ tasks {
         }
         gradleReleaseChannel = "current"
         revision = "release"
-        rejectVersionIf { !isStable(candidate.version) }
+        rejectVersionIf { !isStable(candidate.version) || candidate.group == "io.sentry" }
     }
 
     // To avoid having the warning with org.apache.logging.log4j:log4j-core [2.17.1 -> 2.23.0]
@@ -276,19 +276,6 @@ tasks.named<Checkstyle>("checkstyleMain") {
 tasks.named<Checkstyle>("checkstyleTest") {
     source = sourceSets["test"].allJava
     configFile = rootProject.file("checkstyle/config-test.xml")
-}
-
-tasks.named<DependencyUpdatesTask>("dependencyUpdates").configure {
-    rejectVersionIf {
-        candidate.group == "io.sentry" || (isNonStable(candidate.version) && !isNonStable(currentVersion))
-    }
-}
-
-fun isNonStable(version: String): Boolean {
-    val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.uppercase().contains(it) }
-    val regex = "^[0-9,.v-]+(-r)?$".toRegex()
-    val isStable = stableKeyword || regex.matches(version)
-    return isStable.not()
 }
 
 if (System.getProperty("spring.profiles.active") == "staging") {

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -155,11 +155,8 @@ tasks {
         gradleReleaseChannel = "current"
         revision = "release"
         rejectVersionIf { !isStable(candidate.version) || candidate.group == "io.sentry" }
-    }
-
-    // To avoid having the warning with org.apache.logging.log4j:log4j-core [2.17.1 -> 2.23.0]
-    // See https://github.com/ben-manes/gradle-versions-plugin/issues/686#issuecomment-1225322252
-    withType(DependencyUpdatesTask::class) {
+        // To avoid having the warning with org.apache.logging.log4j:log4j-core [2.17.1 -> 2.23.0]
+        // See https://github.com/ben-manes/gradle-versions-plugin/issues/686#issuecomment-1225322252
         checkBuildEnvironmentConstraints = false
     }
 


### PR DESCRIPTION
For sentry we are using the sentry jvm gradle plugin, which is resolving the main sentry dependency of `io.sentry:sentry` in version `7.13.0`

But our bi-weekly versionCatalogUpdate is finding a missing update:

```
The following dependencies have later release versions:
 - io.sentry:sentry [7.13.0 -> 7.14.0]
     https://github.com/getsentry/sentry-java
```

Meaning that job will always fail because we are not directly using that dependency but letting the sentry plugin resolve it.

In order to let the version-catalog-task ignore that dependency I have added a custom config for the task in our `build.gradle.kts`. This way we won't get the "missing" update anymore but rather a warning in the output:

```
Failed to determine the latest version for the following dependencies (use --info for details):
 - io.sentry:sentry
     7.13.0
```
Which we can ignore. Our job in the pipeline is only checking for the property `outdated.count`  `build/dependencyUpdates/report.json` and will therefore no longer fail.

One side effect of adding this custom config is that the default behavior of the task not updating to unstable versions is not longer in place. Therefore I manually added the recommended function from the creators of the plugin ([here](https://github.com/ben-manes/gradle-versions-plugin?tab=readme-ov-file#rejectversionsif-and-componentselection)) using the example 2 to disallow release candidates as upgradable versions from stable versions

