### PR TITLE
Endpoint to GET norms by manifestation ELI

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/NormController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/NormController.java
@@ -24,10 +24,10 @@ import org.springframework.web.bind.annotation.*;
 /**
  * Controller for norm-related actions.
  *
- * <p>Path Parameters, they represent the eli of a norm and can be used to create an {@link ExpressionEli}:
- * agent - DE: "Verkündungsblatt" year - DE "Verkündungsjahr" naturalIdentifier - DE: "Seitenzahl /
- * Verkündungsnummer" pointInTime - DE: "Versionsdatum" version - DE: "Versionsnummer" language -
- * DE: "Sprache" subtype - DE: "Dokumentenart"
+ * Path parameters represent the eli of the expression of a norm and can be used to create an
+ * {@link ExpressionEli}: agent - DE: "Verkündungsblatt" year - DE "Verkündungsjahr"
+ * naturalIdentifier - DE: "Seitenzahl / Verkündungsnummer" pointInTime - DE: "Versionsdatum"
+ * version - DE: "Versionsnummer" language - DE: "Sprache" subtype - DE: "Dokumentenart"
  */
 @RestController
 @RequestMapping(
@@ -62,8 +62,7 @@ public class NormController {
   }
 
   /**
-   * Retrieves a norm based on its expression ELI. The ELI's components are interpreted as query
-   * parameters.
+   * Retrieves a norm based on its expression ELI.
    *
    * <p>(German terms are taken from the LDML_de 1.6 specs, p146/147, cf. <a href=
    * "https://github.com/digitalservicebund/ris-norms/commit/17778285381a674f1a2b742ed573b7d3d542ea24">...</a>)
@@ -80,11 +79,7 @@ public class NormController {
   }
 
   /**
-   * Retrieves a norm's xml based on its expression ELI. The ELI's components are interpreted as
-   * query parameters.
-   *
-   * <p>(German terms are taken from the LDML_de 1.6 specs, p146/147, cf. <a href=
-   * "https://github.com/digitalservicebund/ris-norms/commit/17778285381a674f1a2b742ed573b7d3d542ea24">...</a>)
+   * Retrieves a norm's xml based on its expression ELI.
    *
    * @param eli Eli of the request
    * @return A {@link ResponseEntity} containing the retrieved norm's xml.
@@ -97,11 +92,7 @@ public class NormController {
   }
 
   /**
-   * Retrieves a norm's html render based on its expression ELI. The ELI's components are
-   * interpreted as query parameters.
-   *
-   * <p>(German terms are taken from the LDML_de 1.6 specs, p146/147, cf. <a href=
-   * "https://github.com/digitalservicebund/ris-norms/commit/17778285381a674f1a2b742ed573b7d3d542ea24">...</a>)
+   * Retrieves a norm's html render based on its expression ELI.
    *
    * @param eli Eli of the request
    * @param showMetadata Boolean indicating whether to include metadata in the HTML response.
@@ -145,11 +136,7 @@ public class NormController {
   }
 
   /**
-   * Updates the XML representation of an amending law based on its expression ELI. The ELI's
-   * components are interpreted as query parameters.
-   *
-   * <p>(German terms are taken from the LDML_de 1.6 specs, p146/147, cf. <a href=
-   * "https://github.com/digitalservicebund/ris-norms/commit/17778285381a674f1a2b742ed573b7d3d542ea24">...</a>)
+   * Updates the XML representation of an amending law based on its expression ELI.
    *
    * @param eli Eli of the request
    * @param xml - the XML representation of the amending law

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/NormManifestationController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/NormManifestationController.java
@@ -1,0 +1,46 @@
+package de.bund.digitalservice.ris.norms.adapter.input.restapi.controller;
+
+import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
+
+import de.bund.digitalservice.ris.norms.application.port.input.LoadNormXmlUseCase;
+import de.bund.digitalservice.ris.norms.domain.entity.eli.ExpressionEli;
+import de.bund.digitalservice.ris.norms.domain.entity.eli.ManifestationEli;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller for norm-related actions.
+ *
+ * Path parameters represent the eli of the expression of a norm and can be used to create an
+ * {@link ExpressionEli}: agent - DE: "Verkündungsblatt" year - DE "Verkündungsjahr"
+ * naturalIdentifier - DE: "Seitenzahl / Verkündungsnummer" pointInTime - DE: "Versionsdatum"
+ * version - DE: "Versionsnummer" language - DE: "Sprache" subtype - DE: "Dokumentenart"
+ */
+@RestController
+@RequestMapping(
+  "/api/v1/norms/eli/bund/{agent}/{year}/{naturalIdentifier}/{pointInTime}/{version}/{language}/{pointInTimeManifestation}/{subtype}.xml"
+)
+public class NormManifestationController {
+
+  private final LoadNormXmlUseCase loadNormXmlUseCase;
+
+  public NormManifestationController(LoadNormXmlUseCase loadNormXmlUseCase) {
+    this.loadNormXmlUseCase = loadNormXmlUseCase;
+  }
+
+  /**
+   * Retrieves the XML of a norm based on its manifestation ELI.
+   *
+   * @param eli Eli of the request
+   * @return A {@link ResponseEntity} containing the retrieved norm as XML.
+   *     <p>Returns HTTP 200 (OK) and the norm as XML.
+   *     <p>Returns HTTP 404 (Not Found) if the norm is not found.
+   */
+  @GetMapping(produces = { APPLICATION_XML_VALUE })
+  public ResponseEntity<String> getNormManifestationXml(final ManifestationEli eli) {
+    var norm = loadNormXmlUseCase.loadNormXml(new LoadNormXmlUseCase.Query(eli));
+    return ResponseEntity.ok(norm);
+  }
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/LoadNormXmlUseCase.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/input/LoadNormXmlUseCase.java
@@ -1,7 +1,7 @@
 package de.bund.digitalservice.ris.norms.application.port.input;
 
 import de.bund.digitalservice.ris.norms.domain.entity.Norm;
-import de.bund.digitalservice.ris.norms.domain.entity.eli.ExpressionEli;
+import de.bund.digitalservice.ris.norms.domain.entity.eli.Eli;
 import java.util.Optional;
 
 /**
@@ -24,5 +24,5 @@ public interface LoadNormXmlUseCase {
    *
    * @param eli The ELI (European Legislation Identifier) used to identify the norm in the query.
    */
-  record Query(ExpressionEli eli) {}
+  record Query(Eli eli) {}
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/NormManifestationControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/NormManifestationControllerTest.java
@@ -1,0 +1,83 @@
+package de.bund.digitalservice.ris.norms.adapter.input.restapi.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import de.bund.digitalservice.ris.norms.application.port.input.LoadNormXmlUseCase;
+import de.bund.digitalservice.ris.norms.config.SecurityConfig;
+import de.bund.digitalservice.ris.norms.domain.entity.eli.ManifestationEli;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Not using SpringBootTest annotation to avoid needing a database connection. Using @Import to load
+ * the {@link SecurityConfig} in order to avoid http 401 Unauthorised
+ */
+@WebMvcTest(NormManifestationController.class)
+@Import(SecurityConfig.class)
+public class NormManifestationControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private LoadNormXmlUseCase loadNormXmlUseCase;
+
+  @Nested
+  class getNormManifestationXml {
+
+    @Test
+    void itReturnsNorm() throws Exception {
+      // Given
+      var eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-1.xml";
+
+      var xml =
+        """
+          <?xml version="1.0" encoding="UTF-8"?>
+          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+          <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
+                                http://Inhaltsdaten.LegalDocML.de/1.6/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
+            <akn:act name="regelungstext">
+              <!-- Metadaten -->
+              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
+                <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
+                  <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
+                    <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                    <akn:FRBRalias GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="vorherige-version-id" value="49eec691-392b-4d77-abaf-23eb871132ad" />
+                    <akn:FRBRalias GUID="9c086b80-be09-49e6-9230-4932cfe88c83" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="aktuelle-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
+                    <akn:FRBRalias GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" eId="meta-1_ident-1_frbrexpression-1_frbralias-3" name="nachfolgende-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
+                  </akn:FRBRExpression>
+                  <akn:FRBRManifestation eId="meta-1_ident-1_frbrmanifestation-1" GUID="bd2375e5-3e81-435d-a4f8-159d8572c46b">
+                    <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1" GUID="9dcc818e-3ed8-4414-b562-342bd5f405b3" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-1.xml" />
+                    <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1" GUID="f3288a2a-3511-454e-ada1-9de8c33f6dbe" date="1964-08-05" name="generierung" />
+                    <akn:FRBRformat eId="meta-1_ident-1_frbrmanifestation-1_frbrformat-1" GUID="634de2b4-5d14-4144-9e8e-80548da73b73" value="xml" />
+                  </akn:FRBRManifestation>
+                </akn:identification>
+              </akn:meta>
+            </akn:act>
+          </akn:akomaNtoso>
+        """;
+
+      // When
+      when(loadNormXmlUseCase.loadNormXml(any())).thenReturn(xml);
+
+      // When // Then
+      mockMvc
+        .perform(get("/api/v1/norms/{manifestationEli}", eli).accept(MediaType.APPLICATION_XML))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
+
+      verify(loadNormXmlUseCase, times(1))
+        .loadNormXml(new LoadNormXmlUseCase.Query(ManifestationEli.fromString(eli)));
+    }
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/NormManifestationControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/NormManifestationControllerIntegrationTest.java
@@ -1,0 +1,103 @@
+package de.bund.digitalservice.ris.norms.integration.adapter.input.restapi;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.NormMapper;
+import de.bund.digitalservice.ris.norms.adapter.output.database.repository.NormRepository;
+import de.bund.digitalservice.ris.norms.domain.entity.NormFixtures;
+import de.bund.digitalservice.ris.norms.integration.BaseIntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+public class NormManifestationControllerIntegrationTest extends BaseIntegrationTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private NormRepository normRepository;
+
+  @AfterEach
+  void cleanUp() {
+    normRepository.deleteAll();
+  }
+
+  @Nested
+  class getNormManifestationXml {
+
+    @Test
+    void itCallsNormServiceAndReturnsNormXml() throws Exception {
+      // Given
+      normRepository.save(NormMapper.mapToDto(NormFixtures.loadFromDisk("SimpleNorm.xml")));
+      var eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-1.xml";
+
+      // When // Then
+      mockMvc
+        .perform(get("/api/v1/norms/{eli}", eli).accept(MediaType.APPLICATION_XML))
+        .andExpect(status().isOk())
+        .andExpect(
+          xpath("//*[@eId='meta-1_ident-1_frbrmanifestation-1_frbrthis-1']/@value").string(eli)
+        );
+    }
+
+    @Test
+    void itReturnsNotFoundIfManifestationDoesntExist() throws Exception {
+      // Given
+      // No norm
+      var eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-1.xml";
+
+      // When // Then
+      mockMvc
+        .perform(get("/api/v1/norms/{eli}", eli).accept(MediaType.APPLICATION_XML))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("type").value("/errors/norm-not-found"))
+        .andExpect(jsonPath("title").value("Norm not found"))
+        .andExpect(jsonPath("status").value(404))
+        .andExpect(
+          jsonPath("detail")
+            .value(
+              "Norm with eli eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-1.xml does not exist"
+            )
+        )
+        .andExpect(
+          jsonPath("instance")
+            .value(
+              "/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-1.xml"
+            )
+        )
+        .andExpect(jsonPath("eli").value(eli));
+    }
+
+    @Test
+    void itReturnsNotFoundIfTypeIsNotXml() throws Exception {
+      // Given
+      normRepository.save(NormMapper.mapToDto(NormFixtures.loadFromDisk("SimpleNorm.xml")));
+      var eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-1.pdf";
+
+      // When // Then
+      mockMvc
+        .perform(get("/api/v1/norms/{eli}", eli))
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("type").value("/errors/internal-server-error"))
+        .andExpect(jsonPath("title").value("Internal Server Error"))
+        .andExpect(jsonPath("status").value(500))
+        .andExpect(
+          jsonPath("detail")
+            .value(
+              "No static resource api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-1.pdf."
+            )
+        )
+        .andExpect(
+          jsonPath("instance")
+            .value(
+              "/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-1.pdf"
+            )
+        );
+    }
+  }
+}

--- a/doc/backend/norms-api-v1.yaml
+++ b/doc/backend/norms-api-v1.yaml
@@ -62,14 +62,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /announcements/{eli}/release:
+  /announcements/{expressionEli}/release:
     get:
-      summary: Get the latest release of a specific announcement by the amending law eli
+      summary: Get the latest release of a specific announcement by the expression ELI of the amending law.
       parameters:
-        - name: eli
+        - name: expressionEli
           in: path
           required: true
-          description: ELI of the amending law
+          description: Expression ELI of the amending law
           schema:
             type: string
       responses:
@@ -92,12 +92,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
     put:
-      summary: Release the XML of a specific announcement by the amending law eli
+      summary: Release the XML of a specific announcement the expression ELI of the amending law.
       parameters:
-        - name: eli
+        - name: expressionEli
           in: path
           required: true
-          description: ELI of the amending law
+          description: Expression ELI of the amending law
           schema:
             type: string
       responses:
@@ -120,14 +120,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /norms/{eli}:
+  /norms/{expressionEli}:
     get:
-      summary: Get a specific norm by eli
+      summary: Get a specific norm by its expression ELI.
       parameters:
-        - name: eli
+        - name: expressionEli
           in: path
           required: true
-          description: ELI of the norm
+          description: Expression ELI of the norm
           schema:
             type: string
         - name: showMetadata
@@ -168,12 +168,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
     put:
-      summary: Update a specific norm by eli
+      summary: Update a specific norm by its expression ELI.
       parameters:
-        - name: eli
+        - name: expressionEli
           in: path
           required: true
-          description: ELI of the norm
+          description: Expression ELI of the norm
           schema:
             type: string
       requestBody:
@@ -203,21 +203,52 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /norms/{eli}/elements:
+  /norms/{manifestationEli}:
+    get:
+      summary: Get a specific norm by its manifestation ELI.
+      parameters:
+        - name: manifestationEli
+          in: path
+          required: true
+          description: Manifestation ELI of the norm. Currently only `xml` is supported as the format.
+          example: "eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/2023-12-30/regelungstext-1.xml"
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The requested norm. The response format depends on the format as specified in the manifestation ELI.
+          content:
+            'application/xml':
+              schema:
+                $ref: '#/components/schemas/LegalDocML.de'
+        '404':
+          description: Norm not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '500':
+          description: Internal server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+
+  /norms/{expressionEli}/elements:
     get:
       summary: Get a norm's elements, filtered by the elements' types
       parameters:
-        - name: eli
+        - name: expressionEli
           in: path
           required: true
-          description: ELI of the norm
+          description: Expression ELI of the norm
           example: "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1"
           schema:
             type: string
         - name: type
           in: query
           required: true
-          description: Type(s) of elements to include in the result.
+          description: Type(s) of elements to include in the result
           schema:
             type: array
             items:
@@ -226,7 +257,7 @@ paths:
         - name: amendedBy
           in: query
           required: false
-          description: ELI of an amending law. The result is restricted to elements that are affected by that law. <br>Note that the validity of that ELI is not checked by this endpoint.
+          description: Expression ELI of an amending law. The result is restricted to elements that are affected by that law. <br>Note that the validity of that ELI is not checked by this endpoint.
           schema:
             type: string
           example: "eli/bund/bgbl-1/2017/s815/1995-03-15/1/deu/regelungstext-1"
@@ -252,14 +283,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /norms/{eli}/elements/{eid}:
+  /norms/{expressionEli}/elements/{eid}:
     get:
       summary: Get a single element inside a norm
       parameters:
-        - name: eli
+        - name: expressionEli
           in: path
           required: true
-          description: ELI of the norm
+          description: Expression ELI of the norm
           example: "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1"
           schema:
             type: string
@@ -301,14 +332,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /norms/{eli}/articles:
+  /norms/{expressionEli}/articles:
     get:
-      summary: Get a list of articles for a specific norm by eli
+      summary: Get a list of articles for a specific norm by its expression ELI.
       parameters:
-        - name: eli
+        - name: expressionEli
           in: path
           required: true
-          description: ELI of the norm
+          description: Expression ELI of the norm
           schema:
             type: string
         - name: refersTo
@@ -320,7 +351,7 @@ paths:
         - name: amendedBy
           in: query
           required: false
-          description: "Filter the articles to articles amended by the given norm. Must be the eli of the amending norm. Requires amendedAt. Only for `Content-Type: application/json`"
+          description: "Filter the articles to articles amended by the given norm. Must be the expression ELI of the amending norm. Requires amendedAt. Only for `Content-Type: application/json`"
           schema:
             type: string
         - name: amendedAt
@@ -348,20 +379,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /norms/{eli}/articles/{eid}:
+  /norms/{expressionEli}/articles/{eid}:
     get:
       summary: Get a specific article by eid for a given norm
       parameters:
-        - name: eli
+        - name: expressionEli
           in: path
           required: true
-          description: ELI of the norm
+          description: Expression ELI of the norm
           schema:
             type: string
         - name: eid
           in: path
           required: true
-          description: EID of the article
+          description: eId of the article
           schema:
             type: string
         - name: atIsoDate
@@ -387,14 +418,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /norms/{eli}/mods:
+  /norms/{expressionEli}/mods:
     patch:
       summary: Save changes to multiple akn:mod elements and update ZF0
       parameters:
-        - name: eli
+        - name: expressionEli
           in: path
           required: true
-          description: ELI of the norm
+          description: Expression ELI of the norm
           schema:
             type: string
         - name: dryRun
@@ -448,20 +479,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /norms/{eli}/mods/{eid}:
+  /norms/{expressionEli}/mods/{eid}:
     put:
       summary: Save an amending command and update ZF0
       parameters:
-        - name: eli
+        - name: expressionEli
           in: path
           required: true
-          description: ELI of the norm
+          description: Expression ELI of the norm
           schema:
             type: string
         - name: eid
           in: path
           required: true
-          description: the eId of the akn:mod
+          description: The eId of the akn:mod
           schema:
             type: string
         - name: dryRun
@@ -508,14 +539,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /norms/{eli}/timeBoundaries:
+  /norms/{expressionEli}/timeBoundaries:
     get:
       summary: Get all time boundaries for a given norm
       parameters:
-        - name: eli
+        - name: expressionEli
           in: path
           required: true
-          description: ELI of the norm
+          description: Expression ELI of the norm
           schema:
             type: string
       responses:
@@ -536,10 +567,10 @@ paths:
     put:
       summary: Update all time boundaries for a given norm
       parameters:
-        - name: eli
+        - name: expressionEli
           in: path
           required: true
-          description: ELI of the norm
+          description: Expression ELI of the norm
           schema:
             type: string
       requestBody:
@@ -573,20 +604,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /norms/{eli}/proprietary/{eid}/{atDate}:
+  /norms/{expressionEli}/proprietary/{eid}/{atDate}:
     get:
       summary: Get the proprietary metadata of a single element at the specified date
       parameters:
-        - name: eli
+        - name: expressionEli
           in: path
           required: true
-          description: ELI of the norm
+          description: Expression ELI of the norm
           schema:
             type: string
         - name: eid
           in: path
           required: true
-          description: the eId of the selected single element
+          description: The eId of the selected single element
           schema:
             type: string
         - name: atDate
@@ -614,16 +645,16 @@ paths:
       tags:
         - under construction
       parameters:
-        - name: eli
+        - name: expressionEli
           in: path
           required: false
-          description: ELI of the norm
+          description: Expression ELI of the norm
           schema:
             type: string
         - name: eid
           in: path
           required: true
-          description: the eId of the selected single element
+          description: The eId of the selected single element
           schema:
             type: string
         - name: atDate
@@ -654,21 +685,21 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
 
-  /norms/{eli}/{eid}:
+  /norms/{expressionEli}/{eid}:
     get:
-      summary: Get an element of a norm by its EID (currently only in HTML preview format)
+      summary: Get an element of a norm by its eId (currently only in HTML preview format)
       parameters:
-        - name: eli
+        - name: expressionEli
           in: path
           required: true
-          description: ELI of the norm
+          description: Expression ELI of the norm
           schema:
             type: string
             example: eli/bund/bgbl-1/2017/s815/1995-03-15/1/deu/regelungstext-1
         - name: eid
           in: path
           required: true
-          description: EID of the element in the norm
+          description: eId of the element in the norm
           schema:
             type: string
             example: hauptteil-1_art-3


### PR DESCRIPTION
I chose to add a new controller for this rather than adding it to the
norms controller because the norm controller currently always expects
expression ELIs. Changing this to support both expression and
manifestation ELIs would mean a bunch of changes to the existing
endpoints, as well as extra boilerplate because we can't use the
controller-level path mapping anymore.

In addition, the manifestation ELI-based endpoints have slightly
different semantics (e.g. the file type will not be provided through a
content header, but by the format property of the ELI).

RISDEV-5107