### PR TITLE
Linter fixes

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -10,7 +10,7 @@ fileignoreconfig:
   - filename: frontend/Dockerfile
     checksum: 0db2e063587f46b2150f978f8dd9c5ce3d001fa8b89a1b67904f7a8363a6bd2a
   - filename: frontend/src/components/controls/RisNavbarSide.spec.ts
-    checksum: a71106dff57951e5d873a7e5cfe6f407b71e832b0b73072328c7577412f8d2f6
+    checksum: e252d2546a75459a49ac1c4073dd76a3a48861b64843b11fa8271b675490cfd8
   - filename: DockerfileApp
     checksum: 79dcfe570176f7ad6b8341bd0b358b2676355b34ba654c29ae267d54a03f7e64
   - filename: docker-compose.yaml

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -13,6 +13,7 @@ import {
   configs as tsEslintConfigs,
 } from "typescript-eslint"
 import vueEslintParser from "vue-eslint-parser"
+import testingLibraryPlugin from "eslint-plugin-testing-library"
 
 export default defineConfig(
   // Files
@@ -32,6 +33,12 @@ export default defineConfig(
   {
     files: ["e2e/**/*.ts"],
     ...playwrightPlugin.configs["flat/recommended"],
+  },
+
+  // Additional rules for unit tests
+  {
+    files: ["src/**/*.spec.ts"],
+    ...testingLibraryPlugin.configs["flat/vue"],
   },
 
   {

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,9 +1,11 @@
 import { includeIgnoreFile } from "@eslint/compat"
 import js from "@eslint/js"
+import vitest from "@vitest/eslint-plugin"
 import prettierConfig from "@vue/eslint-config-prettier"
 import vueTsEslintConfig from "@vue/eslint-config-typescript"
 import importPlugin from "eslint-plugin-import"
 import playwrightPlugin from "eslint-plugin-playwright"
+import testingLibraryPlugin from "eslint-plugin-testing-library"
 import vuePlugin from "eslint-plugin-vue"
 import vueA11yPlugin from "eslint-plugin-vuejs-accessibility"
 import globals from "globals"
@@ -13,7 +15,6 @@ import {
   configs as tsEslintConfigs,
 } from "typescript-eslint"
 import vueEslintParser from "vue-eslint-parser"
-import testingLibraryPlugin from "eslint-plugin-testing-library"
 
 export default defineConfig(
   // Files
@@ -36,9 +37,17 @@ export default defineConfig(
   },
 
   // Additional rules for unit tests
+  // Note that in order to avoid conflicts or plugins replacing parts of each
+  // other, this needs to be two separate blocks. Also the vitest plugin must
+  // be called `vitest`, otherwise it will break ¯\_(ツ)_/¯
   {
     files: ["src/**/*.spec.ts"],
     ...testingLibraryPlugin.configs["flat/vue"],
+  },
+  {
+    files: ["src/**/*.spec.ts"],
+    plugins: { vitest },
+    rules: { ...vitest.configs.recommended.rules },
   },
 
   {
@@ -116,6 +125,14 @@ export default defineConfig(
       // might need to create a bunch of wrapper components / advanced
       // examples to test certain types of behavior (e.g. slots).
       "vue/one-component-per-file": "off",
+
+      // Test format (naming and method use) should be consistent
+      "vitest/consistent-test-it": "error",
+      "vitest/prefer-lowercase-title": "error",
+
+      // Hooks should be easy to find
+      "vitest/prefer-hooks-in-order": "error",
+      "vitest/prefer-hooks-on-top": "error",
     },
   },
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -50,6 +50,7 @@
         "eslint-import-resolver-typescript": "^3.6.3",
         "eslint-plugin-import": "~2.31.0",
         "eslint-plugin-playwright": "~2.0.0",
+        "eslint-plugin-testing-library": "^6.4.0",
         "eslint-plugin-vue": "~9.30.0",
         "eslint-plugin-vuejs-accessibility": "~2.4.0",
         "globals": "^15.10.0",
@@ -2226,6 +2227,13 @@
         "undici-types": "~6.19.8"
       }
     },
+    "node_modules/@types/semver": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
@@ -3152,6 +3160,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/array.prototype.findlastindex": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz",
@@ -3982,6 +4000,19 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -4634,6 +4665,165 @@
         }
       }
     },
+    "node_modules/eslint-plugin-testing-library": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-6.4.0.tgz",
+      "integrity": "sha512-yeWF+YgCgvNyPNI9UKnG0FjeE2sk93N/3lsKqcmR8dSfeXJwFT5irnWo7NjLf152HkRzfoFjh3LsBUrhvFz4eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/types": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/utils": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/eslint-plugin-vue": {
       "version": "9.30.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.30.0.tgz",
@@ -5268,6 +5458,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {
@@ -7293,6 +7504,16 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pathe": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
@@ -8235,6 +8456,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
@@ -8947,6 +9178,29 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tsutils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true,
       "license": "0BSD"
     },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,6 +41,7 @@
         "@typescript-eslint/parser": "~8.12.0",
         "@vitejs/plugin-vue": "~5.1.0",
         "@vitest/coverage-v8": "~2.1.0",
+        "@vitest/eslint-plugin": "^1.1.7",
         "@vue/eslint-config-prettier": "~10.1.0",
         "@vue/eslint-config-typescript": "~14.1.0",
         "autoprefixer": "~10.4.19",
@@ -2504,6 +2505,27 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/@vitest/eslint-plugin": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.1.7.tgz",
+      "integrity": "sha512-pTWGW3y6lH2ukCuuffpan6kFxG6nIuoesbhMiQxskyQMRcCN5t9SXsKrNHvEw3p8wcCsgJoRqFZVkOTn6TjclA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typescript-eslint/utils": ">= 8.0",
+        "eslint": ">= 8.57.0",
+        "typescript": ">= 5.0.0",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/expect": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,6 +62,7 @@
     "@typescript-eslint/parser": "~8.12.0",
     "@vitejs/plugin-vue": "~5.1.0",
     "@vitest/coverage-v8": "~2.1.0",
+    "@vitest/eslint-plugin": "^1.1.7",
     "@vue/eslint-config-prettier": "~10.1.0",
     "@vue/eslint-config-typescript": "~14.1.0",
     "autoprefixer": "~10.4.19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,6 +71,7 @@
     "eslint-import-resolver-typescript": "^3.6.3",
     "eslint-plugin-import": "~2.31.0",
     "eslint-plugin-playwright": "~2.0.0",
+    "eslint-plugin-testing-library": "^6.4.0",
     "eslint-plugin-vue": "~9.30.0",
     "eslint-plugin-vuejs-accessibility": "~2.4.0",
     "globals": "^15.10.0",

--- a/frontend/src/components/RisCharacterRangeSelect.spec.ts
+++ b/frontend/src/components/RisCharacterRangeSelect.spec.ts
@@ -14,7 +14,7 @@ describe("RisCharacterRangeSelect", () => {
 
   it("supports selecting text", async () => {
     const user = userEvent.setup()
-    const result = render(RisCharacterRangeSelect, {
+    const { emitted } = render(RisCharacterRangeSelect, {
       props: {
         render: "<span data-eId='span-1'>Test</span>",
         xml: `<akn:akonaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" ><akn:span eId="span-1">Test</akn:span></akn:akonaNtoso>`,
@@ -33,8 +33,8 @@ describe("RisCharacterRangeSelect", () => {
       { keys: "[/MouseLeft]" },
     ])
 
-    expect(result.emitted("update:modelValue")).toHaveLength(1)
-    expect(result.emitted("update:modelValue")[0]).toContain("span-1/1-3.xml")
+    expect(emitted("update:modelValue")).toHaveLength(1)
+    expect(emitted("update:modelValue")[0]).toContain("span-1/1-3.xml")
   })
 
   // we can't test the highlight stuff as it is not supported by jsdom

--- a/frontend/src/components/RisCharacterRangeSelect.spec.ts
+++ b/frontend/src/components/RisCharacterRangeSelect.spec.ts
@@ -1,9 +1,9 @@
-import { render, screen } from "@testing-library/vue"
-import { describe, expect, it } from "vitest"
 import RisCharacterRangeSelect from "@/components/RisCharacterRangeSelect.vue"
 import { userEvent } from "@testing-library/user-event"
+import { render, screen } from "@testing-library/vue"
+import { describe, expect, it } from "vitest"
 
-describe("RisCharacterRangeSelect", () => {
+describe("risCharacterRangeSelect", () => {
   it("renders the norm html", async () => {
     render(RisCharacterRangeSelect, {
       props: { render: "<span>TEST</span>", xml: "<akn:span>Test</akn:span>" },

--- a/frontend/src/components/RisEmptyState.spec.ts
+++ b/frontend/src/components/RisEmptyState.spec.ts
@@ -1,11 +1,11 @@
 import { render, screen } from "@testing-library/vue"
-import { describe, expect, test } from "vitest"
+import { describe, expect, it } from "vitest"
+import { markRaw } from "vue"
 import UploadFileOutlineRounded from "~icons/ic/baseline-upload-file"
 import RisEmptyState from "./RisEmptyState.vue"
-import { markRaw } from "vue"
 
-describe("RisEmptyState", () => {
-  test("should render text content", () => {
+describe("risEmptyState", () => {
+  it("should render text content", () => {
     render(RisEmptyState, {
       props: { textContent: "Hello, world!" },
     })
@@ -13,7 +13,7 @@ describe("RisEmptyState", () => {
     expect(screen.getByText("Hello, world!")).toBeInTheDocument()
   })
 
-  test("should render the recommended action", () => {
+  it("should render the recommended action", () => {
     render(RisEmptyState, {
       props: { textContent: "No announcements available" },
       slots: { "recommended-action": "Add new announcements" },
@@ -23,7 +23,7 @@ describe("RisEmptyState", () => {
     expect(screen.getByText("Add new announcements")).toBeInTheDocument()
   })
 
-  test("should render the icon", () => {
+  it("should render the icon", () => {
     render(RisEmptyState, {
       props: {
         textContent: "No announcements available",
@@ -34,7 +34,7 @@ describe("RisEmptyState", () => {
     expect(screen.getByTestId("empty-state-icon")).toBeInTheDocument()
   })
 
-  test("should detect the simple variant based on the props", () => {
+  it("should detect the simple variant based on the props", () => {
     render(RisEmptyState, {
       props: { textContent: "No announcements available" },
     })
@@ -45,7 +45,7 @@ describe("RisEmptyState", () => {
     )
   })
 
-  test("should detect the extended variant based on the props", () => {
+  it("should detect the extended variant based on the props", () => {
     render(RisEmptyState, {
       props: {
         textContent: "No announcements available",

--- a/frontend/src/components/RisEmptyState.spec.ts
+++ b/frontend/src/components/RisEmptyState.spec.ts
@@ -20,18 +20,18 @@ describe("RisEmptyState", () => {
     })
 
     expect(screen.getByText("No announcements available")).toBeInTheDocument()
-    expect(screen.queryByText("Add new announcements")).toBeInTheDocument()
+    expect(screen.getByText("Add new announcements")).toBeInTheDocument()
   })
 
   test("should render the icon", () => {
-    const { container } = render(RisEmptyState, {
+    render(RisEmptyState, {
       props: {
         textContent: "No announcements available",
         icon: markRaw(UploadFileOutlineRounded),
       },
     })
 
-    expect(container.querySelector("svg")).toBeInTheDocument()
+    expect(screen.getByTestId("empty-state-icon")).toBeInTheDocument()
   })
 
   test("should detect the simple variant based on the props", () => {

--- a/frontend/src/components/RisEmptyState.vue
+++ b/frontend/src/components/RisEmptyState.vue
@@ -25,6 +25,7 @@ const variant = computed<"simple" | "extended">(() =>
     <component
       :is="icon"
       v-if="icon"
+      data-testid="empty-state-icon"
       class="ds-button-icon mx-auto mb-16 text-4xl text-blue-700"
     />
 

--- a/frontend/src/components/RisLawPreview.spec.ts
+++ b/frontend/src/components/RisLawPreview.spec.ts
@@ -1,5 +1,5 @@
 import { userEvent } from "@testing-library/user-event"
-import { render, screen, waitFor } from "@testing-library/vue"
+import { render, screen } from "@testing-library/vue"
 import { describe, expect, test, vi } from "vitest"
 import { nextTick } from "vue"
 import RisLawPreview from "./RisLawPreview.vue"
@@ -26,7 +26,7 @@ describe("RisLawPreview", () => {
       },
     })
 
-    await waitFor(() => screen.getByRole("button"))
+    await screen.findByRole("button")
     await userEvent.click(screen.getByRole("button", { name: "MOD" }))
 
     expect(handler).toHaveBeenCalledWith({
@@ -51,7 +51,7 @@ describe("RisLawPreview", () => {
       },
     })
 
-    await waitFor(() => screen.getByRole("button"))
+    await screen.findByRole("button")
 
     await user.tab()
     await user.tab()
@@ -80,7 +80,7 @@ describe("RisLawPreview", () => {
       },
     })
 
-    await waitFor(() => screen.getByRole("button"))
+    await screen.findByRole("button")
 
     await user.tab()
     await user.keyboard("{ArrowDown}")
@@ -113,7 +113,7 @@ describe("RisLawPreview", () => {
       },
     })
 
-    await waitFor(() => screen.getAllByRole("button"))
+    await screen.findAllByRole("button")
 
     await user.tab()
 
@@ -158,7 +158,7 @@ describe("RisLawPreview", () => {
       },
     })
 
-    await waitFor(() => screen.getAllByRole("button"))
+    await screen.findAllByRole("button")
 
     await user.tab()
 
@@ -187,7 +187,7 @@ describe("RisLawPreview", () => {
       },
     })
 
-    await waitFor(() => screen.getAllByRole("button"))
+    await screen.findAllByRole("button")
 
     await user.tab()
 
@@ -222,7 +222,7 @@ describe("RisLawPreview", () => {
       },
     })
 
-    await waitFor(() => screen.getAllByRole("button"))
+    await screen.findAllByRole("button")
 
     await user.tab()
 
@@ -255,7 +255,7 @@ describe("RisLawPreview", () => {
       },
     })
 
-    await waitFor(() => screen.getAllByRole("button"))
+    await screen.findAllByRole("button")
 
     await user.tab()
 
@@ -284,7 +284,7 @@ describe("RisLawPreview", () => {
       },
     })
 
-    await waitFor(() => screen.getAllByRole("button"))
+    await screen.findAllByRole("button")
 
     const textbox = screen.getByRole("textbox")
     expect(textbox).not.toHaveAttribute("aria-activedescendant")
@@ -309,12 +309,12 @@ describe("RisLawPreview", () => {
       },
     })
 
-    await waitFor(() => screen.getByText("MOD"))
+    await screen.findByText("MOD")
     expect(screen.getByText("MOD")).toHaveClass("selected")
   })
 
   test("should update selected elements", async () => {
-    const renderResult = render(RisLawPreview, {
+    const { rerender } = render(RisLawPreview, {
       props: {
         content:
           "<div><span class='longTitle'>Test Title</span><div class='akn-mod' data-eId='hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1' data-GUID='148c2f06-6e33-4af8-9f4a-3da67c888510'>MOD</div></div>",
@@ -322,23 +322,23 @@ describe("RisLawPreview", () => {
       },
     })
 
-    await waitFor(() => screen.getByText("MOD"))
+    await screen.findByText("MOD")
     expect(screen.getByText("MOD")).not.toHaveClass("selected")
 
-    await renderResult.rerender({
+    await rerender({
       selected: [
         "hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1",
       ],
     })
 
-    await waitFor(() => screen.getByText("MOD"))
+    await screen.findByText("MOD")
     expect(screen.getByText("MOD")).toHaveClass("selected")
   })
 
   test("should support changing the content", async () => {
     const handler = vi.fn()
 
-    const renderResult = render(RisLawPreview, {
+    const { rerender } = render(RisLawPreview, {
       props: {
         content:
           "<div><span class='longTitle'>Test Title</span><div class='akn-mod' data-eId='hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1' data-GUID='148c2f06-6e33-4af8-9f4a-3da67c888510'>MOD</div></div>",
@@ -351,17 +351,17 @@ describe("RisLawPreview", () => {
       },
     })
 
-    await waitFor(() => screen.getByRole("button"))
+    await screen.findByRole("button")
     await userEvent.click(screen.getByRole("button", { name: "MOD" }))
     expect(screen.getByText("MOD")).toHaveClass("selected")
 
-    await renderResult.rerender({
+    await rerender({
       content:
         "<div><span class='longTitle'>Test Title 2</span><div class='akn-mod' data-eId='hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1' data-GUID='148c2f06-6e33-4af8-9f4a-3da67c888510'>CHANGED MOD</div></div>",
     })
 
     expect(screen.getByText("Test Title 2")).toBeInTheDocument()
-    await waitFor(() => screen.getByRole("button"))
+    await screen.findByRole("button")
 
     expect(screen.getByText("CHANGED MOD")).toHaveClass("selected")
     await userEvent.click(screen.getByRole("button", { name: "CHANGED MOD" }))
@@ -370,7 +370,7 @@ describe("RisLawPreview", () => {
   })
 
   test("should set and update classes of element with the specified eId", async () => {
-    const renderResult = render(RisLawPreview, {
+    const { rerender } = render(RisLawPreview, {
       props: {
         content:
           "<div><span class='longTitle'>Test Title</span><div class='akn-mod' data-eId='hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1' data-GUID='148c2f06-6e33-4af8-9f4a-3da67c888510'>MOD</div></div>",
@@ -385,7 +385,7 @@ describe("RisLawPreview", () => {
     expect(screen.getByText("MOD")).toHaveClass("class-1")
     expect(screen.getByText("MOD")).toHaveClass("class-2")
 
-    await renderResult.rerender({
+    await rerender({
       eIdClasses: {
         "hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1":
           ["class-3", "class-2"],

--- a/frontend/src/components/RisLawPreview.spec.ts
+++ b/frontend/src/components/RisLawPreview.spec.ts
@@ -1,11 +1,11 @@
 import { userEvent } from "@testing-library/user-event"
 import { render, screen } from "@testing-library/vue"
-import { describe, expect, test, vi } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { nextTick } from "vue"
 import RisLawPreview from "./RisLawPreview.vue"
 
-describe("RisLawPreview", () => {
-  test("should render provided content", () => {
+describe("risLawPreview", () => {
+  it("should render provided content", () => {
     render(RisLawPreview, {
       props: { content: "<span class='longTitle'>Test Title</span>" },
     })
@@ -13,7 +13,7 @@ describe("RisLawPreview", () => {
     expect(screen.getByText("Test Title").className).contain("longTitle")
   })
 
-  test("should emit click event", async () => {
+  it("should emit click event", async () => {
     const handler = vi.fn()
 
     render(RisLawPreview, {
@@ -36,7 +36,7 @@ describe("RisLawPreview", () => {
     })
   })
 
-  test("should emit click event when using keyboard navigation without arrows", async () => {
+  it("should emit click event when using keyboard navigation without arrows", async () => {
     const user = userEvent.setup()
     const handler = vi.fn()
 
@@ -66,7 +66,7 @@ describe("RisLawPreview", () => {
     })
   })
 
-  test("should emit click event when using keyboard navigation with arrows", async () => {
+  it("should emit click event when using keyboard navigation with arrows", async () => {
     const user = userEvent.setup()
     const handler = vi.fn()
 
@@ -95,7 +95,7 @@ describe("RisLawPreview", () => {
     })
   })
 
-  test("should move the focus up and down then using keyboard navigation with arrows", async () => {
+  it("should move the focus up and down then using keyboard navigation with arrows", async () => {
     const user = userEvent.setup()
     const handler = vi.fn()
 
@@ -140,7 +140,7 @@ describe("RisLawPreview", () => {
     expect(screen.getByRole("button", { name: "MOD1" })).toHaveClass("focused")
   })
 
-  test("should not move the focus before the first element", async () => {
+  it("should not move the focus before the first element", async () => {
     const user = userEvent.setup()
     const handler = vi.fn()
 
@@ -169,7 +169,7 @@ describe("RisLawPreview", () => {
     expect(screen.getByRole("button", { name: "MOD1" })).toHaveClass("focused")
   })
 
-  test("should not move the focus past the last element", async () => {
+  it("should not move the focus past the last element", async () => {
     const user = userEvent.setup()
     const handler = vi.fn()
 
@@ -204,7 +204,7 @@ describe("RisLawPreview", () => {
     expect(screen.getByRole("button", { name: "MOD3" })).toHaveClass("focused")
   })
 
-  test("should automatically focus the selected element", async () => {
+  it("should automatically focus the selected element", async () => {
     const user = userEvent.setup()
     const handler = vi.fn()
 
@@ -238,7 +238,7 @@ describe("RisLawPreview", () => {
     expect(screen.getByRole("button", { name: "MOD3" })).toHaveClass("focused")
   })
 
-  test("should focus the clicked on element", async () => {
+  it("should focus the clicked on element", async () => {
     const user = userEvent.setup()
 
     render(RisLawPreview, {
@@ -266,7 +266,7 @@ describe("RisLawPreview", () => {
     expect(screen.getByRole("button", { name: "MOD3" })).toHaveClass("focused")
   })
 
-  test("should set the active descendant", async () => {
+  it("should set the active descendant", async () => {
     const user = userEvent.setup()
     const handler = vi.fn()
 
@@ -298,7 +298,7 @@ describe("RisLawPreview", () => {
     expect(textbox).toHaveAttribute("aria-activedescendant", selected.id)
   })
 
-  test("should have .selected class for selected elements", async () => {
+  it("should have .selected class for selected elements", async () => {
     render(RisLawPreview, {
       props: {
         content:
@@ -313,7 +313,7 @@ describe("RisLawPreview", () => {
     expect(screen.getByText("MOD")).toHaveClass("selected")
   })
 
-  test("should update selected elements", async () => {
+  it("should update selected elements", async () => {
     const { rerender } = render(RisLawPreview, {
       props: {
         content:
@@ -335,7 +335,7 @@ describe("RisLawPreview", () => {
     expect(screen.getByText("MOD")).toHaveClass("selected")
   })
 
-  test("should support changing the content", async () => {
+  it("should support changing the content", async () => {
     const handler = vi.fn()
 
     const { rerender } = render(RisLawPreview, {
@@ -369,7 +369,7 @@ describe("RisLawPreview", () => {
     expect(handler).toHaveBeenCalledTimes(2)
   })
 
-  test("should set and update classes of element with the specified eId", async () => {
+  it("should set and update classes of element with the specified eId", async () => {
     const { rerender } = render(RisLawPreview, {
       props: {
         content:

--- a/frontend/src/components/RisModForm.spec.ts
+++ b/frontend/src/components/RisModForm.spec.ts
@@ -38,7 +38,7 @@ describe("risModForm", () => {
     })
 
     // Form
-    const formElement = screen.getByRole("form")
+    const formElement = screen.getByTestId("mod-form")
     expect(formElement).toBeInTheDocument()
 
     // Textual Mode Type

--- a/frontend/src/components/RisModForm.spec.ts
+++ b/frontend/src/components/RisModForm.spec.ts
@@ -13,7 +13,7 @@ vi.mock("primevue/usetoast", () => {
   }
 })
 
-describe("RisModForm", () => {
+describe("risModForm", () => {
   const textualModType: ModType = "aenderungsbefehl-ersetzen"
   const timeBoundaries = [
     { date: "2024-12-31", temporalGroupEid: "eid-1" },
@@ -27,7 +27,7 @@ describe("RisModForm", () => {
   const quotedStructureContent = "<quotedStructure>content</quotedStructure>"
   const targetLawHtml = "<p>Target Law Content</p>"
 
-  it("Should render the form with only mandatory fields", async () => {
+  it("should render the form with only mandatory fields", async () => {
     const user = userEvent.setup()
     render(RisModForm, {
       props: {
@@ -93,7 +93,7 @@ describe("RisModForm", () => {
     expect(quotedTextSecondElement).not.toHaveAttribute("readonly")
   })
 
-  it("Should render the form with conditional fields for when textualModType === 'aenderungsbefehl-ersetzen'", () => {
+  it("should render the form with conditional fields for when textualModType === 'aenderungsbefehl-ersetzen'", () => {
     render(RisModForm, {
       props: {
         textualModType,
@@ -125,7 +125,7 @@ describe("RisModForm", () => {
     expect(screen.queryByTestId("replacingElement")).not.toBeInTheDocument()
   })
 
-  it("Should render the form with conditional fields for when textualModType === 'aenderungsbefehl-ersetzen' and there is a quotedStructureContent", () => {
+  it("should render the form with conditional fields for when textualModType === 'aenderungsbefehl-ersetzen' and there is a quotedStructureContent", () => {
     render(RisModForm, {
       props: {
         textualModType,
@@ -160,7 +160,7 @@ describe("RisModForm", () => {
     ).not.toBeInTheDocument()
   })
 
-  it("Should render the form when timeBoundaries are empty", async () => {
+  it("should render the form when timeBoundaries are empty", async () => {
     const user = userEvent.setup()
     render(RisModForm, {
       props: {
@@ -178,7 +178,7 @@ describe("RisModForm", () => {
     expect(timeBoundaryOptionElements.length).toBe(1)
   })
 
-  it("Should render the form when a timeBoundary is pre selected", async () => {
+  it("should render the form when a timeBoundary is pre selected", async () => {
     const user = userEvent.setup()
     render(RisModForm, {
       props: {
@@ -206,7 +206,7 @@ describe("RisModForm", () => {
     )
   })
 
-  it("Should render the form with quoted structure content", () => {
+  it("should render the form with quoted structure content", () => {
     render(RisModForm, {
       props: {
         textualModType,

--- a/frontend/src/components/RisModForm.spec.ts
+++ b/frontend/src/components/RisModForm.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
-import { getByText, render, screen } from "@testing-library/vue"
+import { render, screen, within } from "@testing-library/vue"
 import RisModForm from "@/components/RisModForm.vue"
 import { userEvent } from "@testing-library/user-event"
 import { ModType } from "@/types/ModType"
@@ -31,7 +31,6 @@ describe("RisModForm", () => {
     const user = userEvent.setup()
     render(RisModForm, {
       props: {
-        id: "risModForm",
         textualModType,
         timeBoundaries,
         destinationHref,
@@ -39,7 +38,7 @@ describe("RisModForm", () => {
     })
 
     // Form
-    const formElement = document.querySelector(`#risModForm`)
+    const formElement = screen.getByRole("form")
     expect(formElement).toBeInTheDocument()
 
     // Textual Mode Type
@@ -97,7 +96,6 @@ describe("RisModForm", () => {
   it("Should render the form with conditional fields for when textualModType === 'aenderungsbefehl-ersetzen'", () => {
     render(RisModForm, {
       props: {
-        id: "risModForm",
         textualModType,
         timeBoundaries,
         destinationHref,
@@ -130,7 +128,6 @@ describe("RisModForm", () => {
   it("Should render the form with conditional fields for when textualModType === 'aenderungsbefehl-ersetzen' and there is a quotedStructureContent", () => {
     render(RisModForm, {
       props: {
-        id: "risModForm",
         textualModType,
         timeBoundaries,
         destinationHref,
@@ -167,7 +164,6 @@ describe("RisModForm", () => {
     const user = userEvent.setup()
     render(RisModForm, {
       props: {
-        id: "risModForm",
         textualModType,
         timeBoundaries: [],
         destinationHref,
@@ -186,7 +182,6 @@ describe("RisModForm", () => {
     const user = userEvent.setup()
     render(RisModForm, {
       props: {
-        id: "risModForm",
         textualModType,
         timeBoundaries,
         selectedTimeBoundary: timeBoundaries[1],
@@ -214,7 +209,6 @@ describe("RisModForm", () => {
   it("Should render the form with quoted structure content", () => {
     render(RisModForm, {
       props: {
-        id: "risModForm",
         textualModType,
         timeBoundaries,
         destinationHref,
@@ -238,7 +232,6 @@ describe("RisModForm", () => {
     const onGeneratePreview = vi.fn()
 
     const props = {
-      id: "risModForm",
       textualModType,
       timeBoundaries,
       selectedTimeBoundary: timeBoundaries[1],
@@ -271,7 +264,6 @@ describe("RisModForm", () => {
     const onUpdateDestinationHref = vi.fn()
 
     const props = {
-      id: "risModForm",
       textualModType,
       timeBoundaries,
       destinationHref,
@@ -301,7 +293,6 @@ describe("RisModForm", () => {
     const onGeneratePreview = vi.fn()
 
     const props = {
-      id: "risModForm",
       textualModType,
       timeBoundaries,
       destinationHref,
@@ -324,9 +315,8 @@ describe("RisModForm", () => {
   it("emits an update & generate preview when the a new destination is selected", async () => {
     const user = userEvent.setup()
 
-    const result = render(RisModForm, {
+    const { emitted } = render(RisModForm, {
       props: {
-        id: "risModForm",
         textualModType,
         timeBoundaries,
         destinationHref:
@@ -339,7 +329,9 @@ describe("RisModForm", () => {
     await user.pointer([
       {
         keys: "[MouseLeft>]",
-        target: getByText(screen.getByLabelText("zu ersetzender Text"), "Test"),
+        target: within(screen.getByLabelText("zu ersetzender Text")).getByText(
+          "Test",
+        ),
         offset: 1,
       },
       {
@@ -348,12 +340,12 @@ describe("RisModForm", () => {
       { keys: "[/MouseLeft]" },
     ])
 
-    expect(result.emitted("update:destinationHref")).toHaveLength(1)
-    expect(result.emitted("update:destinationHref")[0]).toContain(
+    expect(emitted("update:destinationHref")).toHaveLength(1)
+    expect(emitted("update:destinationHref")[0]).toContain(
       "eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/span-1/1-3.xml",
     )
 
-    expect(result.emitted("generate-preview")).toHaveLength(1)
+    expect(emitted("generate-preview")).toHaveLength(1)
   })
 
   it("emits an update when the quotedTextSecond input is changed", async () => {
@@ -362,7 +354,6 @@ describe("RisModForm", () => {
     const onGeneratePreview = vi.fn()
 
     const props = {
-      id: "risModForm",
       textualModType,
       timeBoundaries,
       destinationHref,
@@ -397,7 +388,6 @@ describe("RisModForm", () => {
     const onGeneratePreview = vi.fn()
 
     const props = {
-      id: "risModForm",
       textualModType,
       timeBoundaries,
       destinationHref,
@@ -424,7 +414,6 @@ describe("RisModForm", () => {
 
     render(RisModForm, {
       props: {
-        id: "risModForm",
         textualModType,
         timeBoundaries,
         destinationHref,
@@ -449,7 +438,6 @@ describe("RisModForm", () => {
 
     const { rerender } = render(RisModForm, {
       props: {
-        id: "risModForm",
         textualModType,
         timeBoundaries,
         destinationHref,

--- a/frontend/src/components/RisModForm.vue
+++ b/frontend/src/components/RisModForm.vue
@@ -350,7 +350,7 @@ const selectableAknElementsEventHandlers = Object.fromEntries(
 
 <template>
   <form
-    role="form"
+    data-testid="mod-form"
     class="grid h-full max-h-full grid-cols-1 grid-rows-[min-content,min-content,1fr,min-content] gap-y-12 overflow-auto"
   >
     <div class="grid grid-cols-2 gap-x-16">

--- a/frontend/src/components/RisModForm.vue
+++ b/frontend/src/components/RisModForm.vue
@@ -18,8 +18,6 @@ import IconCheck from "~icons/ic/baseline-check"
 import { useElementId } from "@/composables/useElementId"
 
 const props = defineProps<{
-  /** Unique ID for the dro. */
-  id: string
   /** Either replacement, insertion or repeal */
   textualModType: ModType | ""
   /** the possible time boundaries in the format YYYY-MM-DD. */
@@ -352,7 +350,7 @@ const selectableAknElementsEventHandlers = Object.fromEntries(
 
 <template>
   <form
-    :id="id"
+    role="form"
     class="grid h-full max-h-full grid-cols-1 grid-rows-[min-content,min-content,1fr,min-content] gap-y-12 overflow-auto"
   >
     <div class="grid grid-cols-2 gap-x-16">

--- a/frontend/src/components/RisTemporalDataIntervals.spec.ts
+++ b/frontend/src/components/RisTemporalDataIntervals.spec.ts
@@ -4,7 +4,7 @@ import dayjs from "dayjs"
 import { describe, expect, it, vi } from "vitest"
 import RisTemporalDataIntervals from "./RisTemporalDataIntervals.vue"
 
-describe("RisTemporalDateIntervals", () => {
+describe("risTemporalDateIntervals", () => {
   it("renders the correct number of date inputs and checks their values", async () => {
     const dates = [
       { date: "2023-01-01", eid: "event-1", eventRefEid: "ref-1" },

--- a/frontend/src/components/affectedDocuments/RisAffectedDocumentPanel.spec.ts
+++ b/frontend/src/components/affectedDocuments/RisAffectedDocumentPanel.spec.ts
@@ -1,10 +1,10 @@
 import { render, screen } from "@testing-library/vue"
-import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import { createRouter, createWebHashHistory } from "vue-router"
 import { ref } from "vue"
 import { Norm } from "@/types/norm"
 
-describe("RisAffectedDocumentPanel", () => {
+describe("risAffectedDocumentPanel", () => {
   const data = ref<Norm | null>(null)
   const isFetching = ref(false)
   const error = ref<Error | null>(null)
@@ -36,7 +36,7 @@ describe("RisAffectedDocumentPanel", () => {
 
   const eli = "eli/bund/bgbl-1/1968/s537/1968-05-19/18/deu/regelungstext-1"
 
-  test("should show title, eli and edit metadata button", async () => {
+  it("should show title, eli and edit metadata button", async () => {
     data.value = {
       title: "Some title",
       eli: "eli/bund/bgbl-1/1968/s537/1968-05-19/18/deu/regelungstext-1",
@@ -61,7 +61,7 @@ describe("RisAffectedDocumentPanel", () => {
     ).toBeInTheDocument()
   })
 
-  test("should render fna", async () => {
+  it("should render fna", async () => {
     data.value = {
       eli: "eli/bund/bgbl-1/1968/s537/1968-05-19/18/deu/regelungstext-1",
       fna: "1234",
@@ -80,7 +80,7 @@ describe("RisAffectedDocumentPanel", () => {
     expect(document.body).not.toHaveTextContent("FNA 1234-")
   })
 
-  test("should render as a list item", async () => {
+  it("should render as a list item", async () => {
     data.value = {
       eli: "eli/bund/bgbl-1/1968/s537/1968-05-19/18/deu/regelungstext-1",
     }
@@ -97,7 +97,7 @@ describe("RisAffectedDocumentPanel", () => {
     expect(screen.getByRole("listitem")).toBeInTheDocument()
   })
 
-  test("should render as a regular container if not told to be a list item", async () => {
+  it("should render as a regular container if not told to be a list item", async () => {
     data.value = {
       eli: "eli/bund/bgbl-1/1968/s537/1968-05-19/18/deu/regelungstext-1",
     }
@@ -114,7 +114,7 @@ describe("RisAffectedDocumentPanel", () => {
     expect(screen.queryByRole("listitem")).not.toBeInTheDocument()
   })
 
-  test("should render fna and short title", async () => {
+  it("should render fna and short title", async () => {
     data.value = {
       eli: "eli/bund/bgbl-1/1968/s537/1968-05-19/18/deu/regelungstext-1",
       fna: "1234",
@@ -133,7 +133,7 @@ describe("RisAffectedDocumentPanel", () => {
     expect(document.body).toHaveTextContent("FNA 1234-SomeShortTitle")
   })
 
-  test("should render short title without fna", async () => {
+  it("should render short title without fna", async () => {
     data.value = {
       eli: "eli/bund/bgbl-1/1968/s537/1968-05-19/18/deu/regelungstext-1",
       shortTitle: "SomeShortTitle",
@@ -152,7 +152,7 @@ describe("RisAffectedDocumentPanel", () => {
     expect(document.body).not.toHaveTextContent("FNA")
   })
 
-  test("should link to the metadata editor", async () => {
+  it("should link to the metadata editor", async () => {
     data.value = {
       eli: "eli/bund/bgbl-1/1968/s537/1968-05-19/18/deu/regelungstext-1",
     }
@@ -176,7 +176,7 @@ describe("RisAffectedDocumentPanel", () => {
     )
   })
 
-  test("should link to the reference editor", async () => {
+  it("should link to the reference editor", async () => {
     data.value = {
       eli: "eli/bund/bgbl-1/1968/s537/1968-05-19/18/deu/regelungstext-1",
     }
@@ -200,7 +200,7 @@ describe("RisAffectedDocumentPanel", () => {
     )
   })
 
-  test("should show an error message", async () => {
+  it("should show an error message", async () => {
     error.value = new Error("A error message")
 
     const { default: RisAffectedDocumentPanel } = await import(
@@ -217,7 +217,7 @@ describe("RisAffectedDocumentPanel", () => {
     )
   })
 
-  test("should show a loading indicator", async () => {
+  it("should show a loading indicator", async () => {
     isFetching.value = true
 
     const { default: RisAffectedDocumentPanel } = await import(

--- a/frontend/src/components/amendingLaws/RisAmendingLawCard.spec.ts
+++ b/frontend/src/components/amendingLaws/RisAmendingLawCard.spec.ts
@@ -1,9 +1,9 @@
 import { render, screen } from "@testing-library/vue"
-import { describe, expect, test } from "vitest"
+import { describe, expect, it } from "vitest"
 import RisAmendingLawCard from "./RisAmendingLawCard.vue"
 
-describe("RisAmendingLawCard", () => {
-  test("should render overview of open print amending law", () => {
+describe("risAmendingLawCard", () => {
+  it("should render overview of open print amending law", () => {
     render(RisAmendingLawCard, {
       props: {
         eli: "someEli",
@@ -15,7 +15,7 @@ describe("RisAmendingLawCard", () => {
     expect(screen.getByText("GazetteName 2021 S. 456")).toBeInTheDocument()
   })
 
-  test("should render overview of open digital amending law", () => {
+  it("should render overview of open digital amending law", () => {
     render(RisAmendingLawCard, {
       props: {
         eli: "someEli",

--- a/frontend/src/components/controls/RisAlert.spec.ts
+++ b/frontend/src/components/controls/RisAlert.spec.ts
@@ -18,7 +18,7 @@ describe("RisAlert", () => {
   })
 
   test("emits close event", () => {
-    const renderResult = render(RisAlert, {
+    const { emitted } = render(RisAlert, {
       props: {
         variant: "error",
       },
@@ -30,6 +30,6 @@ describe("RisAlert", () => {
     const alert = screen.getByRole("alert")
     within(alert).getByRole("button", { name: "Schließen" }).click()
 
-    expect(renderResult.emitted().close.length).toBe(1)
+    expect(emitted().close.length).toBe(1)
   })
 })

--- a/frontend/src/components/controls/RisAlert.spec.ts
+++ b/frontend/src/components/controls/RisAlert.spec.ts
@@ -1,9 +1,9 @@
 import { render, screen, within } from "@testing-library/vue"
-import { describe, expect, test } from "vitest"
+import { describe, expect, it } from "vitest"
 import RisAlert from "@/components/controls/RisAlert.vue"
 
-describe("RisAlert", () => {
-  test("renders slot content", () => {
+describe("risAlert", () => {
+  it("renders slot content", () => {
     render(RisAlert, {
       props: {
         variant: "success",
@@ -17,7 +17,7 @@ describe("RisAlert", () => {
     expect(within(alert).getByText("This was a success")).toBeInTheDocument()
   })
 
-  test("emits close event", () => {
+  it("emits close event", () => {
     const { emitted } = render(RisAlert, {
       props: {
         variant: "error",

--- a/frontend/src/components/controls/RisCallout.spec.ts
+++ b/frontend/src/components/controls/RisCallout.spec.ts
@@ -1,16 +1,16 @@
 import { userEvent } from "@testing-library/user-event"
 import { render, screen } from "@testing-library/vue"
-import { describe, expect, test, vi } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { defineComponent } from "vue"
 import RisCallout from "./RisCallout.vue"
 
-describe("RisCallout", () => {
-  test("renders", () => {
+describe("risCallout", () => {
+  it("renders", () => {
     render(RisCallout, { props: { title: "Foo" } })
     expect(screen.getByText("Foo")).toBeInTheDocument()
   })
 
-  test("shows as neutral variant", () => {
+  it("shows as neutral variant", () => {
     render(RisCallout, { props: { title: "Foo", variant: "neutral" } })
     expect(screen.getByTestId("callout-wrapper")).toHaveAttribute(
       "data-variant",
@@ -18,7 +18,7 @@ describe("RisCallout", () => {
     )
   })
 
-  test("shows as error variant", () => {
+  it("shows as error variant", () => {
     render(RisCallout, { props: { title: "Foo", variant: "error" } })
     expect(screen.getByTestId("callout-wrapper")).toHaveAttribute(
       "data-variant",
@@ -26,7 +26,7 @@ describe("RisCallout", () => {
     )
   })
 
-  test("shows as warning variant", () => {
+  it("shows as warning variant", () => {
     render(RisCallout, { props: { title: "Foo", variant: "warning" } })
     expect(screen.getByTestId("callout-wrapper")).toHaveAttribute(
       "data-variant",
@@ -34,7 +34,7 @@ describe("RisCallout", () => {
     )
   })
 
-  test("shows as success variant", () => {
+  it("shows as success variant", () => {
     render(RisCallout, { props: { title: "Foo", variant: "success" } })
     expect(screen.getByTestId("callout-wrapper")).toHaveAttribute(
       "data-variant",
@@ -42,7 +42,7 @@ describe("RisCallout", () => {
     )
   })
 
-  test("shows as neutral variant by default", () => {
+  it("shows as neutral variant by default", () => {
     render(RisCallout, { props: { title: "Foo" } })
     expect(screen.getByTestId("callout-wrapper")).toHaveAttribute(
       "data-variant",
@@ -50,7 +50,7 @@ describe("RisCallout", () => {
     )
   })
 
-  test("displays a message", () => {
+  it("displays a message", () => {
     const component = defineComponent({
       components: { RisCallout },
       template: `<RisCallout title="Foo">Bar</RisCallout>`,
@@ -61,7 +61,7 @@ describe("RisCallout", () => {
     expect(screen.getByText("Bar")).toBeInTheDocument()
   })
 
-  test("displays a custom icon", () => {
+  it("displays a custom icon", () => {
     const component = defineComponent({
       components: { RisCallout },
       template: `
@@ -76,28 +76,28 @@ describe("RisCallout", () => {
     expect(screen.getByText("🐸")).toBeInTheDocument()
   })
 
-  test("shows a dismiss button", () => {
+  it("shows a dismiss button", () => {
     render(RisCallout, { props: { title: "Foo", allowDismiss: true } })
     expect(
       screen.getByRole("button", { name: "Hinweis schließen" }),
     ).toBeInTheDocument()
   })
 
-  test("doesn't show the dismiss button", () => {
+  it("doesn't show the dismiss button", () => {
     render(RisCallout, { props: { title: "Foo", allowDismiss: false } })
     expect(
       screen.queryByRole("button", { name: "Hinweis schließen" }),
     ).not.toBeInTheDocument()
   })
 
-  test("doesn't show the dismiss button by default", () => {
+  it("doesn't show the dismiss button by default", () => {
     render(RisCallout, { props: { title: "Foo", allowDismiss: false } })
     expect(
       screen.queryByRole("button", { name: "Hinweis schließen" }),
     ).not.toBeInTheDocument()
   })
 
-  test("is hidden on dismiss", async () => {
+  it("is hidden on dismiss", async () => {
     const update = vi.fn()
     render(RisCallout, {
       props: { title: "Foo", allowDismiss: true, "onUpdate:visible": update },
@@ -109,17 +109,17 @@ describe("RisCallout", () => {
     expect(update).toHaveBeenCalled()
   })
 
-  test("is visible based on the model value", () => {
+  it("is visible based on the model value", () => {
     render(RisCallout, { props: { title: "Foo", visible: true } })
     expect(screen.getByText("Foo")).toBeVisible()
   })
 
-  test("is hidden based on the model value", () => {
+  it("is hidden based on the model value", () => {
     render(RisCallout, { props: { title: "Foo", visible: false } })
     expect(screen.queryByRole("Foo")).not.toBeInTheDocument()
   })
 
-  test("is visible by default", () => {
+  it("is visible by default", () => {
     render(RisCallout, { props: { title: "Foo" } })
     expect(screen.getByText("Foo")).toBeVisible()
   })

--- a/frontend/src/components/controls/RisCheckboxInput.spec.ts
+++ b/frontend/src/components/controls/RisCheckboxInput.spec.ts
@@ -1,7 +1,7 @@
 import RisCheckboxInput from "@/components/controls/RisCheckboxInput.vue"
 import { userEvent } from "@testing-library/user-event"
 import { render, screen } from "@testing-library/vue"
-import { describe, expect, test } from "vitest"
+import { describe, expect, it } from "vitest"
 
 function renderComponent(options?: {
   modelValue?: boolean
@@ -21,76 +21,76 @@ function renderComponent(options?: {
   return { user, props, ...utils }
 }
 
-describe("RisCheckboxInput", () => {
-  test("shows a checkbox input element", () => {
+describe("risCheckboxInput", () => {
+  it("shows a checkbox input element", () => {
     renderComponent()
     const input = screen.queryByRole("checkbox")
     expect(input).toBeInTheDocument()
   })
 
-  test("shows checked", () => {
+  it("shows checked", () => {
     renderComponent({ modelValue: true })
     const input: HTMLInputElement = screen.getByRole("checkbox")
     expect(input).toBeChecked()
   })
 
-  test("shows unchecked", () => {
+  it("shows unchecked", () => {
     renderComponent({ modelValue: false })
     const input: HTMLInputElement = screen.getByRole("checkbox")
     expect(input).not.toBeChecked()
   })
 
-  test("emits model update event when user checks the box", async () => {
+  it("emits model update event when user checks the box", async () => {
     const { emitted } = renderComponent()
     const input = screen.getByRole("checkbox")
     await userEvent.click(input)
     expect(emitted("update:modelValue")).toEqual([[true]])
   })
 
-  test("emits model update event when user unchecks the box", async () => {
+  it("emits model update event when user unchecks the box", async () => {
     const { emitted } = renderComponent({ modelValue: true })
     const input = screen.getByRole("checkbox")
     await userEvent.click(input)
     expect(emitted("update:modelValue")).toEqual([[false]])
   })
 
-  test("renders the checkbox as disabled", () => {
+  it("renders the checkbox as disabled", () => {
     renderComponent({ readOnly: true })
     const input = screen.getByRole("checkbox")
     expect(input).toBeDisabled()
   })
 
-  test("renders the checkbox as enabled by default", () => {
+  it("renders the checkbox as enabled by default", () => {
     renderComponent()
     const input = screen.getByRole("checkbox")
     expect(input).toBeEnabled()
   })
 
-  test("renders the mini variant by default", () => {
+  it("renders the mini variant by default", () => {
     renderComponent()
     const input = screen.getByRole("checkbox")
     expect(input).toHaveClass("ds-checkbox-mini")
   })
 
-  test("renders the regular variant when specified", () => {
+  it("renders the regular variant when specified", () => {
     renderComponent({ size: "regular" })
     const input = screen.getByRole("checkbox")
     expect(input).not.toHaveClass("ds-checkbox-small")
   })
 
-  test("renders the small variant when specified", () => {
+  it("renders the small variant when specified", () => {
     renderComponent({ size: "small" })
     const input = screen.getByRole("checkbox")
     expect(input).toHaveClass("ds-checkbox-small")
   })
 
-  test("renders the mini variant when specified", () => {
+  it("renders the mini variant when specified", () => {
     renderComponent({ size: "mini" })
     const input = screen.getByRole("checkbox")
     expect(input).toHaveClass("ds-checkbox-mini")
   })
 
-  test("renders the label", () => {
+  it("renders the label", () => {
     renderComponent({ label: "Text" })
     const input = screen.getByRole("checkbox")
     expect(input).toHaveAccessibleName("Text")

--- a/frontend/src/components/controls/RisCopyableLabel.spec.ts
+++ b/frontend/src/components/controls/RisCopyableLabel.spec.ts
@@ -1,15 +1,15 @@
 import { render, screen } from "@testing-library/vue"
-import { describe, expect, test, vi } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import RisCopyableLabel from "./RisCopyableLabel.vue"
 import { userEvent } from "@testing-library/user-event"
 
-describe("RisCopyableLabel", () => {
-  test("renders", () => {
+describe("risCopyableLabel", () => {
+  it("renders", () => {
     render(RisCopyableLabel, { props: { text: "Foo" } })
     expect(screen.getByText("Foo")).toBeInTheDocument()
   })
 
-  test("renders an accessible label with the default value", () => {
+  it("renders an accessible label with the default value", () => {
     render(RisCopyableLabel, { props: { text: "Foo" } })
 
     expect(
@@ -19,7 +19,7 @@ describe("RisCopyableLabel", () => {
     ).toBeInTheDocument()
   })
 
-  test("renders an accessible label with a custom value", () => {
+  it("renders an accessible label with a custom value", () => {
     render(RisCopyableLabel, { props: { text: "Foo", name: "Bar" } })
 
     expect(
@@ -29,7 +29,7 @@ describe("RisCopyableLabel", () => {
     ).toBeInTheDocument()
   })
 
-  test("copies the text if no value is provided", async () => {
+  it("copies the text if no value is provided", async () => {
     const user = userEvent.setup()
     const spy = vi.spyOn(navigator.clipboard, "writeText")
     render(RisCopyableLabel, { props: { text: "Foo" } })
@@ -39,7 +39,7 @@ describe("RisCopyableLabel", () => {
     expect(spy).toHaveBeenCalledWith("Foo")
   })
 
-  test("copies the value if provided", async () => {
+  it("copies the value if provided", async () => {
     const user = userEvent.setup()
     const spy = vi.spyOn(navigator.clipboard, "writeText")
     render(RisCopyableLabel, { props: { text: "Foo", value: "Bar" } })

--- a/frontend/src/components/controls/RisDateInput.spec.ts
+++ b/frontend/src/components/controls/RisDateInput.spec.ts
@@ -9,6 +9,7 @@ import InputText from "primevue/inputtext"
 beforeEach(() => {
   vi.spyOn(HTMLElement.prototype, "offsetParent", "get").mockImplementation(
     function (this: HTMLElement) {
+      // eslint-disable-next-line testing-library/no-node-access -- Needed for mocking
       return this.parentNode as Element
     },
   )

--- a/frontend/src/components/controls/RisDateInput.spec.ts
+++ b/frontend/src/components/controls/RisDateInput.spec.ts
@@ -1,7 +1,7 @@
 import { ValidationError } from "@/types/validationError"
 import { userEvent } from "@testing-library/user-event"
 import { render, screen } from "@testing-library/vue"
-import { describe, expect, test, beforeEach, vi, afterEach } from "vitest"
+import { describe, expect, it, beforeEach, vi, afterEach } from "vitest"
 import { nextTick } from "vue"
 import RisDateInput from "./RisDateInput.vue"
 import InputText from "primevue/inputtext"
@@ -41,8 +41,8 @@ function renderComponent(options?: {
   return { user, props, ...utils }
 }
 
-describe("DateInput", () => {
-  test("shows an date input element", () => {
+describe("dateInput", () => {
+  it("shows an date input element", () => {
     renderComponent()
     const input = screen.getByRole<HTMLInputElement>("textbox")
 
@@ -50,7 +50,7 @@ describe("DateInput", () => {
     expect(input?.type).toBe("text")
   })
 
-  test("allows typing a date inside input (stubbed inputMask)", async () => {
+  it("allows typing a date inside input (stubbed inputMask)", async () => {
     renderComponent({
       stubs: {
         InputMask: InputText,
@@ -63,14 +63,14 @@ describe("DateInput", () => {
     expect(input).toHaveValue("12.05.2020")
   })
 
-  test("displays modelValue in correct format", async () => {
+  it("displays modelValue in correct format", async () => {
     renderComponent({ modelValue: "2022-05-13" })
     const input = screen.getByRole("textbox")
 
     expect(input).toHaveValue("13.05.2022")
   })
 
-  test("emits model update event when input completed and valid", async () => {
+  it("emits model update event when input completed and valid", async () => {
     const { emitted } = renderComponent({
       modelValue: "2022-05-13T18:08:14.036Z",
       stubs: {
@@ -91,7 +91,7 @@ describe("DateInput", () => {
     ])
   })
 
-  test("updates when the model is changed to empty string", async () => {
+  it("updates when the model is changed to empty string", async () => {
     const { rerender } = renderComponent({ modelValue: "2024-04-22" })
 
     const input = screen.getByRole("textbox")
@@ -101,7 +101,7 @@ describe("DateInput", () => {
     expect(input).toHaveValue("")
   })
 
-  test("updates when the model is changed to undefined", async () => {
+  it("updates when the model is changed to undefined", async () => {
     const { rerender } = renderComponent({ modelValue: "2024-04-22" })
 
     const input = screen.getByRole("textbox")
@@ -111,7 +111,7 @@ describe("DateInput", () => {
     expect(input).toHaveValue("")
   })
 
-  test("removes validation errors on backspace delete", async () => {
+  it("removes validation errors on backspace delete", async () => {
     const { emitted } = renderComponent({
       modelValue: "2022-05-13",
       stubs: {
@@ -128,7 +128,7 @@ describe("DateInput", () => {
     expect(emitted()["update:validationError"]).toBeTruthy()
   })
 
-  test("does not allow invalid dates", async () => {
+  it("does not allow invalid dates", async () => {
     const { emitted } = renderComponent({
       stubs: {
         InputMask: InputText,
@@ -151,7 +151,7 @@ describe("DateInput", () => {
     ).toBe("Kein valides Datum")
   })
 
-  test("does not allow letters", async () => {
+  it("does not allow letters", async () => {
     renderComponent()
     const input = screen.getByRole("textbox")
 
@@ -161,7 +161,7 @@ describe("DateInput", () => {
     expect(input).toHaveTextContent("")
   })
 
-  test("does not allow incomplete dates", async () => {
+  it("does not allow incomplete dates", async () => {
     const { emitted } = renderComponent()
     const input = screen.getByRole("textbox")
 
@@ -181,17 +181,17 @@ describe("DateInput", () => {
     ).toBe(true)
   })
 
-  test("sets the input to readonly", () => {
+  it("sets the input to readonly", () => {
     renderComponent({ isReadOnly: true })
     expect(screen.getByRole("textbox")).toHaveAttribute("readonly")
   })
 
-  test("sets the input to editable", () => {
+  it("sets the input to editable", () => {
     renderComponent({ isReadOnly: false })
     expect(screen.getByRole("textbox")).not.toHaveAttribute("readonly")
   })
 
-  test("shows error message block for external validation errors", async () => {
+  it("shows error message block for external validation errors", async () => {
     const validationError = {
       message: "Externes Fehler",
       instance: "identifier",

--- a/frontend/src/components/controls/RisErrorCallout.spec.ts
+++ b/frontend/src/components/controls/RisErrorCallout.spec.ts
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/vue"
-import { describe, expect, test, vi } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { defineComponent, ref } from "vue"
 import RisErrorCallout from "./RisErrorCallout.vue"
 import { useSentryTraceId } from "@/composables/useSentryTraceId"
@@ -19,19 +19,19 @@ vi.mock("@/lib/errorMessages", () => ({
   },
 }))
 
-describe("RisErrorCallout", () => {
+describe("risErrorCallout", () => {
   vi.mock("@/composables/useSentryTraceId", () => ({
     useSentryTraceId: () => ref("000000000000000000000000"),
   }))
 
   useSentryTraceId()
 
-  test("renders", () => {
+  it("renders", () => {
     render(RisErrorCallout, { props: { error: { type: "/errors/foo" } } })
     expect(screen.getByText("Error of type /errors/foo")).toBeInTheDocument()
   })
 
-  test("shows as error variant", () => {
+  it("shows as error variant", () => {
     render(RisErrorCallout, { props: { error: { type: "/errors/foo" } } })
     expect(screen.getByTestId("error-callout")).toHaveAttribute(
       "data-variant",
@@ -39,7 +39,7 @@ describe("RisErrorCallout", () => {
     )
   })
 
-  test("displays a message", () => {
+  it("displays a message", () => {
     const component = defineComponent({
       components: { RisErrorCallout },
       template: `
@@ -51,7 +51,7 @@ describe("RisErrorCallout", () => {
     expect(screen.getByText("Bar")).toBeInTheDocument()
   })
 
-  test("displays a suggestion", () => {
+  it("displays a suggestion", () => {
     const component = defineComponent({
       components: { RisErrorCallout },
       template: `
@@ -63,7 +63,7 @@ describe("RisErrorCallout", () => {
     expect(screen.getByText("Try again")).toBeInTheDocument()
   })
 
-  test("displays sentry trace id", () => {
+  it("displays sentry trace id", () => {
     render(RisErrorCallout, { props: { error: { type: "/errors/foo" } } })
 
     expect(screen.getByText("000000000000000000000000")).toBeInTheDocument()

--- a/frontend/src/components/controls/RisErrorToast.spec.ts
+++ b/frontend/src/components/controls/RisErrorToast.spec.ts
@@ -1,7 +1,7 @@
 import { ErrorToastPayload } from "@/lib/errorToast"
 import { userEvent } from "@testing-library/user-event"
 import { render, screen } from "@testing-library/vue"
-import { describe, expect, test, vi } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import RisErrorToast from "./RisErrorToast.vue"
 
 function renderWithError(message: Partial<ErrorToastPayload>) {
@@ -19,13 +19,13 @@ function renderWithError(message: Partial<ErrorToastPayload>) {
   })
 }
 
-describe("RisErrorToast", () => {
-  test("renders the title", () => {
+describe("risErrorToast", () => {
+  it("renders the title", () => {
     renderWithError({ summary: "test title" })
     expect(screen.getByText("test title")).toBeInTheDocument()
   })
 
-  test("renders the message", () => {
+  it("renders the message", () => {
     renderWithError({
       summary: "test title",
       detail: { title: "test title", message: "test message" },
@@ -34,7 +34,7 @@ describe("RisErrorToast", () => {
     expect(screen.getByText("test message")).toBeInTheDocument()
   })
 
-  test("renders the suggestion", () => {
+  it("renders the suggestion", () => {
     renderWithError({
       summary: "test title",
       detail: { title: "test title", suggestion: "test suggestion" },
@@ -43,7 +43,7 @@ describe("RisErrorToast", () => {
     expect(screen.getByText("test suggestion")).toBeInTheDocument()
   })
 
-  test("renders the trace ID", () => {
+  it("renders the trace ID", () => {
     renderWithError({
       summary: "test title",
       detail: { title: "test title", traceId: "4711" },
@@ -52,7 +52,7 @@ describe("RisErrorToast", () => {
     expect(screen.getByText("Trace-ID kopieren")).toBeInTheDocument()
   })
 
-  test("sets the trace ID value", async () => {
+  it("sets the trace ID value", async () => {
     const user = userEvent.setup()
     const spy = vi.spyOn(navigator.clipboard, "writeText")
     renderWithError({

--- a/frontend/src/components/controls/RisExpandableText.spec.ts
+++ b/frontend/src/components/controls/RisExpandableText.spec.ts
@@ -1,15 +1,15 @@
 import { render, screen } from "@testing-library/vue"
-import { describe, expect, test, vi } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import RisExpandableText from "./RisExpandableText.vue"
 import { userEvent } from "@testing-library/user-event"
 
-describe("RisExpandableText", () => {
-  test("renders the text", () => {
+describe("risExpandableText", () => {
+  it("renders the text", () => {
     render(RisExpandableText, { slots: { default: "Test" } })
     expect(screen.getByText("Test")).toBeInTheDocument()
   })
 
-  test("renders an expand button", async () => {
+  it("renders an expand button", async () => {
     // Need to mock these properties as JSDOM doesn't implement layout so they would always be 0
     vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(100)
     vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(50)
@@ -22,7 +22,7 @@ describe("RisExpandableText", () => {
     })
   })
 
-  test("expands the text", async () => {
+  it("expands the text", async () => {
     // Need to mock these properties as JSDOM doesn't implement layout so they would always be 0
     vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(100)
     vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(50)
@@ -39,7 +39,7 @@ describe("RisExpandableText", () => {
     expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "true")
   })
 
-  test("collapses the text", async () => {
+  it("collapses the text", async () => {
     // Need to mock these properties as JSDOM doesn't implement layout so they would always be 0
     vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(100)
     vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(50)
@@ -56,7 +56,7 @@ describe("RisExpandableText", () => {
     expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "false")
   })
 
-  test("renders a collapse button", async () => {
+  it("renders a collapse button", async () => {
     // Need to mock these properties as JSDOM doesn't implement layout so they would always be 0
     vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(100)
     vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(50)
@@ -72,7 +72,7 @@ describe("RisExpandableText", () => {
     })
   })
 
-  test("does not render the expand/collapse button if the text is not truncated", async () => {
+  it("does not render the expand/collapse button if the text is not truncated", async () => {
     // Need to mock these properties as JSDOM doesn't implement layout so they would always be 0
     // Need to mock these properties as JSDOM doesn't implement layout so they would always be 0
     vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(100)

--- a/frontend/src/components/controls/RisHeader.spec.ts
+++ b/frontend/src/components/controls/RisHeader.spec.ts
@@ -471,7 +471,7 @@ describe("RisHeader", () => {
       ).toBeInTheDocument()
     })
 
-    test("renders teleported content in the actions section", () => {
+    test("renders teleported content in the actions section", async () => {
       // Given
       const child = defineComponent({
         setup() {
@@ -492,7 +492,7 @@ describe("RisHeader", () => {
       render(component, { global })
 
       // Then
-      vi.waitFor(() => {
+      await vi.waitFor(() => {
         const button = screen.getByRole("button", { name: "Click me" })
         expect(button).toBeInTheDocument()
       })

--- a/frontend/src/components/controls/RisHeader.spec.ts
+++ b/frontend/src/components/controls/RisHeader.spec.ts
@@ -1,11 +1,11 @@
 import { userEvent } from "@testing-library/user-event"
 import { render, screen, within } from "@testing-library/vue"
-import { afterAll, beforeAll, describe, expect, test, vi } from "vitest"
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
 import { defineComponent, nextTick, onUnmounted, ref } from "vue"
 import { Router, createRouter, createWebHashHistory } from "vue-router"
 import RisHeader, { useHeaderContext } from "./RisHeader.vue"
 
-describe("RisHeader", () => {
+describe("risHeader", () => {
   let global = {}
   let router: Router
 
@@ -31,7 +31,7 @@ describe("RisHeader", () => {
     vi.resetAllMocks()
   })
 
-  test("renders", () => {
+  it("renders", () => {
     // Given
     render(RisHeader, { global, props: { breadcrumbs: [] } })
 
@@ -40,7 +40,7 @@ describe("RisHeader", () => {
   })
 
   describe("back button", () => {
-    test("renders the history back button", () => {
+    it("renders the history back button", () => {
       // Given
       render(RisHeader, {
         global,
@@ -51,7 +51,7 @@ describe("RisHeader", () => {
       expect(screen.getByRole("button", { name: "Zurück" })).toBeInTheDocument()
     })
 
-    test("goes back on clicking the history back button", async () => {
+    it("goes back on clicking the history back button", async () => {
       // Given
       render(RisHeader, {
         global,
@@ -67,7 +67,7 @@ describe("RisHeader", () => {
       expect(routerBack).toHaveBeenCalled()
     })
 
-    test("renders a link when a custom back destination is provided", () => {
+    it("renders a link when a custom back destination is provided", () => {
       // Given
       render(RisHeader, {
         global,
@@ -80,7 +80,7 @@ describe("RisHeader", () => {
       expect(link).toHaveAttribute("href", "#/")
     })
 
-    test("renders the link to a previous breadcrumb", async () => {
+    it("renders the link to a previous breadcrumb", async () => {
       // Given
       render(RisHeader, {
         global,
@@ -100,7 +100,7 @@ describe("RisHeader", () => {
       expect(link).toHaveAttribute("href", "#/foo")
     })
 
-    test("renders a separator between back button and breadcrumbs", () => {
+    it("renders a separator between back button and breadcrumbs", () => {
       // Given
       render(RisHeader, {
         global,
@@ -113,7 +113,7 @@ describe("RisHeader", () => {
       expect(screen.getByTestId("back-button-separator")).toBeInTheDocument()
     })
 
-    test("renders no separator if no back button exists", async () => {
+    it("renders no separator if no back button exists", async () => {
       // Given
       render(RisHeader, {
         global,
@@ -129,7 +129,7 @@ describe("RisHeader", () => {
       expect(screen.queryByTestId("back-button-separator")).toBeFalsy()
     })
 
-    test("renders no separator if no breadcrumbs exists", () => {
+    it("renders no separator if no breadcrumbs exists", () => {
       // Given
       render(RisHeader, {
         global,
@@ -145,7 +145,7 @@ describe("RisHeader", () => {
   })
 
   describe("breadcrumbs", () => {
-    test("renders breadcrumbs", () => {
+    it("renders breadcrumbs", () => {
       // Given
       render(RisHeader, {
         global,
@@ -163,7 +163,7 @@ describe("RisHeader", () => {
       expect(links[1]).toHaveTextContent("Bar")
     })
 
-    test("renders a text-only breadcrumb", () => {
+    it("renders a text-only breadcrumb", () => {
       // Given
       render(RisHeader, {
         global,
@@ -178,7 +178,7 @@ describe("RisHeader", () => {
       expect(within(navigation).queryByRole("link")).toBeFalsy()
     })
 
-    test("renders a link breadcrumb", () => {
+    it("renders a link breadcrumb", () => {
       // Given
       render(RisHeader, {
         global,
@@ -192,7 +192,7 @@ describe("RisHeader", () => {
       expect(link).toHaveTextContent("Foo")
     })
 
-    test("renders a breadcrumb with a dynamic title", async () => {
+    it("renders a breadcrumb with a dynamic title", async () => {
       // Given
       const title = ref("Foo")
       render(RisHeader, {
@@ -212,7 +212,7 @@ describe("RisHeader", () => {
       expect(link).toHaveTextContent("Bar")
     })
 
-    test("updates breadcrumbs when the prop value changes", async () => {
+    it("updates breadcrumbs when the prop value changes", async () => {
       // Given
       const { rerender } = render(RisHeader, {
         global,
@@ -238,7 +238,7 @@ describe("RisHeader", () => {
       expect(links[0]).toHaveTextContent("Baz")
     })
 
-    test("allows adding breadcrumbs from child components", async () => {
+    it("allows adding breadcrumbs from child components", async () => {
       // Given
       const dummyChild = defineComponent({
         setup() {
@@ -266,7 +266,7 @@ describe("RisHeader", () => {
       })
     })
 
-    test("cleans up breadcrumbs from children when they're unmounted", async () => {
+    it("cleans up breadcrumbs from children when they're unmounted", async () => {
       // Given
       const user = userEvent.setup()
 
@@ -311,7 +311,7 @@ describe("RisHeader", () => {
       })
     })
 
-    test("shows dynamic titles on breadcrumbs from children", async () => {
+    it("shows dynamic titles on breadcrumbs from children", async () => {
       // Given
       const user = userEvent.setup()
 
@@ -360,7 +360,7 @@ describe("RisHeader", () => {
       })
     })
 
-    test("renders parent and child breadcrumbs", async () => {
+    it("renders parent and child breadcrumbs", async () => {
       // Given
       const dummyChild = defineComponent({
         setup() {
@@ -390,7 +390,7 @@ describe("RisHeader", () => {
       })
     })
 
-    test("renders breadcrumbs from nested children", async () => {
+    it("renders breadcrumbs from nested children", async () => {
       // Given
       const dummyInnerChild = defineComponent({
         setup() {
@@ -430,7 +430,7 @@ describe("RisHeader", () => {
       })
     })
 
-    test("renders link as plain text if the link points to the current route", async () => {
+    it("renders link as plain text if the link points to the current route", async () => {
       // Given
       render(RisHeader, {
         global,
@@ -451,7 +451,7 @@ describe("RisHeader", () => {
   })
 
   describe("action slot", () => {
-    test("renders slot content in the actions section", () => {
+    it("renders slot content in the actions section", () => {
       // Given
       const component = defineComponent({
         components: { RisHeader },
@@ -471,7 +471,7 @@ describe("RisHeader", () => {
       ).toBeInTheDocument()
     })
 
-    test("renders teleported content in the actions section", async () => {
+    it("renders teleported content in the actions section", async () => {
       // Given
       const child = defineComponent({
         setup() {

--- a/frontend/src/components/controls/RisInfoHeader.spec.ts
+++ b/frontend/src/components/controls/RisInfoHeader.spec.ts
@@ -1,9 +1,9 @@
 import { render, screen } from "@testing-library/vue"
-import { describe, expect, test } from "vitest"
+import { describe, expect, it } from "vitest"
 import RisInfoHeader from "./RisInfoHeader.vue"
 
-describe("RisInfoHeader", () => {
-  test("renders heading and subtitle", () => {
+describe("risInfoHeader", () => {
+  it("renders heading and subtitle", () => {
     const heading = "Test Heading"
     const subtitle = "Test Title"
 

--- a/frontend/src/components/controls/RisInfoModal.spec.ts
+++ b/frontend/src/components/controls/RisInfoModal.spec.ts
@@ -1,9 +1,9 @@
 import { render, screen } from "@testing-library/vue"
-import { describe, expect, test } from "vitest"
+import { describe, expect, it } from "vitest"
 import RisInfoModal from "./RisInfoModal.vue"
 
-describe("RisInfoModal", () => {
-  test("renders title and description", () => {
+describe("risInfoModal", () => {
+  it("renders title and description", () => {
     const title = "Test Title"
     const description = "Test Description"
 
@@ -16,7 +16,7 @@ describe("RisInfoModal", () => {
     expect(screen.getByText(description)).toBeInTheDocument()
   })
 
-  test("renders a button with the correct label", () => {
+  it("renders a button with the correct label", () => {
     const iconText = "Icon Text"
     const title = "Dummy Title"
 

--- a/frontend/src/components/controls/RisLoadingSpinner.spec.ts
+++ b/frontend/src/components/controls/RisLoadingSpinner.spec.ts
@@ -1,9 +1,9 @@
-import { describe, expect, test } from "vitest"
+import { describe, expect, it } from "vitest"
 import RisLoadingSpinner from "./RisLoadingSpinner.vue"
 import { render, screen } from "@testing-library/vue"
 
-describe("RisLoadingSpinner", () => {
-  test("renders", () => {
+describe("risLoadingSpinner", () => {
+  it("renders", () => {
     render(RisLoadingSpinner)
     expect(screen.getByRole("status", { name: "Lädt..." })).toBeInTheDocument()
   })

--- a/frontend/src/components/controls/RisNavbar.spec.ts
+++ b/frontend/src/components/controls/RisNavbar.spec.ts
@@ -1,10 +1,10 @@
 import { render, screen } from "@testing-library/vue"
-import { describe, expect, test } from "vitest"
+import { describe, expect, it } from "vitest"
 import RisNavbar from "./RisNavbar.vue"
 import { createRouter, createWebHashHistory } from "vue-router"
 
-describe("RisNavbar", () => {
-  test("should show 'Rechtsinformationen' and 'des Bundes'", () => {
+describe("risNavbar", () => {
+  it("should show 'Rechtsinformationen' and 'des Bundes'", () => {
     const router = createRouter({
       history: createWebHashHistory(),
       routes: [{ name: "Home", path: "/", component: () => {} }],

--- a/frontend/src/components/controls/RisNavbarSide.spec.ts
+++ b/frontend/src/components/controls/RisNavbarSide.spec.ts
@@ -1,11 +1,11 @@
 import { render, screen } from "@testing-library/vue"
-import { describe, expect, test } from "vitest"
+import { describe, expect, it } from "vitest"
 import { createRouter, createWebHistory } from "vue-router"
 import type { Router, RouteRecordRaw, RouteLocationRaw } from "vue-router"
 import RisNavbarSide from "./RisNavbarSide.vue"
 
-describe("NavbarSide", () => {
-  test("it displays the go back label with related route", async () => {
+describe("navbarSide", () => {
+  it("displays the go back label with related route", async () => {
     await renderComponent({
       goBackLabel: "Zur Übersicht",
     })
@@ -14,7 +14,7 @@ describe("NavbarSide", () => {
     expect(goBackItem).toBeVisible()
   })
 
-  test("it renders sidenav with multiple items and correct routes", async () => {
+  it("renders sidenav with multiple items and correct routes", async () => {
     const menuItems = [
       { label: "first item", route: "/first-route" },
       { label: "second item", route: "/second-route" },
@@ -31,7 +31,7 @@ describe("NavbarSide", () => {
     expect(secondItem).toHaveAttribute("href", "/second-route")
   })
 
-  test("it shows all level two items of an active level one item", async () => {
+  it("shows all level two items of an active level one item", async () => {
     const menuItems = [
       {
         label: "first level one",
@@ -53,7 +53,7 @@ describe("NavbarSide", () => {
     expect(screen.queryByText("second level two")).toBeVisible()
   })
 
-  test("it underlines the expanded level one item with children", async () => {
+  it("underlines the expanded level one item with children", async () => {
     const menuItems = [
       {
         label: "underlined level one",
@@ -73,7 +73,7 @@ describe("NavbarSide", () => {
     expect(screen.getByLabelText("child one")).toHaveClass("underline")
   })
 
-  test("it applies special class to menu item which matches current route", async () => {
+  it("applies special class to menu item which matches current route", async () => {
     const menuItems = [
       { label: "active item", route: { path: "/matching" } },
       { label: "passive item", route: { path: "/not-matching" } },
@@ -87,7 +87,7 @@ describe("NavbarSide", () => {
     expect(screen.getByLabelText("passive item")).not.toHaveClass("bg-blue-200")
   })
 
-  test("hides the back button if no route is provided", () => {
+  it("hides the back button if no route is provided", () => {
     renderComponent({ goBackRoute: undefined })
 
     expect(screen.queryByLabelText("Zurück")).not.toBeInTheDocument()

--- a/frontend/src/components/controls/RisRadioInput.spec.ts
+++ b/frontend/src/components/controls/RisRadioInput.spec.ts
@@ -28,7 +28,7 @@ function renderComponent(
   return render(RadioInput, { props: effectiveProps, attrs })
 }
 
-describe("RisRadioInput", () => {
+describe("risRadioInput", () => {
   it("renders a radio", () => {
     renderComponent()
     const input = screen.getByRole("radio")

--- a/frontend/src/components/controls/RisTextAreaInput.spec.ts
+++ b/frontend/src/components/controls/RisTextAreaInput.spec.ts
@@ -1,6 +1,6 @@
 import { userEvent } from "@testing-library/user-event"
 import { render, screen } from "@testing-library/vue"
-import { describe, expect, test } from "vitest"
+import { describe, expect, it } from "vitest"
 import TextAreaInput from "@/components/controls/RisTextAreaInput.vue"
 
 type TextAreaInputProps = InstanceType<typeof TextAreaInput>["$props"]
@@ -21,8 +21,8 @@ function renderComponent(
   return render(TextAreaInput, { props: defaultProps, attrs })
 }
 
-describe("TextAreaInput", () => {
-  test("shows an textarea element", () => {
+describe("textAreaInput", () => {
+  it("shows an textarea element", () => {
     renderComponent({})
     const input: HTMLTextAreaElement | null = screen.queryByRole("textbox")
 
@@ -30,19 +30,19 @@ describe("TextAreaInput", () => {
     expect(input?.tagName).toBe("TEXTAREA")
   })
 
-  test("sets the ID of the textarea", () => {
+  it("sets the ID of the textarea", () => {
     renderComponent({ id: "test-id" })
     const input: HTMLTextAreaElement | null = screen.queryByRole("textbox")
     expect(input).toHaveAttribute("id", "test-id")
   })
 
-  test("shows textarea with a placeholder", () => {
+  it("shows textarea with a placeholder", () => {
     renderComponent({ placeholder: "Test Placeholder" })
     const textarea = screen.queryByPlaceholderText("Test Placeholder")
     expect(textarea).toBeInTheDocument()
   })
 
-  test("allows to type text inside textarea", async () => {
+  it("allows to type text inside textarea", async () => {
     const user = userEvent.setup()
     renderComponent({ modelValue: "one" })
     const textarea: HTMLTextAreaElement = screen.getByRole("textbox")
@@ -53,14 +53,14 @@ describe("TextAreaInput", () => {
     expect(textarea).toHaveValue("one two")
   })
 
-  test("displays the model value", () => {
+  it("displays the model value", () => {
     renderComponent({ modelValue: "one" })
     const textarea: HTMLTextAreaElement = screen.getByRole("textbox")
 
     expect(textarea).toHaveValue("one")
   })
 
-  test("updates the model value", async () => {
+  it("updates the model value", async () => {
     const user = userEvent.setup()
     let testModel = "one"
     renderComponent({
@@ -73,7 +73,7 @@ describe("TextAreaInput", () => {
     expect(testModel).toBe("one two")
   })
 
-  test("emits blur event when textarea loses focus", async () => {
+  it("emits blur event when textarea loses focus", async () => {
     const { emitted } = renderComponent({})
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
     await userEvent.type(textarea, " two")
@@ -81,43 +81,43 @@ describe("TextAreaInput", () => {
     expect(emitted("blur")).toBeTruthy()
   })
 
-  test("sets the textarea to readonly", () => {
+  it("sets the textarea to readonly", () => {
     renderComponent({ readOnly: true })
     const textarea: HTMLTextAreaElement = screen.getByRole("textbox")
     expect(textarea).toHaveAttribute("readonly")
   })
 
-  test("sets the tabindex to -1 when readonly", () => {
+  it("sets the tabindex to -1 when readonly", () => {
     renderComponent({ readOnly: true })
     const textarea: HTMLTextAreaElement = screen.getByRole("textbox")
     expect(textarea).toHaveAttribute("tabindex", "-1")
   })
 
-  test("doesn't set the textarea to readonly", () => {
+  it("doesn't set the textarea to readonly", () => {
     renderComponent({ readOnly: false })
     const textarea: HTMLTextAreaElement = screen.getByRole("textbox")
     expect(textarea).not.toHaveAttribute("readonly")
   })
 
-  test("leaves the tabindex alone when not readonly", () => {
+  it("leaves the tabindex alone when not readonly", () => {
     renderComponent({ readOnly: false })
     const textarea: HTMLTextAreaElement = screen.getByRole("textbox")
     expect(textarea).not.toHaveAttribute("tabindex")
   })
 
-  test("sets the tabindex to the given value", () => {
+  it("sets the tabindex to the given value", () => {
     renderComponent({}, { tabindex: 815 })
     const textarea: HTMLTextAreaElement = screen.getByRole("textbox")
     expect(textarea).toHaveAttribute("tabindex", "815")
   })
 
-  test("renders the number of rows", () => {
+  it("renders the number of rows", () => {
     renderComponent({ rows: 5 })
     const textarea: HTMLTextAreaElement = screen.getByRole("textbox")
     expect(textarea).toHaveAttribute("rows", "5")
   })
 
-  test("renders a label when provided and associates it with the textarea", () => {
+  it("renders a label when provided and associates it with the textarea", () => {
     const labelText = "Test Label"
     renderComponent({ label: labelText, id: "test-id" })
 

--- a/frontend/src/components/editor/RisCodeEditor.spec.ts
+++ b/frontend/src/components/editor/RisCodeEditor.spec.ts
@@ -1,10 +1,10 @@
 import { render, screen } from "@testing-library/vue"
-import { beforeAll, describe, expect, test, vi } from "vitest"
+import { beforeAll, describe, expect, it, vi } from "vitest"
 import { nextTick } from "vue"
 import RisCodeEditor from "./RisCodeEditor.vue"
 import { EditorView } from "codemirror"
 
-describe("RisCodeEditor", () => {
+describe("risCodeEditor", () => {
   // We can't reliably test user interactions with the component in a unit test as parts of codemirror that get
   // called on interactions require a real browser. We therefore are creating some transactions on codemirror directly
   // to test the interactions between our component and codemirror.
@@ -29,7 +29,7 @@ describe("RisCodeEditor", () => {
     )
   })
 
-  test("renders initial content", async () => {
+  it("renders initial content", async () => {
     render(RisCodeEditor, {
       props: {
         modelValue: '<akn:FRBRuri value="eli/bund/bgbl-1/1964/s593"/>',
@@ -45,7 +45,7 @@ describe("RisCodeEditor", () => {
     )
   })
 
-  test("renders changed content when the initial content changes", async () => {
+  it("renders changed content when the initial content changes", async () => {
     const { rerender } = render(RisCodeEditor, {
       props: {
         modelValue: '<akn:FRBRuri value="eli/bund/bgbl-1/1964/s593"/>',
@@ -63,7 +63,7 @@ describe("RisCodeEditor", () => {
     expect(screen.getByRole("textbox").textContent).toBe("<xml></xml>")
   })
 
-  test("changing the content creates a change event", async () => {
+  it("changing the content creates a change event", async () => {
     const { emitted } = render(RisCodeEditor, {
       props: {
         modelValue: '<akn:FRBRuri value="eli/bund/bgbl-1/1964/s593"/>',
@@ -88,7 +88,7 @@ describe("RisCodeEditor", () => {
     ])
   })
 
-  test("changing the content and then updating the initial content to the same content does not cause a recreation of the editor", async () => {
+  it("changing the content and then updating the initial content to the same content does not cause a recreation of the editor", async () => {
     const { rerender } = render(RisCodeEditor, {
       props: {
         modelValue: '<akn:FRBRuri value="eli/bund/bgbl-1/1964/s593"/>',

--- a/frontend/src/components/editor/RisCodeEditor.spec.ts
+++ b/frontend/src/components/editor/RisCodeEditor.spec.ts
@@ -46,7 +46,7 @@ describe("RisCodeEditor", () => {
   })
 
   test("renders changed content when the initial content changes", async () => {
-    const renderResult = render(RisCodeEditor, {
+    const { rerender } = render(RisCodeEditor, {
       props: {
         modelValue: '<akn:FRBRuri value="eli/bund/bgbl-1/1964/s593"/>',
       },
@@ -57,14 +57,14 @@ describe("RisCodeEditor", () => {
       '<akn:FRBRuri value="eli/bund/bgbl-1/1964/s593"/>',
     )
 
-    await renderResult.rerender({
+    await rerender({
       modelValue: "<xml></xml>",
     })
     expect(screen.getByRole("textbox").textContent).toBe("<xml></xml>")
   })
 
   test("changing the content creates a change event", async () => {
-    const renderResult = render(RisCodeEditor, {
+    const { emitted } = render(RisCodeEditor, {
       props: {
         modelValue: '<akn:FRBRuri value="eli/bund/bgbl-1/1964/s593"/>',
       },
@@ -82,14 +82,14 @@ describe("RisCodeEditor", () => {
       '<akn:FRBRuri value="eli/bund/bgbl-1/1990/s2954"/>',
     )
 
-    expect(renderResult.emitted()["update:modelValue"].length).toBe(1)
-    expect(renderResult.emitted()["update:modelValue"][0]).toEqual([
+    expect(emitted()["update:modelValue"].length).toBe(1)
+    expect(emitted()["update:modelValue"][0]).toEqual([
       '<akn:FRBRuri value="eli/bund/bgbl-1/1990/s2954"/>',
     ])
   })
 
   test("changing the content and then updating the initial content to the same content does not cause a recreation of the editor", async () => {
-    const renderResult = render(RisCodeEditor, {
+    const { rerender } = render(RisCodeEditor, {
       props: {
         modelValue: '<akn:FRBRuri value="eli/bund/bgbl-1/1964/s593"/>',
       },
@@ -102,7 +102,7 @@ describe("RisCodeEditor", () => {
     editorView.dispatch({
       changes: { from: 20, to: 45, insert: "eli/bund/bgbl-1/1990/s2954" },
     })
-    await renderResult.rerender({
+    await rerender({
       modelValue: '<akn:FRBRuri value="eli/bund/bgbl-1/1990/s2954"/>',
     })
 

--- a/frontend/src/components/editor/RisTabs.spec.ts
+++ b/frontend/src/components/editor/RisTabs.spec.ts
@@ -53,10 +53,10 @@ describe("RisTabs", () => {
   })
 
   it("changes the tab status after updating the activeTab model", async () => {
-    const parentComponent = render(ParentComponent)
+    const { rerender } = render(ParentComponent)
     const firstTab = screen.getByRole("tab", { name: "Tab 1" })
     expect(firstTab.getAttribute("aria-selected")).toBe("true")
-    await parentComponent.rerender({
+    await rerender({
       activeTab: "tab2",
     })
     const secondTab = screen.getByRole("tab", { name: "Tab 2" })

--- a/frontend/src/components/editor/RisTabs.spec.ts
+++ b/frontend/src/components/editor/RisTabs.spec.ts
@@ -18,7 +18,7 @@ const ParentComponent = {
   },
 }
 
-describe("RisTabs", () => {
+describe("risTabs", () => {
   it("activates the first tab by default", async () => {
     const tabs = [
       { id: "tab1", label: "Tab 1" },

--- a/frontend/src/components/editor/composables/useCodemirrorVueEditableExtension.spec.ts
+++ b/frontend/src/components/editor/composables/useCodemirrorVueEditableExtension.spec.ts
@@ -1,10 +1,10 @@
 import { nextTick, ref, shallowRef } from "vue"
 import { EditorView } from "@codemirror/view"
 import { useCodemirrorVueEditableExtension } from "@/components/editor/composables/useCodemirrorVueEditableExtension"
-import { describe, test, expect } from "vitest"
+import { describe, it, expect } from "vitest"
 
 describe("useCodemirrorVueEditableExtension", () => {
-  test("Sets initial state", async () => {
+  it("sets initial state", async () => {
     const editable = ref(true)
     const editorView = shallowRef<EditorView | null>(null)
     const extension = useCodemirrorVueEditableExtension(editorView, editable)
@@ -17,7 +17,7 @@ describe("useCodemirrorVueEditableExtension", () => {
     )
   })
 
-  test("Updates state", async () => {
+  it("updates state", async () => {
     const editable = ref(false)
     const editorView = shallowRef<EditorView | null>(null)
     const extension = useCodemirrorVueEditableExtension(editorView, editable)

--- a/frontend/src/components/editor/composables/useCodemirrorVueReadonlyExtension.spec.ts
+++ b/frontend/src/components/editor/composables/useCodemirrorVueReadonlyExtension.spec.ts
@@ -1,10 +1,10 @@
 import { nextTick, ref, shallowRef } from "vue"
 import { useCodemirrorVueReadonlyExtension } from "@/components/editor/composables/useCodemirrorVueReadonlyExtension"
 import { EditorView } from "@codemirror/view"
-import { describe, test, expect } from "vitest"
+import { describe, it, expect } from "vitest"
 
 describe("useCodemirrorVueReadonlyExtension", () => {
-  test("Sets initial state", () => {
+  it("sets initial state", () => {
     const readOnly = ref(true)
     const editorView = shallowRef<EditorView | null>(null)
     const extension = useCodemirrorVueReadonlyExtension(editorView, readOnly)
@@ -13,7 +13,7 @@ describe("useCodemirrorVueReadonlyExtension", () => {
     expect(editorView.value?.state.readOnly).toBe(true)
   })
 
-  test("Updates state", async () => {
+  it("updates state", async () => {
     const readOnly = ref(false)
     const editorView = shallowRef<EditorView | null>(null)
     const extension = useCodemirrorVueReadonlyExtension(editorView, readOnly)

--- a/frontend/src/components/references/RisModRefsEditor.spec.ts
+++ b/frontend/src/components/references/RisModRefsEditor.spec.ts
@@ -24,7 +24,7 @@ vi.mock("primevue/usetoast", () => {
   }
 })
 
-describe("RisModRefsEditor", () => {
+describe("risModRefsEditor", () => {
   beforeEach(() => {
     vi.resetAllMocks()
     vi.resetModules()
@@ -35,7 +35,7 @@ describe("RisModRefsEditor", () => {
     renderError.value = undefined
   })
 
-  it("Should not render component if no mod was selected", async () => {
+  it("should not render component if no mod was selected", async () => {
     vi.doMock("vue-router", () => ({
       useRoute: vi.fn().mockReturnValue({
         params: {
@@ -67,7 +67,7 @@ describe("RisModRefsEditor", () => {
     expect(emptyState).toBeInTheDocument()
   })
 
-  it("Should render the html of the second quotedText of the selected mod", async () => {
+  it("should render the html of the second quotedText of the selected mod", async () => {
     vi.doMock("vue-router", () => ({
       useRoute: vi.fn().mockReturnValue({
         params: {
@@ -108,7 +108,7 @@ describe("RisModRefsEditor", () => {
     expect(renderedRef).toBeInTheDocument()
   })
 
-  it("Should save the updated xml from the RisRefSelectionPanel", async () => {
+  it("should save the updated xml from the RisRefSelectionPanel", async () => {
     vi.doMock("vue-router", () => ({
       useRoute: vi.fn().mockReturnValue({
         params: {
@@ -179,7 +179,7 @@ describe("RisModRefsEditor", () => {
     ])
   })
 
-  it("Should save the updated xml from the RisRefEditorTable", async () => {
+  it("should save the updated xml from the RisRefEditorTable", async () => {
     vi.doMock("vue-router", () => ({
       useRoute: vi.fn().mockReturnValue({
         params: {
@@ -249,7 +249,7 @@ describe("RisModRefsEditor", () => {
     ])
   })
 
-  it("Should sync selected refs", async () => {
+  it("should sync selected refs", async () => {
     const route: RouteLocationRaw = reactive({
       params: {
         refEid: undefined,

--- a/frontend/src/components/references/RisModRefsEditor.spec.ts
+++ b/frontend/src/components/references/RisModRefsEditor.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { getByRole, render, screen } from "@testing-library/vue"
+import { render, screen, within } from "@testing-library/vue"
 import { nextTick, reactive, ref } from "vue"
 import { userEvent } from "@testing-library/user-event"
 import { RouteLocationRaw } from "vue-router"
@@ -123,7 +123,7 @@ describe("RisModRefsEditor", () => {
     )
     const user = userEvent.setup()
 
-    const renderResult = render(RisModRefsEditor, {
+    const { emitted } = render(RisModRefsEditor, {
       props: {
         normXml: `
           <akn:act xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/">
@@ -164,8 +164,8 @@ describe("RisModRefsEditor", () => {
     await user.click(screen.getByText("RisRefSelectionPanel"))
     await user.click(screen.getByRole("button", { name: "Speichern" }))
 
-    expect(renderResult.emitted("save")).toHaveLength(1)
-    expect(renderResult.emitted("save")[0]).toEqual([
+    expect(emitted("save")).toHaveLength(1)
+    expect(emitted("save")[0]).toEqual([
       `<akn:act xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/">
             <akn:mod eId="mod-1">
                <akn:quotedText eId="mod-1_quot-1">First mod old text</akn:quotedText>
@@ -194,7 +194,7 @@ describe("RisModRefsEditor", () => {
     )
     const user = userEvent.setup()
 
-    const renderResult = render(RisModRefsEditor, {
+    const { emitted } = render(RisModRefsEditor, {
       props: {
         normXml: `
           <akn:act xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/">
@@ -234,8 +234,8 @@ describe("RisModRefsEditor", () => {
     await user.click(screen.getByText("RisRefEditorTable"))
     await user.click(screen.getByRole("button", { name: "Speichern" }))
 
-    expect(renderResult.emitted("save")).toHaveLength(1)
-    expect(renderResult.emitted("save")[0]).toEqual([
+    expect(emitted("save")).toHaveLength(1)
+    expect(emitted("save")[0]).toEqual([
       `<akn:act xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/">
             <akn:mod eId="mod-1">
                <akn:quotedText eId="mod-1_quot-1">First mod old text</akn:quotedText>
@@ -305,7 +305,7 @@ describe("RisModRefsEditor", () => {
     expect(ref2Highlight).toHaveClass("selected")
 
     await userEvent.click(
-      getByRole(ref1Region, "textbox", { name: "ELI mit Zielstelle" }),
+      within(ref1Region).getByRole("textbox", { name: "ELI mit Zielstelle" }),
     )
 
     expect(ref1Region).toHaveClass("bg-blue-300")

--- a/frontend/src/components/references/RisModSelectionPanel.spec.ts
+++ b/frontend/src/components/references/RisModSelectionPanel.spec.ts
@@ -69,7 +69,7 @@ describe("RisModSelectionPanel", () => {
   })
 
   it("Clicking on a akn:mod element emits an update for the model with the eid of the clicked on akn:mod element", async () => {
-    const renderResult = render(RisModSelectionPanel, {
+    const { emitted } = render(RisModSelectionPanel, {
       props: {
         normXml: "<xml></xml>",
       },
@@ -80,7 +80,7 @@ describe("RisModSelectionPanel", () => {
     screen.getByText("a mod").click()
     screen.getByText("a second mod").click()
 
-    const updateModelValueEvents = renderResult.emitted("update:modelValue")
+    const updateModelValueEvents = emitted("update:modelValue")
     expect(updateModelValueEvents).toHaveLength(2)
     expect(updateModelValueEvents[0]).toEqual(["eid-1"])
     expect(updateModelValueEvents[1]).toEqual(["eid-2"])

--- a/frontend/src/components/references/RisModSelectionPanel.spec.ts
+++ b/frontend/src/components/references/RisModSelectionPanel.spec.ts
@@ -17,8 +17,8 @@ vi.mock("@/composables/useNormRender", () => ({
   }),
 }))
 
-describe("RisModSelectionPanel", () => {
-  it("Should render the html of the norm", async () => {
+describe("risModSelectionPanel", () => {
+  it("should render the html of the norm", async () => {
     render(RisModSelectionPanel, {
       props: {
         normXml: "<xml></xml>",
@@ -31,7 +31,7 @@ describe("RisModSelectionPanel", () => {
     expect(renderedMod).toBeInTheDocument()
   })
 
-  it("Should show loading state while loading", async () => {
+  it("should show loading state while loading", async () => {
     renderIsFetching.value = true
 
     render(RisModSelectionPanel, {
@@ -51,7 +51,7 @@ describe("RisModSelectionPanel", () => {
     expect(loadingIndicator).not.toBeInTheDocument()
   })
 
-  it("Should show error when one exists", async () => {
+  it("should show error when one exists", async () => {
     renderError.value = "A error"
 
     render(RisModSelectionPanel, {
@@ -68,7 +68,7 @@ describe("RisModSelectionPanel", () => {
     expect(errorMessage).toBeInTheDocument()
   })
 
-  it("Clicking on a akn:mod element emits an update for the model with the eid of the clicked on akn:mod element", async () => {
+  it("clicking on a akn:mod element emits an update for the model with the eid of the clicked on akn:mod element", async () => {
     const { emitted } = render(RisModSelectionPanel, {
       props: {
         normXml: "<xml></xml>",
@@ -86,7 +86,7 @@ describe("RisModSelectionPanel", () => {
     expect(updateModelValueEvents[1]).toEqual(["eid-2"])
   })
 
-  it("The value of the model is selected", async () => {
+  it("the value of the model is selected", async () => {
     render(RisModSelectionPanel, {
       props: {
         normXml: "<xml></xml>",

--- a/frontend/src/components/references/RisRefEditor.spec.ts
+++ b/frontend/src/components/references/RisRefEditor.spec.ts
@@ -4,8 +4,8 @@ import { userEvent } from "@testing-library/user-event"
 import RisRefEditor from "@/components/references/RisRefEditor.vue"
 import { flushPromises } from "@vue/test-utils"
 
-describe("RisRefEditor", () => {
-  it("Should render a a select for the refersTo and an input for the href", async () => {
+describe("risRefEditor", () => {
+  it("should render a a select for the refersTo and an input for the href", async () => {
     render(RisRefEditor, {
       props: {
         xmlSnippet: `<akn:ref xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="quot-1_ref-1" href="eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/hauptteil-1_abschnitt-erster_art-4_abs-3.xml" refersTo="zitierung">§4 Abs. 3 StVO</akn:ref>`,
@@ -26,7 +26,7 @@ describe("RisRefEditor", () => {
     )
   })
 
-  it("Can select a new refersTo value", async () => {
+  it("can select a new refersTo value", async () => {
     const user = userEvent.setup()
 
     const { emitted } = render(RisRefEditor, {
@@ -53,7 +53,7 @@ describe("RisRefEditor", () => {
     ])
   })
 
-  it("Can change href", async () => {
+  it("can change href", async () => {
     const user = userEvent.setup()
 
     const { emitted } = render(RisRefEditor, {
@@ -78,7 +78,7 @@ describe("RisRefEditor", () => {
     ])
   })
 
-  it("Can send delete event", async () => {
+  it("can send delete event", async () => {
     const { emitted } = render(RisRefEditor, {
       props: {
         xmlSnippet: `<akn:ref xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="quot-1_ref-1" href="eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/hauptteil-1_abschnitt-erster_art-4_abs-3.xml" refersTo="zitierung">§4 Abs. 3 StVO</akn:ref>`,
@@ -90,7 +90,7 @@ describe("RisRefEditor", () => {
     expect(emitted("delete")).toHaveLength(1)
   })
 
-  it("Can send the focus previous event", async () => {
+  it("can send the focus previous event", async () => {
     const user = userEvent.setup()
     const { emitted } = render(RisRefEditor, {
       props: {
@@ -103,7 +103,7 @@ describe("RisRefEditor", () => {
     expect(emitted("selectPrevious")).toBeTruthy()
   })
 
-  it("Can send the focus next event", async () => {
+  it("can send the focus next event", async () => {
     const user = userEvent.setup()
     const { emitted } = render(RisRefEditor, {
       props: {
@@ -116,7 +116,7 @@ describe("RisRefEditor", () => {
     expect(emitted("selectNext")).toBeTruthy()
   })
 
-  it("Focuses the input", async () => {
+  it("focuses the input", async () => {
     const { rerender } = render(RisRefEditor, {
       props: {
         xmlSnippet: `<akn:ref xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="quot-1_ref-1" href="eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/hauptteil-1_abschnitt-erster_art-4_abs-3.xml" refersTo="zitierung">§4 Abs. 3 StVO</akn:ref>`,

--- a/frontend/src/components/references/RisRefEditor.spec.ts
+++ b/frontend/src/components/references/RisRefEditor.spec.ts
@@ -29,7 +29,7 @@ describe("RisRefEditor", () => {
   it("Can select a new refersTo value", async () => {
     const user = userEvent.setup()
 
-    const result = render(RisRefEditor, {
+    const { emitted } = render(RisRefEditor, {
       props: {
         xmlSnippet: `<akn:ref xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="quot-1_ref-1" href="eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/hauptteil-1_abschnitt-erster_art-4_abs-3.xml">§4 Abs. 3 StVO</akn:ref>`,
       },
@@ -47,8 +47,8 @@ describe("RisRefEditor", () => {
 
     await user.click(optionElements)
 
-    await expect.poll(() => result.emitted("update:xmlSnippet")).toHaveLength(1)
-    expect(result.emitted("update:xmlSnippet")[0]).toEqual([
+    await expect.poll(() => emitted("update:xmlSnippet")).toHaveLength(1)
+    expect(emitted("update:xmlSnippet")[0]).toEqual([
       '<akn:ref xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="quot-1_ref-1" href="eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/hauptteil-1_abschnitt-erster_art-4_abs-3.xml" refersTo="zitierung">§4 Abs. 3 StVO</akn:ref>',
     ])
   })
@@ -56,7 +56,7 @@ describe("RisRefEditor", () => {
   it("Can change href", async () => {
     const user = userEvent.setup()
 
-    const result = render(RisRefEditor, {
+    const { emitted } = render(RisRefEditor, {
       props: {
         xmlSnippet: `<akn:ref xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="quot-1_ref-1" href="eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/hauptteil-1_abschnitt-erster_art-4_abs-3.xml" refersTo="zitierung">§4 Abs. 3 StVO</akn:ref>`,
       },
@@ -72,14 +72,14 @@ describe("RisRefEditor", () => {
       "eli/bund/bgbl-1/2001/s1/2022-12-19/1/deu/regelungstext-1/art-4_abs-3.xml",
     )
 
-    await expect.poll(() => result.emitted("update:xmlSnippet")).toHaveLength(1)
-    expect(result.emitted("update:xmlSnippet")[0]).toEqual([
+    await expect.poll(() => emitted("update:xmlSnippet")).toHaveLength(1)
+    expect(emitted("update:xmlSnippet")[0]).toEqual([
       '<akn:ref xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="quot-1_ref-1" href="eli/bund/bgbl-1/2001/s1/2022-12-19/1/deu/regelungstext-1/art-4_abs-3.xml" refersTo="zitierung">§4 Abs. 3 StVO</akn:ref>',
     ])
   })
 
   it("Can send delete event", async () => {
-    const result = render(RisRefEditor, {
+    const { emitted } = render(RisRefEditor, {
       props: {
         xmlSnippet: `<akn:ref xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="quot-1_ref-1" href="eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/hauptteil-1_abschnitt-erster_art-4_abs-3.xml" refersTo="zitierung">§4 Abs. 3 StVO</akn:ref>`,
       },
@@ -87,7 +87,7 @@ describe("RisRefEditor", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Löschen" }))
 
-    expect(result.emitted("delete")).toHaveLength(1)
+    expect(emitted("delete")).toHaveLength(1)
   })
 
   it("Can send the focus previous event", async () => {

--- a/frontend/src/components/references/RisRefEditorTable.spec.ts
+++ b/frontend/src/components/references/RisRefEditorTable.spec.ts
@@ -1,6 +1,6 @@
 import RisRefEditorTable from "@/components/references/RisRefEditorTable.vue"
 import { userEvent } from "@testing-library/user-event"
-import { getByRole, render, screen, waitFor } from "@testing-library/vue"
+import { render, screen, waitFor, within } from "@testing-library/vue"
 import { flushPromises } from "@vue/test-utils"
 import { describe, expect, it } from "vitest"
 import { nextTick } from "vue"
@@ -38,7 +38,7 @@ describe("RisRefEditorTable", () => {
 
   it("Should delete a ref when the delete icon is clicked", async () => {
     const user = userEvent.setup()
-    const result = render(RisRefEditorTable, {
+    const { emitted } = render(RisRefEditorTable, {
       props: {
         xmlSnippet:
           "<akn:quotedText xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.7/\" eId='quot-1'>Render of <akn:ref eId='quot-1_ref-1'>a ref</akn:ref> and <akn:ref eId='quot-1_ref-2'>a second ref</akn:ref> and <akn:p eId='quot-1_p-1'>place for a third ref</akn:p></akn:quotedText>",
@@ -46,18 +46,20 @@ describe("RisRefEditorTable", () => {
     })
 
     const refEditor2 = screen.getByRole("region", { name: "a second ref" })
-    const deleteButton = getByRole(refEditor2, "button", { name: "Löschen" })
+    const deleteButton = within(refEditor2).getByRole("button", {
+      name: "Löschen",
+    })
     await user.click(deleteButton)
 
-    await expect.poll(() => result.emitted("update:xmlSnippet")).toHaveLength(1)
-    expect((result.emitted("update:xmlSnippet")[0] as [string])[0]).toContain(
+    await expect.poll(() => emitted("update:xmlSnippet")).toHaveLength(1)
+    expect((emitted("update:xmlSnippet")[0] as [string])[0]).toContain(
       'Render of <akn:ref eId="quot-1_ref-1">a ref</akn:ref> and a second ref',
     )
   })
 
   it("Selects a ref when it's href input is clicked", async () => {
     const user = userEvent.setup()
-    const result = render(RisRefEditorTable, {
+    const { emitted } = render(RisRefEditorTable, {
       props: {
         xmlSnippet:
           "<akn:quotedText xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.7/\" eId='quot-1'>Render of <akn:ref eId='quot-1_ref-1'>a ref</akn:ref> and <akn:ref eId='quot-1_ref-2'>a second ref</akn:ref> and <akn:p eId='quot-1_p-1'>place for a third ref</akn:p></akn:quotedText>",
@@ -67,20 +69,18 @@ describe("RisRefEditorTable", () => {
     await nextTick()
 
     const refEditor2 = screen.getByRole("region", { name: "a second ref" })
-    const hrefInput = getByRole(refEditor2, "textbox", {
+    const hrefInput = within(refEditor2).getByRole("textbox", {
       name: "ELI mit Zielstelle",
     })
     await user.click(hrefInput)
 
-    await expect
-      .poll(() => result.emitted("update:selectedRef"))
-      .toHaveLength(1)
-    expect(result.emitted("update:selectedRef")[0]).toEqual(["quot-1_ref-2"])
+    await expect.poll(() => emitted("update:selectedRef")).toHaveLength(1)
+    expect(emitted("update:selectedRef")[0]).toEqual(["quot-1_ref-2"])
   })
 
   it("Selects a ref when it is navigated to using keyboard navigation", async () => {
     const user = userEvent.setup()
-    const result = render(RisRefEditorTable, {
+    const { emitted } = render(RisRefEditorTable, {
       props: {
         xmlSnippet:
           "<akn:quotedText xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.7/\" eId='quot-1'>Render of <akn:ref eId='quot-1_ref-1'>a ref</akn:ref> and <akn:ref eId='quot-1_ref-2'>a second ref</akn:ref> and <akn:p eId='quot-1_p-1'>place for a third ref</akn:p></akn:quotedText>",
@@ -93,11 +93,9 @@ describe("RisRefEditorTable", () => {
     await user.tab()
     await user.tab()
 
-    await expect
-      .poll(() => result.emitted("update:selectedRef"))
-      .toHaveLength(2)
-    expect(result.emitted("update:selectedRef")[0]).toEqual(["quot-1_ref-1"])
-    expect(result.emitted("update:selectedRef")[1]).toEqual(["quot-1_ref-2"])
+    await expect.poll(() => emitted("update:selectedRef")).toHaveLength(2)
+    expect(emitted("update:selectedRef")[0]).toEqual(["quot-1_ref-1"])
+    expect(emitted("update:selectedRef")[1]).toEqual(["quot-1_ref-2"])
   })
 
   it("Selects next and previous refs by pressing arrow keys", async () => {

--- a/frontend/src/components/references/RisRefEditorTable.spec.ts
+++ b/frontend/src/components/references/RisRefEditorTable.spec.ts
@@ -5,8 +5,8 @@ import { flushPromises } from "@vue/test-utils"
 import { describe, expect, it } from "vitest"
 import { nextTick } from "vue"
 
-describe("RisRefEditorTable", () => {
-  it("Should not render the ref editor because no akn:ref present in the xml snippet", async () => {
+describe("risRefEditorTable", () => {
+  it("should not render the ref editor because no akn:ref present in the xml snippet", async () => {
     render(RisRefEditorTable, {
       props: {
         xmlSnippet:
@@ -20,7 +20,7 @@ describe("RisRefEditorTable", () => {
     expect(emptyState).toBeInTheDocument()
   })
 
-  it("Should render a ref editor for every akn:ref of the xml snippet", async () => {
+  it("should render a ref editor for every akn:ref of the xml snippet", async () => {
     render(RisRefEditorTable, {
       props: {
         xmlSnippet:
@@ -36,7 +36,7 @@ describe("RisRefEditorTable", () => {
     expect(refEditor2).toBeInTheDocument()
   })
 
-  it("Should delete a ref when the delete icon is clicked", async () => {
+  it("should delete a ref when the delete icon is clicked", async () => {
     const user = userEvent.setup()
     const { emitted } = render(RisRefEditorTable, {
       props: {
@@ -57,7 +57,7 @@ describe("RisRefEditorTable", () => {
     )
   })
 
-  it("Selects a ref when it's href input is clicked", async () => {
+  it("selects a ref when it's href input is clicked", async () => {
     const user = userEvent.setup()
     const { emitted } = render(RisRefEditorTable, {
       props: {
@@ -78,7 +78,7 @@ describe("RisRefEditorTable", () => {
     expect(emitted("update:selectedRef")[0]).toEqual(["quot-1_ref-2"])
   })
 
-  it("Selects a ref when it is navigated to using keyboard navigation", async () => {
+  it("selects a ref when it is navigated to using keyboard navigation", async () => {
     const user = userEvent.setup()
     const { emitted } = render(RisRefEditorTable, {
       props: {
@@ -98,7 +98,7 @@ describe("RisRefEditorTable", () => {
     expect(emitted("update:selectedRef")[1]).toEqual(["quot-1_ref-2"])
   })
 
-  it("Selects next and previous refs by pressing arrow keys", async () => {
+  it("selects next and previous refs by pressing arrow keys", async () => {
     const user = userEvent.setup()
     render(RisRefEditorTable, {
       props: {
@@ -114,7 +114,7 @@ describe("RisRefEditorTable", () => {
     await waitFor(() => expect(inputs[1]).toHaveFocus())
   })
 
-  it("Does not move past the last ref", async () => {
+  it("does not move past the last ref", async () => {
     const user = userEvent.setup()
     render(RisRefEditorTable, {
       props: {
@@ -134,7 +134,7 @@ describe("RisRefEditorTable", () => {
     expect(inputs[1]).toHaveFocus()
   })
 
-  it("Does not move above the first ref", async () => {
+  it("does not move above the first ref", async () => {
     const user = userEvent.setup()
     render(RisRefEditorTable, {
       props: {

--- a/frontend/src/components/references/RisRefSelectionPanel.spec.ts
+++ b/frontend/src/components/references/RisRefSelectionPanel.spec.ts
@@ -18,7 +18,7 @@ vi.mock("@/composables/useNormRender", () => ({
   }),
 }))
 
-describe("RisRefSelectionPanel", () => {
+describe("risRefSelectionPanel", () => {
   beforeEach(() => {
     renderData.value =
       "<div class='akn-quotedText' data-eId='quot-1'>Render of <div class='akn-ref' data-eId='quot-1_ref-1'>a ref</div> and <div class='akn-ref' data-eId='quot-1_ref-2'>a second ref</div> and <p class='akn-p' data-eId='quot-1_p-1'>place for a third ref</p></div>"
@@ -26,7 +26,7 @@ describe("RisRefSelectionPanel", () => {
     renderError.value = undefined
   })
 
-  it("Should render the html of the xml snippet", async () => {
+  it("should render the html of the xml snippet", async () => {
     render(RisRefSelectionPanel, {
       props: {
         xmlSnippet: "<xml></xml>",
@@ -39,7 +39,7 @@ describe("RisRefSelectionPanel", () => {
     expect(renderedRef).toBeInTheDocument()
   })
 
-  it("Should show loading state while loading", async () => {
+  it("should show loading state while loading", async () => {
     renderIsFetching.value = true
 
     render(RisRefSelectionPanel, {
@@ -58,7 +58,7 @@ describe("RisRefSelectionPanel", () => {
     expect.poll(() => loadingIndicator).not.toBeInTheDocument()
   })
 
-  it("Should show error when one exists", async () => {
+  it("should show error when one exists", async () => {
     renderError.value = "A error"
 
     render(RisRefSelectionPanel, {
@@ -75,7 +75,7 @@ describe("RisRefSelectionPanel", () => {
     expect(errorMessage).toBeInTheDocument()
   })
 
-  it("Highlighting a part of the text creates a new akn:ref element, the xmlSnippet is updated and the newly created element is selected", async () => {
+  it("highlighting a part of the text creates a new akn:ref element, the xmlSnippet is updated and the newly created element is selected", async () => {
     const { emitted } = render(RisRefSelectionPanel, {
       props: {
         xmlSnippet:

--- a/frontend/src/components/references/RisRefSelectionPanel.spec.ts
+++ b/frontend/src/components/references/RisRefSelectionPanel.spec.ts
@@ -76,7 +76,7 @@ describe("RisRefSelectionPanel", () => {
   })
 
   it("Highlighting a part of the text creates a new akn:ref element, the xmlSnippet is updated and the newly created element is selected", async () => {
-    const renderResult = render(RisRefSelectionPanel, {
+    const { emitted } = render(RisRefSelectionPanel, {
       props: {
         xmlSnippet:
           "<akn:quotedText xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.7/\" eId='quot-1'>Render of <akn:ref eId='quot-1_ref-1'>a ref</akn:ref> and <akn:ref eId='quot-1_ref-2'>a second ref</akn:ref> and <akn:p eId='quot-1_p-1'>place for a third ref</akn:p></akn:quotedText>",
@@ -97,7 +97,7 @@ describe("RisRefSelectionPanel", () => {
       { keys: "[/MouseLeft]" },
     ])
 
-    const updateXmlSnippetEvents = renderResult.emitted("update:xmlSnippet")
+    const updateXmlSnippetEvents = emitted("update:xmlSnippet")
     expect(updateXmlSnippetEvents).toHaveLength(1)
 
     const updatedXml = updateXmlSnippetEvents[0] as string
@@ -107,13 +107,13 @@ describe("RisRefSelectionPanel", () => {
     expect(newRef).toBeTruthy()
     expect(newRef?.textContent).toEqual("for a third")
 
-    const selectedRefUpdateEvents = renderResult.emitted("update:selectedRef")
+    const selectedRefUpdateEvents = emitted("update:selectedRef")
     expect(selectedRefUpdateEvents).toHaveLength(1)
     expect(selectedRefUpdateEvents[0]).toEqual(["quot-1_p-1_ref-1"])
   })
 
   it("selects a akn:ref element if it is clicked on", async () => {
-    const renderResult = render(RisRefSelectionPanel, {
+    const { emitted } = render(RisRefSelectionPanel, {
       props: {
         xmlSnippet: "<xml></xml>",
       },
@@ -123,7 +123,7 @@ describe("RisRefSelectionPanel", () => {
 
     await userEvent.click(screen.getByText("a ref"))
 
-    const selectedRefUpdateEvents = renderResult.emitted("update:selectedRef")
+    const selectedRefUpdateEvents = emitted("update:selectedRef")
     expect(selectedRefUpdateEvents).toHaveLength(1)
     expect(selectedRefUpdateEvents[0]).toEqual(["quot-1_ref-1"])
   })
@@ -142,7 +142,7 @@ describe("RisRefSelectionPanel", () => {
   })
 
   it("click on the delete icon deletes the akn:ref element", async () => {
-    const renderResult = render(RisRefSelectionPanel, {
+    const { emitted } = render(RisRefSelectionPanel, {
       props: {
         xmlSnippet:
           "<akn:quotedText xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.7/\" eId='quot-1'>Render of <akn:ref eId='quot-1_ref-1'>a ref</akn:ref> and <akn:ref eId='quot-1_ref-2'>a second ref</akn:ref></akn:quotedText>",
@@ -154,7 +154,7 @@ describe("RisRefSelectionPanel", () => {
     await userEvent.click(screen.getByText("a ref"))
     await userEvent.click(screen.getByRole("button", { name: "Löschen" }))
 
-    const updateXmlSnippetEvents = renderResult.emitted("update:xmlSnippet")
+    const updateXmlSnippetEvents = emitted("update:xmlSnippet")
     expect(updateXmlSnippetEvents).toHaveLength(1)
     expect(updateXmlSnippetEvents[0]).toEqual([
       `<akn:quotedText xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="quot-1">Render of a ref and <akn:ref eId="quot-1_ref-2">a second ref</akn:ref></akn:quotedText>`,

--- a/frontend/src/composables/useAffectedDocuments.spec.ts
+++ b/frontend/src/composables/useAffectedDocuments.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { nextTick, ref } from "vue"
 
 describe("useAffectedDocuments", () => {
@@ -7,7 +7,7 @@ describe("useAffectedDocuments", () => {
     vi.resetAllMocks()
   })
 
-  test("should provide the affected documents", async () => {
+  it("should provide the affected documents", async () => {
     const useArticles = vi.fn().mockReturnValue({
       data: ref([
         {

--- a/frontend/src/composables/useAknTextSelection.spec.ts
+++ b/frontend/src/composables/useAknTextSelection.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest"
+import { describe, expect, it } from "vitest"
 import {
   hasElementAsParentElement,
   limitSelectionToOneElement,
@@ -6,7 +6,7 @@ import {
 
 describe("useAknTextSelection", () => {
   describe("hasElementAsParentElement", () => {
-    test("returns true if the parent element is the direct parent", () => {
+    it("returns true if the parent element is the direct parent", () => {
       const htmlElement = document.createElement("div")
       htmlElement.innerHTML = `<span>Test</span>`
 
@@ -17,7 +17,7 @@ describe("useAknTextSelection", () => {
       expect(result).toBe(true)
     })
 
-    test("returns false if the parent element is a child", () => {
+    it("returns false if the parent element is a child", () => {
       const htmlElement = document.createElement("div")
       htmlElement.innerHTML = `<span>Test</span>`
 
@@ -28,7 +28,7 @@ describe("useAknTextSelection", () => {
       expect(result).toBe(false)
     })
 
-    test("returns true if the parent element is a grandparent", () => {
+    it("returns true if the parent element is a grandparent", () => {
       const htmlElement = document.createElement("div")
       htmlElement.innerHTML = `<span>Test</span>`
 
@@ -41,7 +41,7 @@ describe("useAknTextSelection", () => {
   })
 
   describe("limitSelectionToOneElement", () => {
-    test("selection stays the same if it only has one node", () => {
+    it("selection stays the same if it only has one node", () => {
       document.documentElement.innerHTML = `<span id="test">Test</span>`
       const textNode = document.getElementById("test")!.firstChild!
 
@@ -56,7 +56,7 @@ describe("useAknTextSelection", () => {
       expect(selection.focusOffset).toEqual(3)
     })
 
-    test("selection ends at the end of the first selected node if the other node is behind it", () => {
+    it("selection ends at the end of the first selected node if the other node is behind it", () => {
       document.documentElement.innerHTML = `<span id="test-1">Test</span><span id="test-2">No. 2</span>`
       const textNode1 = document.getElementById("test-1")!.firstChild!
       const textNode2 = document.getElementById("test-2")!.firstChild!
@@ -73,7 +73,7 @@ describe("useAknTextSelection", () => {
       expect(selection.focusOffset).toEqual(4)
     })
 
-    test("selection beginns at the start of the first selected node if the other node is in front of it", () => {
+    it("selection beginns at the start of the first selected node if the other node is in front of it", () => {
       document.documentElement.innerHTML = `<span id="test-1">Test</span><span id="test-2">No. 2</span>`
       const textNode1 = document.getElementById("test-1")!.firstChild!
       const textNode2 = document.getElementById("test-2")!.firstChild!
@@ -91,7 +91,7 @@ describe("useAknTextSelection", () => {
     })
   })
 
-  test("selection is not limited if selecting over another node", () => {
+  it("selection is not limited if selecting over another node", () => {
     document.documentElement.innerHTML = `<span id="test">Test <span>No.</span> 2</span>`
     const textNode1 = document.getElementById("test")!.firstChild!
     const textNode2 = document.getElementById("test")!.lastChild!

--- a/frontend/src/composables/useArticle.spec.ts
+++ b/frontend/src/composables/useArticle.spec.ts
@@ -1,5 +1,5 @@
 import { LawElementIdentifier } from "@/types/lawElementIdentifier"
-import { beforeEach, describe, expect, test, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { nextTick, ref } from "vue"
 
 describe("useArticle", () => {
@@ -7,7 +7,7 @@ describe("useArticle", () => {
     vi.resetModules()
   })
 
-  test("should provide the article", async () => {
+  it("should provide the article", async () => {
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce(
       new Response(
         JSON.stringify({
@@ -35,7 +35,7 @@ describe("useArticle", () => {
     )
   })
 
-  test("should load the article when the identifier changes", async () => {
+  it("should load the article when the identifier changes", async () => {
     const fetchSpy = vi.spyOn(global, "fetch")
 
     const { useArticle } = await import("./useArticle")

--- a/frontend/src/composables/useEIdRange.spec.ts
+++ b/frontend/src/composables/useEIdRange.spec.ts
@@ -1,25 +1,25 @@
-import { describe, expect, test } from "vitest"
+import { describe, expect, it } from "vitest"
 import { useEIdRange } from "@/composables/useEIdRange"
 import { ref } from "vue"
 
 describe("useEIdRange", () => {
-  test("empty startEId -> empty range", () => {
+  it("empty startEId -> empty range", () => {
     const eIds = useEIdRange(ref(null), ref(""), ref())
     expect(eIds.value).toHaveLength(0)
   })
 
-  test("empty endEId -> range is only the start eId", () => {
+  it("empty endEId -> range is only the start eId", () => {
     const eIds = useEIdRange(ref("eid-1"), ref(""), ref())
     expect(eIds.value).toHaveLength(1)
     expect(eIds.value).toContain("eid-1")
   })
 
-  test("empty html -> range is empty", () => {
+  it("empty html -> range is empty", () => {
     const eIds = useEIdRange(ref("eid-1"), ref("eid-3"), ref())
     expect(eIds.value).toHaveLength(0)
   })
 
-  test("finds all eIds between", () => {
+  it("finds all eIds between", () => {
     const eIds = useEIdRange(
       ref(
         "hauptteil-1_art-1_abs-1_untergl-1_listenelem-6_untergl-1_listenelem-a_inhalt-1_text-1_ändbefehl-1_quotstruct-1_abs-2",

--- a/frontend/src/composables/useEidPathParameter.spec.ts
+++ b/frontend/src/composables/useEidPathParameter.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { reactive } from "vue"
 
 describe("useEidPathParameter", () => {
@@ -7,7 +7,7 @@ describe("useEidPathParameter", () => {
     vi.resetAllMocks()
   })
 
-  test("should provide the eId from the route", async () => {
+  it("should provide the eId from the route", async () => {
     vi.doMock("vue-router", () => ({
       useRoute: vi.fn().mockReturnValue(
         reactive({
@@ -22,7 +22,7 @@ describe("useEidPathParameter", () => {
     expect(eid.value).toBe("foo")
   })
 
-  test("should return undefined if the route doesn't include an eId", async () => {
+  it("should return undefined if the route doesn't include an eId", async () => {
     vi.doMock("vue-router", () => ({
       useRoute: vi.fn().mockReturnValue(
         reactive({

--- a/frontend/src/composables/useElementId.spec.ts
+++ b/frontend/src/composables/useElementId.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { useElementId } from "./useElementId"
 
 describe("useElementId", () => {
@@ -6,12 +6,12 @@ describe("useElementId", () => {
     vi.unstubAllGlobals()
   })
 
-  test("returns an identifier", () => {
+  it("returns an identifier", () => {
     const { identifier } = useElementId()
     expect(identifier).toBeTruthy()
   })
 
-  test("returns multiple identifiers with destructuring", () => {
+  it("returns multiple identifiers with destructuring", () => {
     const { id1, id2, id3, id4, id5 } = useElementId()
     expect(id1).toBeTruthy()
     expect(typeof id1).toBe("string")
@@ -25,7 +25,7 @@ describe("useElementId", () => {
     expect(typeof id5).toBe("string")
   })
 
-  test("returns multiple identifiers with object access", () => {
+  it("returns multiple identifiers with object access", () => {
     const ids = useElementId()
     expect(ids.id1).toBeTruthy()
     expect(typeof ids.id1).toBe("string")
@@ -39,7 +39,7 @@ describe("useElementId", () => {
     expect(typeof ids.id5).toBe("string")
   })
 
-  test("returns different identifiers when called multiple times", () => {
+  it("returns different identifiers when called multiple times", () => {
     const ids = new Array(1000)
       .fill(undefined)
       .map(() => useElementId().someId)
@@ -49,12 +49,12 @@ describe("useElementId", () => {
     expect(ids.size).toBe(1000)
   })
 
-  test("returns an ID with the default prefix", () => {
+  it("returns an ID with the default prefix", () => {
     const { identifier } = useElementId("element")
     expect(identifier.startsWith("element-")).toBe(true)
   })
 
-  test("returns an ID with a custom prefix", () => {
+  it("returns an ID with a custom prefix", () => {
     const { identifier } = useElementId("test")
     expect(identifier.startsWith("test-")).toBe(true)
   })

--- a/frontend/src/composables/useEliPathParameter.spec.ts
+++ b/frontend/src/composables/useEliPathParameter.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { reactive } from "vue"
 
 describe("useEliPathParameter", () => {
@@ -7,7 +7,7 @@ describe("useEliPathParameter", () => {
     vi.resetAllMocks()
   })
 
-  test("should provide a valid ELI", async () => {
+  it("should provide a valid ELI", async () => {
     vi.doMock("vue-router", () => ({
       useRoute: vi.fn().mockReturnValue(
         reactive({
@@ -33,7 +33,7 @@ describe("useEliPathParameter", () => {
     )
   })
 
-  test("should provide a valid ELI with named parameters", async () => {
+  it("should provide a valid ELI with named parameters", async () => {
     vi.doMock("vue-router", () => ({
       useRoute: vi.fn().mockReturnValue(
         reactive({
@@ -59,7 +59,7 @@ describe("useEliPathParameter", () => {
     )
   })
 
-  test("should react to route param changes", async () => {
+  it("should react to route param changes", async () => {
     const route = reactive({
       params: {
         eliJurisdiction: "bund",
@@ -93,7 +93,7 @@ describe("useEliPathParameter", () => {
     )
   })
 
-  test("should react to route param changes with named parameters", async () => {
+  it("should react to route param changes with named parameters", async () => {
     const route = reactive({
       params: {
         testEliJurisdiction: "bund",
@@ -127,7 +127,7 @@ describe("useEliPathParameter", () => {
     )
   })
 
-  test("should throw if ELI parameters are missing", async () => {
+  it("should throw if ELI parameters are missing", async () => {
     vi.doMock("vue-router", () => ({
       useRoute: vi.fn().mockReturnValue(
         reactive({
@@ -144,7 +144,7 @@ describe("useEliPathParameter", () => {
     )
   })
 
-  test("should throw if named ELI parameters are missing", async () => {
+  it("should throw if named ELI parameters are missing", async () => {
     vi.doMock("vue-router", () => ({
       useRoute: vi.fn().mockReturnValue(
         reactive({
@@ -168,7 +168,7 @@ describe("createEliPathParameter", () => {
     vi.resetAllMocks()
   })
 
-  test("creates a valid path", async () => {
+  it("creates a valid path", async () => {
     const getPath = vi
       .fn()
       .mockResolvedValue(
@@ -202,7 +202,7 @@ describe("createEliPathParameter", () => {
     expect(path).toBe(expectedPath)
   })
 
-  test("creates a path with a prefix", async () => {
+  it("creates a path with a prefix", async () => {
     const getPath = vi.fn((prefix) =>
       Promise.resolve(
         `eli/:${prefix}EliJurisdiction(bund)` +

--- a/frontend/src/composables/useErrorMessage.spec.ts
+++ b/frontend/src/composables/useErrorMessage.spec.ts
@@ -1,5 +1,5 @@
 import { ErrorResponse } from "@/types/errorResponse"
-import { describe, expect, test, vi } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { useErrorMessage } from "./useErrorMessage"
 import { ref } from "vue"
 
@@ -18,31 +18,31 @@ vi.mock("@/lib/errorMessages", () => ({
 }))
 
 describe("useErrorMessage", () => {
-  test("maps a known error type to a message", () => {
+  it("maps a known error type to a message", () => {
     const source: ErrorResponse = { type: "/errors/foo" }
     const result = useErrorMessage(source)
     expect(result.value).toEqual({ title: "Error of type /errors/foo" })
   })
 
-  test("maps an unknown error type to the fallback message", () => {
+  it("maps an unknown error type to the fallback message", () => {
     const source: ErrorResponse = { type: "/errors/non-existent-error" }
     const result = useErrorMessage(source)
     expect(result.value).toEqual({ title: "The fallback message" })
   })
 
-  test("maps errors of a different format to the fallback message", () => {
+  it("maps errors of a different format to the fallback message", () => {
     const source = { foo: "bar" }
     const result = useErrorMessage(source)
     expect(result.value).toEqual({ title: "The fallback message" })
   })
 
-  test("returns undefined if there is no error to map", () => {
+  it("returns undefined if there is no error to map", () => {
     const source = undefined
     const result = useErrorMessage(source)
     expect(result.value).toBeUndefined()
   })
 
-  test("updates when the inputs change", () => {
+  it("updates when the inputs change", () => {
     const source = ref<ErrorResponse>()
 
     const result = useErrorMessage(source)

--- a/frontend/src/composables/useMod.spec.ts
+++ b/frontend/src/composables/useMod.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { nextTick, ref } from "vue"
 
 describe("useMod", () => {
@@ -7,7 +7,7 @@ describe("useMod", () => {
     vi.resetAllMocks()
   })
 
-  test("should provide the data about a mod", async () => {
+  it("should provide the data about a mod", async () => {
     vi.doMock("@/services/ldmldeModService", () => ({
       getDestinationHref: vi
         .fn()
@@ -63,7 +63,7 @@ describe("useMod", () => {
     )
   })
 
-  test("should fallback to getDestinationHref if getDestinationRangeFrom is not present", async () => {
+  it("should fallback to getDestinationHref if getDestinationRangeFrom is not present", async () => {
     vi.doMock("@/services/ldmldeModService", () => ({
       getDestinationHref: vi
         .fn()
@@ -115,7 +115,7 @@ describe("useMod", () => {
     )
   })
 
-  test("should provide default values without a mod eid", async () => {
+  it("should provide default values without a mod eid", async () => {
     const { useMod } = await import("./useMod")
 
     const {
@@ -135,7 +135,7 @@ describe("useMod", () => {
     expect(quotedStructureContent.value).toBeUndefined()
   })
 
-  test("should support changing the values of the returned refs", async () => {
+  it("should support changing the values of the returned refs", async () => {
     vi.doMock("@/services/ldmldeModService", () => ({
       getDestinationHref: vi.fn(),
       getDestinationRangeFrom: vi.fn(),
@@ -161,7 +161,7 @@ describe("useMod", () => {
     expect(quotedTextSecond.value).toBe("newer text")
   })
 
-  test("should overwrite the changed values when the eid changes", async () => {
+  it("should overwrite the changed values when the eid changes", async () => {
     vi.doMock("@/services/ldmldeModService", () => ({
       getDestinationHref: vi.fn(),
       getDestinationRangeFrom: vi.fn(),
@@ -193,7 +193,7 @@ describe("useMod", () => {
     expect(quotedTextSecond.value).toBe("new text")
   })
 
-  test("should overwrite the changed values when the xml changes", async () => {
+  it("should overwrite the changed values when the xml changes", async () => {
     vi.doMock("@/services/ldmldeModService", () => ({
       getDestinationHref: vi.fn(),
       getDestinationRangeFrom: vi.fn(),
@@ -225,7 +225,7 @@ describe("useMod", () => {
     expect(quotedTextSecond.value).toBe("new text")
   })
 
-  test("should create update and preview using useUpdateModData", async () => {
+  it("should create update and preview using useUpdateModData", async () => {
     const eli = "test-eli"
     const eid = "test-eid"
 

--- a/frontend/src/composables/useModEidPathParameter.spec.ts
+++ b/frontend/src/composables/useModEidPathParameter.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { reactive } from "vue"
 
 describe("useModEidPathParameter", () => {
@@ -7,7 +7,7 @@ describe("useModEidPathParameter", () => {
     vi.resetAllMocks()
   })
 
-  test("should provide a valid eid", async () => {
+  it("should provide a valid eid", async () => {
     vi.doMock("vue-router", () => ({
       useRoute: vi.fn().mockReturnValue(
         reactive({
@@ -25,7 +25,7 @@ describe("useModEidPathParameter", () => {
     expect(modEid.value).toBe("unknown-eid-1")
   })
 
-  test("should react to route param changes", async () => {
+  it("should react to route param changes", async () => {
     const route = reactive({
       params: {
         modEid: "unknown-eid-1",
@@ -45,7 +45,7 @@ describe("useModEidPathParameter", () => {
     expect(modEid.value).toBe("unknown-eid-2")
   })
 
-  test("should update route when changed", async () => {
+  it("should update route when changed", async () => {
     const routerReplace = vi.fn()
 
     vi.doMock("vue-router", () => ({
@@ -64,7 +64,7 @@ describe("useModEidPathParameter", () => {
     })
   })
 
-  test("should update route when changed to empty", async () => {
+  it("should update route when changed to empty", async () => {
     const routerReplace = vi.fn()
 
     vi.doMock("vue-router", () => ({

--- a/frontend/src/composables/useModEidSelection.spec.ts
+++ b/frontend/src/composables/useModEidSelection.spec.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach } from "vitest"
 import { nextTick, ref } from "vue"
 
 describe("useModEidSelection", () => {
@@ -7,7 +7,7 @@ describe("useModEidSelection", () => {
     vi.resetAllMocks()
   })
 
-  test("values is initially empty", async () => {
+  it("values is initially empty", async () => {
     vi.doMock("./useModEidPathParameter", () => ({
       useModEidPathParameter: vi.fn().mockReturnValue(ref("")),
     }))
@@ -18,7 +18,7 @@ describe("useModEidSelection", () => {
     expect(values.value).toHaveLength(0)
   })
 
-  test("selects new value on mouse click", async () => {
+  it("selects new value on mouse click", async () => {
     vi.doMock("./useModEidPathParameter", () => ({
       useModEidPathParameter: vi.fn().mockReturnValue(ref("")),
     }))
@@ -36,7 +36,7 @@ describe("useModEidSelection", () => {
     expect(values.value).toContain("eid-1")
   })
 
-  test("selects new value on keyboard event", async () => {
+  it("selects new value on keyboard event", async () => {
     vi.doMock("./useModEidPathParameter", () => ({
       useModEidPathParameter: vi.fn().mockReturnValue(ref("")),
     }))
@@ -54,7 +54,7 @@ describe("useModEidSelection", () => {
     expect(values.value).toContain("eid-1")
   })
 
-  test("normal click replaces the selection", async () => {
+  it("normal click replaces the selection", async () => {
     vi.doMock("./useModEidPathParameter", () => ({
       useModEidPathParameter: vi.fn().mockReturnValue(ref("")),
     }))
@@ -77,7 +77,7 @@ describe("useModEidSelection", () => {
     expect(values.value).toContain("eid-2")
   })
 
-  test("extends the selection if the meta key is pressed", async () => {
+  it("extends the selection if the meta key is pressed", async () => {
     vi.doMock("./useModEidPathParameter", () => ({
       useModEidPathParameter: vi.fn().mockReturnValue(ref("")),
     }))
@@ -105,7 +105,7 @@ describe("useModEidSelection", () => {
     expect(values.value).toContain("eid-2")
   })
 
-  test("extends the selection if the ctrl key is pressed", async () => {
+  it("extends the selection if the ctrl key is pressed", async () => {
     vi.doMock("./useModEidPathParameter", () => ({
       useModEidPathParameter: vi.fn().mockReturnValue(ref("")),
     }))
@@ -133,7 +133,7 @@ describe("useModEidSelection", () => {
     expect(values.value).toContain("eid-2")
   })
 
-  test("deselects just the clicked element if the ctrl key is pressed", async () => {
+  it("deselects just the clicked element if the ctrl key is pressed", async () => {
     vi.doMock("./useModEidPathParameter", () => ({
       useModEidPathParameter: vi.fn().mockReturnValue(ref("")),
     }))
@@ -166,7 +166,7 @@ describe("useModEidSelection", () => {
     expect(values.value).toContain("eid-3")
   })
 
-  test("deselectAll clears the selection", async () => {
+  it("deselectAll clears the selection", async () => {
     vi.doMock("./useModEidPathParameter", () => ({
       useModEidPathParameter: vi.fn().mockReturnValue(ref("")),
     }))
@@ -188,7 +188,7 @@ describe("useModEidSelection", () => {
     expect(values.value).toHaveLength(0)
   })
 
-  test("shift click allows to select a range", async () => {
+  it("shift click allows to select a range", async () => {
     vi.doMock("./useModEidPathParameter", () => ({
       useModEidPathParameter: vi.fn().mockReturnValue(ref("")),
     }))
@@ -220,7 +220,7 @@ describe("useModEidSelection", () => {
     expect(values.value).toContain("eid-4")
   })
 
-  test("shift click allows to select a range (inverse direction)", async () => {
+  it("shift click allows to select a range (inverse direction)", async () => {
     vi.doMock("./useModEidPathParameter", () => ({
       useModEidPathParameter: vi.fn().mockReturnValue(ref("")),
     }))
@@ -251,7 +251,7 @@ describe("useModEidSelection", () => {
     expect(values.value).toContain("eid-4")
   })
 
-  test("shift click starts range selection add last clicked element", async () => {
+  it("shift click starts range selection add last clicked element", async () => {
     vi.doMock("./useModEidPathParameter", () => ({
       useModEidPathParameter: vi.fn().mockReturnValue(ref("")),
     }))
@@ -292,7 +292,7 @@ describe("useModEidSelection", () => {
     expect(values.value).toContain("eid-4")
   })
 
-  test("shift click starts range selection add last clicked element, even if it was deselected", async () => {
+  it("shift click starts range selection add last clicked element, even if it was deselected", async () => {
     vi.doMock("./useModEidPathParameter", () => ({
       useModEidPathParameter: vi.fn().mockReturnValue(ref("")),
     }))
@@ -328,7 +328,7 @@ describe("useModEidSelection", () => {
     expect(values.value).toContain("eid-4")
   })
 
-  test("shift + ctrl click allows to add selection of a range", async () => {
+  it("shift + ctrl click allows to add selection of a range", async () => {
     vi.doMock("./useModEidPathParameter", () => ({
       useModEidPathParameter: vi.fn().mockReturnValue(ref("")),
     }))
@@ -365,7 +365,7 @@ describe("useModEidSelection", () => {
     expect(values.value).toContain("eid-5")
   })
 
-  test("shift + ctrl click allows to deselect a range of a selection", async () => {
+  it("shift + ctrl click allows to deselect a range of a selection", async () => {
     vi.doMock("./useModEidPathParameter", () => ({
       useModEidPathParameter: vi.fn().mockReturnValue(ref("")),
     }))
@@ -405,7 +405,7 @@ describe("useModEidSelection", () => {
     expect(values.value).toContain("eid-5")
   })
 
-  test("shift + ctrl click allows to add selection of a range over already selected elements", async () => {
+  it("shift + ctrl click allows to add selection of a range over already selected elements", async () => {
     vi.doMock("./useModEidPathParameter", () => ({
       useModEidPathParameter: vi.fn().mockReturnValue(ref("")),
     }))
@@ -444,7 +444,7 @@ describe("useModEidSelection", () => {
   })
 
   describe("path parameter", () => {
-    test("values takes initial value from path", async () => {
+    it("values takes initial value from path", async () => {
       vi.doMock("./useModEidPathParameter", () => ({
         useModEidPathParameter: vi.fn().mockReturnValue(ref("eid-1")),
       }))
@@ -457,7 +457,7 @@ describe("useModEidSelection", () => {
       expect(values.value).toContain("eid-1")
     })
 
-    test("path parameter includes the selected eid if only one is selected", async () => {
+    it("path parameter includes the selected eid if only one is selected", async () => {
       const pathParameter = ref("")
       vi.doMock("./useModEidPathParameter", () => ({
         useModEidPathParameter: vi.fn().mockReturnValue(pathParameter),
@@ -477,7 +477,7 @@ describe("useModEidSelection", () => {
       expect(pathParameter.value).toBe("eid-1")
     })
 
-    test("path parameter is empty when multiple eids are selected", async () => {
+    it("path parameter is empty when multiple eids are selected", async () => {
       const pathParameter = ref("")
       vi.doMock("./useModEidPathParameter", () => ({
         useModEidPathParameter: vi.fn().mockReturnValue(pathParameter),

--- a/frontend/src/composables/useModHighlightClasses.spec.ts
+++ b/frontend/src/composables/useModHighlightClasses.spec.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach } from "vitest"
 
 describe("useModEidSelection", () => {
   beforeEach(() => {
@@ -6,7 +6,7 @@ describe("useModEidSelection", () => {
     vi.resetAllMocks()
   })
 
-  test("if there are no mods no classes are returned", async () => {
+  it("if there are no mods no classes are returned", async () => {
     vi.doMock("@/services/ldmldeModService", () => ({
       getModEIds: vi.fn().mockReturnValue([]),
     }))
@@ -17,7 +17,7 @@ describe("useModEidSelection", () => {
     expect(classes.value).toEqual({})
   })
 
-  test("mods get classes in order of dates (oldest gets the first color)", async () => {
+  it("mods get classes in order of dates (oldest gets the first color)", async () => {
     vi.doMock("@/services/ldmldeModService", () => ({
       getModEIds: vi.fn().mockReturnValue(["eid-1", "eid-2"]),
       getTimeBoundaryDate: vi
@@ -71,7 +71,7 @@ describe("useModEidSelection", () => {
     ])
   })
 
-  test("when more than 10 dates exist the later dates get the default color", async () => {
+  it("when more than 10 dates exist the later dates get the default color", async () => {
     vi.doMock("@/services/ldmldeModService", () => ({
       getModEIds: vi
         .fn()
@@ -209,7 +209,7 @@ describe("useModEidSelection", () => {
     ])
   })
 
-  test("missing time boundaries get the last color", async () => {
+  it("missing time boundaries get the last color", async () => {
     vi.doMock("@/services/ldmldeModService", () => ({
       getModEIds: vi.fn().mockReturnValue(["eid-1", "eid-2"]),
       getTimeBoundaryDate: vi
@@ -254,7 +254,7 @@ describe("useModEidSelection", () => {
     ])
   })
 
-  test("time boundaries with the same date but different temporal groups get different colors", async () => {
+  it("time boundaries with the same date but different temporal groups get different colors", async () => {
     vi.doMock("@/services/ldmldeModService", () => ({
       getModEIds: vi.fn().mockReturnValue(["eid-1", "eid-2", "eid-3"]),
       getTimeBoundaryDate: vi
@@ -327,7 +327,7 @@ describe("useModEidSelection", () => {
     ])
   })
 
-  test("mods with the same time boundary get the same color", async () => {
+  it("mods with the same time boundary get the same color", async () => {
     vi.doMock("@/services/ldmldeModService", () => ({
       getModEIds: vi.fn().mockReturnValue(["eid-1", "eid-2", "eid-3"]),
       getTimeBoundaryDate: vi
@@ -396,7 +396,7 @@ describe("useModEidSelection", () => {
     ])
   })
 
-  test("selected mods get different classes", async () => {
+  it("selected mods get different classes", async () => {
     vi.doMock("@/services/ldmldeModService", () => ({
       getModEIds: vi.fn().mockReturnValue(["eid-1", "eid-2", "eid-3"]),
       getTimeBoundaryDate: vi

--- a/frontend/src/composables/useMods.spec.ts
+++ b/frontend/src/composables/useMods.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { nextTick, ref } from "vue"
 
 describe("useMods", () => {
@@ -7,7 +7,7 @@ describe("useMods", () => {
     vi.resetAllMocks()
   })
 
-  test("should provide the data about the mods", async () => {
+  it("should provide the data about the mods", async () => {
     vi.doMock("@/services/ldmldeService", () => ({
       getNodeByEid: vi.fn().mockReturnValue({}),
     }))
@@ -37,7 +37,7 @@ describe("useMods", () => {
     expect(mods.value[1].textualModType).toBe("aenderungsbefehl-ersetzen")
   })
 
-  test("should react if the eids change", async () => {
+  it("should react if the eids change", async () => {
     vi.doMock("@/services/ldmldeService", () => ({
       getNodeByEid: vi.fn().mockReturnValue({}),
     }))
@@ -71,7 +71,7 @@ describe("useMods", () => {
     expect(mods.value[1].timeBoundary?.date).toBe("2024-04-04")
   })
 
-  test("should support changing the value of the returned data", async () => {
+  it("should support changing the value of the returned data", async () => {
     vi.doMock("@/services/ldmldeModService", () => ({
       getTimeBoundaryDate: vi.fn().mockImplementation((xml, eid) => {
         switch (eid) {
@@ -105,7 +105,7 @@ describe("useMods", () => {
     expect(mods.value[0].timeBoundary?.date).toBe("2022-03-03")
   })
 
-  test("should overwrite the changed values when the eid changes", async () => {
+  it("should overwrite the changed values when the eid changes", async () => {
     vi.doMock("@/services/ldmldeModService", () => ({
       getTimeBoundaryDate: vi.fn().mockImplementation((xml, eid) => {
         switch (eid) {
@@ -144,7 +144,7 @@ describe("useMods", () => {
     expect(mods.value[0].timeBoundary?.date).toBe("2022-02-02")
   })
 
-  test("should create preview and update using useUpdateMods", async () => {
+  it("should create preview and update using useUpdateMods", async () => {
     const useUpdateMods = vi.fn()
 
     vi.doMock("@/services/ldmldeModService", () => ({

--- a/frontend/src/composables/useMultiSelection.spec.ts
+++ b/frontend/src/composables/useMultiSelection.spec.ts
@@ -1,21 +1,21 @@
 import { useMultiSelection } from "@/composables/useMultiSelection"
-import { describe, test, expect } from "vitest"
+import { describe, it, expect } from "vitest"
 
 describe("useMultiSelection", () => {
-  test("values is initially empty", () => {
+  it("values is initially empty", () => {
     const { values } = useMultiSelection<string>()
     expect(values.value).toHaveLength(0)
   })
 
   describe("select", () => {
-    test("selects the provided value", () => {
+    it("selects the provided value", () => {
       const { values, select } = useMultiSelection<string>()
       select("foo")
       expect(values.value).toHaveLength(1)
       expect(values.value).toContain("foo")
     })
 
-    test("does not overwrite existing selection", () => {
+    it("does not overwrite existing selection", () => {
       const { values, select } = useMultiSelection<string>()
       select("foo")
       select("bar")
@@ -26,14 +26,14 @@ describe("useMultiSelection", () => {
   })
 
   describe("toggle", () => {
-    test("selects the value is it's not selected", () => {
+    it("selects the value is it's not selected", () => {
       const { values, toggle } = useMultiSelection<string>()
       toggle("foo")
       expect(values.value).toHaveLength(1)
       expect(values.value).toContain("foo")
     })
 
-    test("deselects the value if it is selected", () => {
+    it("deselects the value if it is selected", () => {
       const { values, toggle, selectAll } = useMultiSelection<string>()
       selectAll(["foo", "bar", "baz"])
       toggle("bar")
@@ -44,7 +44,7 @@ describe("useMultiSelection", () => {
   })
 
   describe("selectAll", () => {
-    test("selects multiple values", () => {
+    it("selects multiple values", () => {
       const { values, selectAll } = useMultiSelection<string>()
       selectAll(["foo", "bar"])
       expect(values.value).toHaveLength(2)
@@ -52,7 +52,7 @@ describe("useMultiSelection", () => {
       expect(values.value).toContain("bar")
     })
 
-    test("does not overwrite existing selection", () => {
+    it("does not overwrite existing selection", () => {
       const { values, select, selectAll } = useMultiSelection<string>()
       select("foo")
       selectAll(["bar", "baz"])
@@ -64,7 +64,7 @@ describe("useMultiSelection", () => {
   })
 
   describe("clear", () => {
-    test("clears the selection", () => {
+    it("clears the selection", () => {
       const { values, selectAll, clear } = useMultiSelection<string>()
       selectAll(["foo", "bar"])
       clear()
@@ -73,7 +73,7 @@ describe("useMultiSelection", () => {
   })
 
   describe("deselectAll", () => {
-    test("deselects multiple values", () => {
+    it("deselects multiple values", () => {
       const { values, selectAll, deselectAll } = useMultiSelection<string>()
       selectAll(["foo", "bar", "baz"])
       deselectAll(["foo", "bar"])

--- a/frontend/src/composables/useNormXml.spec.ts
+++ b/frontend/src/composables/useNormXml.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { nextTick, ref } from "vue"
 import { UseFetchReturn } from "@vueuse/core"
 
@@ -8,7 +8,7 @@ describe("useNormXml", () => {
     vi.resetAllMocks()
   })
 
-  test("should provide the target law xml", async () => {
+  it("should provide the target law xml", async () => {
     const dataRef = ref<string>()
     vi.doMock("@/services/normService", () => ({
       useGetNormXml: vi.fn().mockReturnValue({
@@ -31,7 +31,7 @@ describe("useNormXml", () => {
     expect(data.value).toEqual("<xml></xml>")
   })
 
-  test("should update the xml", async () => {
+  it("should update the xml", async () => {
     const updateRef = ref<string>()
     vi.doMock("@/services/normService", () => ({
       useGetNormXml: vi.fn().mockReturnValue({

--- a/frontend/src/composables/useRef.spec.ts
+++ b/frontend/src/composables/useRef.spec.ts
@@ -1,9 +1,9 @@
-import { describe, expect, test, vi } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { useRef } from "@/composables/useRef"
 import { ref } from "vue"
 
 describe("useRef", () => {
-  test("should provide the data about a ref", async () => {
+  it("should provide the data about a ref", async () => {
     const { refersTo, href } = useRef(
       `<akn:ref xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="quot-1_ref-1" href="eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/hauptteil-1_abschnitt-erster_art-4_abs-3.xml" refersTo="zitierung">§4 Abs. 3 StVO</akn:ref>`,
       () => {},
@@ -15,7 +15,7 @@ describe("useRef", () => {
     )
   })
 
-  test("should call the update when the refersTo or href change", async () => {
+  it("should call the update when the refersTo or href change", async () => {
     const updateFn = vi.fn()
     const { refersTo, href } = useRef(
       `<akn:ref xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="quot-1_ref-1" href="eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/hauptteil-1_abschnitt-erster_art-4_abs-3.xml">§4 Abs. 3 StVO</akn:ref>`,
@@ -36,7 +36,7 @@ describe("useRef", () => {
     expect(updateFn).toBeCalledTimes(2)
   })
 
-  test("should react to changes of the xmlSnippet", async () => {
+  it("should react to changes of the xmlSnippet", async () => {
     const xmlSnippet = ref(
       `<akn:ref xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="quot-1_ref-1" href="eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/hauptteil-1_abschnitt-erster_art-4_abs-3.xml" refersTo="zitierung">§4 Abs. 3 StVO</akn:ref>`,
     )

--- a/frontend/src/composables/useTimeBoundaryPathParameter.spec.ts
+++ b/frontend/src/composables/useTimeBoundaryPathParameter.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { reactive } from "vue"
 
 describe("useTimeBoundaryPathParameter", () => {
@@ -7,7 +7,7 @@ describe("useTimeBoundaryPathParameter", () => {
     vi.resetAllMocks()
   })
 
-  test("should provide a valid time boundary", async () => {
+  it("should provide a valid time boundary", async () => {
     vi.doMock("vue-router", () => ({
       useRoute: vi
         .fn()
@@ -23,7 +23,7 @@ describe("useTimeBoundaryPathParameter", () => {
     expect(timeBoundary.value).toBe("2024-05-10")
   })
 
-  test("should react to route param changes", async () => {
+  it("should react to route param changes", async () => {
     const route = reactive({ params: { timeBoundary: "2024-05-10" } })
 
     vi.doMock("vue-router", () => ({
@@ -41,7 +41,7 @@ describe("useTimeBoundaryPathParameter", () => {
     expect(timeBoundary.value).toBe("2024-05-11")
   })
 
-  test("should update route param when changed", async () => {
+  it("should update route param when changed", async () => {
     const routerReplace = vi.fn()
 
     vi.doMock("vue-router", () => ({
@@ -61,7 +61,7 @@ describe("useTimeBoundaryPathParameter", () => {
     })
   })
 
-  test("returns the current value as a date", async () => {
+  it("returns the current value as a date", async () => {
     vi.doMock("vue-router", () => ({
       useRoute: vi
         .fn()
@@ -77,7 +77,7 @@ describe("useTimeBoundaryPathParameter", () => {
     expect(timeBoundaryAsDate.value).toEqual(new Date("2024-05-10"))
   })
 
-  test("should not set the time boundary to an empty value", async () => {
+  it("should not set the time boundary to an empty value", async () => {
     const routerReplace = vi.fn()
 
     vi.doMock("vue-router", () => ({

--- a/frontend/src/lib/errorResponseMapper.spec.ts
+++ b/frontend/src/lib/errorResponseMapper.spec.ts
@@ -1,5 +1,5 @@
 import { ErrorResponse } from "@/types/errorResponse"
-import { describe, expect, test, vi } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import {
   getFallbackError,
   isErrorResponse,
@@ -21,25 +21,25 @@ vi.mock("@/lib/errorMessages", () => ({
 }))
 
 describe("isErrorResponse", () => {
-  test("returns true if the candidate's type exists in the mapping", () => {
+  it("returns true if the candidate's type exists in the mapping", () => {
     const candidate = { type: "/errors/foo" }
     const result = isErrorResponse(candidate)
     expect(result).toBe(true)
   })
 
-  test("returns false if the candidate's type does not exist in the mapping", () => {
+  it("returns false if the candidate's type does not exist in the mapping", () => {
     const candidate = { type: "/errors/non-existing-type" }
     const result = isErrorResponse(candidate)
     expect(result).toBe(false)
   })
 
-  test("returns false if the candidate has no type", () => {
+  it("returns false if the candidate has no type", () => {
     const candidate = { foo: "bar" }
     const result = isErrorResponse(candidate)
     expect(result).toBe(false)
   })
 
-  test("returns false if the candidate is not an object", () => {
+  it("returns false if the candidate is not an object", () => {
     const candidate = "example"
     const result = isErrorResponse(candidate)
     expect(result).toBe(false)
@@ -47,19 +47,19 @@ describe("isErrorResponse", () => {
 })
 
 describe("getFallbackError", () => {
-  test("returns a fallback error", () => {
+  it("returns a fallback error", () => {
     expect(getFallbackError()).toEqual({ type: "__fallback__" })
   })
 })
 
 describe("mapErrorResponse", () => {
-  test("returns a mapped response from a string", () => {
+  it("returns a mapped response from a string", () => {
     const e: ErrorResponse = { type: "/errors/foo" }
     const result = mapErrorResponse(e)
     expect(result).toEqual({ title: "Error of type /errors/foo" })
   })
 
-  test("returns a mapped response from an object", () => {
+  it("returns a mapped response from an object", () => {
     const e: ErrorResponse<{ example: string }> = {
       type: "/errors/bar",
       example: "Example",
@@ -74,7 +74,7 @@ describe("mapErrorResponse", () => {
     })
   })
 
-  test("returns the fallback response if the type has no mapping", () => {
+  it("returns the fallback response if the type has no mapping", () => {
     const e: ErrorResponse = { type: "/errors/non-existing-type" }
     const result = mapErrorResponse(e)
     expect(result).toEqual({ title: "The fallback message" })

--- a/frontend/src/lib/errorToast.spec.ts
+++ b/frontend/src/lib/errorToast.spec.ts
@@ -1,7 +1,6 @@
 import { ErrorResponse } from "@/types/errorResponse"
-import { describe, expect, test, vi } from "vitest"
+import { afterAll, describe, expect, it, vi } from "vitest"
 import { useErrorToast } from "./errorToast"
-import { afterEach } from "node:test"
 
 const { add } = vi.hoisted(() => ({
   add: vi.fn(),
@@ -26,11 +25,11 @@ vi.mock("@/lib/errorMessages", () => ({
 }))
 
 describe("errorToast", () => {
-  afterEach(() => {
+  afterAll(() => {
     vi.resetAllMocks()
   })
 
-  test("shows a toast with a known error message", () => {
+  it("shows a toast with a known error message", () => {
     const source: ErrorResponse = { type: "/errors/foo" }
     const { addErrorToast } = useErrorToast()
     addErrorToast(source)
@@ -42,7 +41,7 @@ describe("errorToast", () => {
     )
   })
 
-  test("shows a toast with a fallback message for an unkown error type", () => {
+  it("shows a toast with a fallback message for an unkown error type", () => {
     const source: ErrorResponse = { type: "/errors/non-existent-error" }
     const { addErrorToast } = useErrorToast()
     addErrorToast(source)
@@ -54,7 +53,7 @@ describe("errorToast", () => {
     )
   })
 
-  test("shows a toast with a fallback message for errors of a different format", () => {
+  it("shows a toast with a fallback message for errors of a different format", () => {
     const source = { foo: "bar" }
     const { addErrorToast } = useErrorToast()
     addErrorToast(source)
@@ -66,7 +65,7 @@ describe("errorToast", () => {
     )
   })
 
-  test("shows a toast with a fallback message if the error is undefined", () => {
+  it("shows a toast with a fallback message if the error is undefined", () => {
     const source = undefined
     const { addErrorToast } = useErrorToast()
     addErrorToast(source)
@@ -78,7 +77,7 @@ describe("errorToast", () => {
     )
   })
 
-  test("includes the trace ID if provided", () => {
+  it("includes the trace ID if provided", () => {
     const source: ErrorResponse = { type: "/errors/foo" }
     const { addErrorToast } = useErrorToast()
     addErrorToast(source, "4711")
@@ -90,7 +89,7 @@ describe("errorToast", () => {
     )
   })
 
-  test("includes the message details if applicable", () => {
+  it("includes the message details if applicable", () => {
     const source: ErrorResponse<{ example: string }> = {
       type: "/errors/bar",
       example: "example",

--- a/frontend/src/lib/frbr.spec.ts
+++ b/frontend/src/lib/frbr.spec.ts
@@ -1,9 +1,9 @@
 import { Norm } from "@/types/norm"
-import { describe, expect, test } from "vitest"
+import { describe, expect, it } from "vitest"
 import { getFrbrDisplayText } from "./frbr"
 
 describe("getFrbrDisplayText", () => {
-  test("formats the name of a printed announced law", () => {
+  it("formats the name of a printed announced law", () => {
     const amendingLaw: Norm = {
       eli: "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1",
       frbrName: "BGBl. I",
@@ -15,7 +15,7 @@ describe("getFrbrDisplayText", () => {
     expect(getFrbrDisplayText(amendingLaw)).toBe("BGBl. I 2017 S. 419")
   })
 
-  test("formats the name of a digitally announced law", () => {
+  it("formats the name of a digitally announced law", () => {
     const amendingLaw: Norm = {
       eli: "eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1",
       frbrName: "BGBl. I",

--- a/frontend/src/lib/htmlRangeToLdmlDeRange.spec.ts
+++ b/frontend/src/lib/htmlRangeToLdmlDeRange.spec.ts
@@ -1,3 +1,5 @@
+// ESLint confuses htmlRenderRangeToLdmlDeRange with the testing library render method
+/* eslint testing-library/render-result-naming-convention: 0 */
 import { describe, expect, test } from "vitest"
 import {
   findHtmlNodeInLdml,

--- a/frontend/src/lib/htmlRangeToLdmlDeRange.spec.ts
+++ b/frontend/src/lib/htmlRangeToLdmlDeRange.spec.ts
@@ -1,6 +1,6 @@
 // ESLint confuses htmlRenderRangeToLdmlDeRange with the testing library render method
 /* eslint testing-library/render-result-naming-convention: 0 */
-import { describe, expect, test } from "vitest"
+import { describe, expect, it } from "vitest"
 import {
   findHtmlNodeInLdml,
   findLdmlNodeInHtml,
@@ -12,7 +12,7 @@ import { xmlStringToDocument } from "@/services/xmlService"
 import { getNodeByEid } from "@/services/ldmldeService"
 
 describe("findHtmlNodeInLdml", () => {
-  test("finds the node (element)", () => {
+  it("finds the node (element)", () => {
     const htmlElement = document.createElement("div")
     htmlElement.innerHTML = `<div class="akn-ref" data-eId="quot-1_ref-1">Test</div>`
 
@@ -26,7 +26,7 @@ describe("findHtmlNodeInLdml", () => {
     expect((result as Element).getAttribute("eId")).toEqual("quot-1_ref-1")
   })
 
-  test("finds the node (text node)", () => {
+  it("finds the node (text node)", () => {
     const htmlElement = document.createElement("div")
     htmlElement.innerHTML = `<div class="akn-ref" data-eId="quot-1_ref-1">Test</div>`
 
@@ -42,7 +42,7 @@ describe("findHtmlNodeInLdml", () => {
     expect(result?.nodeType).toEqual(Node.TEXT_NODE)
   })
 
-  test("finds nothing if eId does not match (element)", () => {
+  it("finds nothing if eId does not match (element)", () => {
     const htmlElement = document.createElement("div")
     htmlElement.innerHTML = `<div class="akn-ref" data-eId="quot-1_ref-2">Test</div>`
 
@@ -54,7 +54,7 @@ describe("findHtmlNodeInLdml", () => {
     expect(result).toBeNull()
   })
 
-  test("finds nothing if eId does not match (text node)", () => {
+  it("finds nothing if eId does not match (text node)", () => {
     const htmlElement = document.createElement("div")
     htmlElement.innerHTML = `<div class="akn-ref" data-eId="quot-1_ref-2">Test</div>`
 
@@ -71,7 +71,7 @@ describe("findHtmlNodeInLdml", () => {
 })
 
 describe("findLdmlNodeInHtml", () => {
-  test("finds the node (element)", () => {
+  it("finds the node (element)", () => {
     const htmlElement = document.createElement("div")
     htmlElement.innerHTML = `<div class="akn-ref" data-eId="quot-1_ref-1">Test</div>`
 
@@ -87,7 +87,7 @@ describe("findLdmlNodeInHtml", () => {
     expect((result as Element).getAttribute("data-eid")).toEqual("quot-1_ref-1")
   })
 
-  test("finds the node (text node)", () => {
+  it("finds the node (text node)", () => {
     const htmlElement = document.createElement("div")
     htmlElement.innerHTML = `<div class="akn-ref" data-eId="quot-1_ref-1">Test</div>`
 
@@ -102,7 +102,7 @@ describe("findLdmlNodeInHtml", () => {
     expect(result?.textContent).toEqual("Test")
   })
 
-  test("finds nothing if eId does not match (element)", () => {
+  it("finds nothing if eId does not match (element)", () => {
     const htmlElement = document.createElement("div")
     htmlElement.innerHTML = `<div class="akn-ref" data-eId="quot-1_ref-2">Test</div>`
 
@@ -117,7 +117,7 @@ describe("findLdmlNodeInHtml", () => {
     expect(result).toBeNull()
   })
 
-  test("finds nothing if eId does not match (text node)", () => {
+  it("finds nothing if eId does not match (text node)", () => {
     const htmlElement = document.createElement("div")
     htmlElement.innerHTML = `<div class="akn-ref" data-eId="quot-1_ref-2">Test</div>`
 
@@ -147,7 +147,7 @@ describe("findOffsetInOtherNode", () => {
 
   for (let i = 0; i < (htmlElement.firstChild?.textContent?.length ?? 0); i++) {
     if (!htmlElement.firstChild?.textContent?.charAt(i).match(/\s/)) {
-      test(`finds the same character for non white-space indexes (Index: ${i})`, () => {
+      it(`finds the same character for non white-space indexes (Index: ${i})`, () => {
         const offset = findOffsetInOtherNode(
           htmlElement.firstChild!,
           i,
@@ -162,7 +162,7 @@ describe("findOffsetInOtherNode", () => {
 })
 
 describe("htmlRenderRangeToLdmlDeRange", () => {
-  test("creates correct range for a simple range", () => {
+  it("creates correct range for a simple range", () => {
     const htmlElement = document.createElement("div")
     htmlElement.innerHTML = `<div class="akn-ref" data-eId="quot-1_ref-1">Test text 123</div>`
 
@@ -186,7 +186,7 @@ describe("htmlRenderRangeToLdmlDeRange", () => {
     expect(result?.endOffset).toEqual(15)
   })
 
-  test("creates correct range for range over nested element", () => {
+  it("creates correct range for range over nested element", () => {
     const htmlElement = document.createElement("div")
     htmlElement.innerHTML = `<div class="akn-quotedText" data-eId="quot-1">Test <span class="akn:ref" data-eId="quot-1_ref-1">text</span> 123</div>`
 
@@ -215,7 +215,7 @@ describe("htmlRenderRangeToLdmlDeRange", () => {
 })
 
 describe("ldmlRenderRangeToHtmlRange", () => {
-  test("creates correct range for a simple range", () => {
+  it("creates correct range for a simple range", () => {
     const htmlElement = document.createElement("div")
     htmlElement.innerHTML = `<div class="akn-ref" data-eId="quot-1_ref-1">Test text    123</div>`
 
@@ -239,7 +239,7 @@ describe("ldmlRenderRangeToHtmlRange", () => {
     expect(result?.endOffset).toEqual(15)
   })
 
-  test("creates correct range for range over nested element", () => {
+  it("creates correct range for range over nested element", () => {
     const htmlElement = document.createElement("div")
     htmlElement.innerHTML = `<div class="akn-quotedText" data-eId="quot-1">Test <span class="akn:ref" data-eId="quot-1_ref-1">text</span>    123</div>`
 

--- a/frontend/src/lib/proprietary.spec.ts
+++ b/frontend/src/lib/proprietary.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest"
+import { describe, expect, it } from "vitest"
 import {
   DocumentTypeValues,
   MetaArtValues,
@@ -14,7 +14,7 @@ import {
 } from "./proprietary"
 
 describe("getDocumentTypeFromMetadata", () => {
-  test("returns the document type", () => {
+  it("returns the document type", () => {
     const combinations = Object.entries(DocumentTypeValues)
 
     combinations.forEach(([expectedResult, input]) => {
@@ -24,7 +24,7 @@ describe("getDocumentTypeFromMetadata", () => {
     })
   })
 
-  test("returns unknown if no combination matches", () => {
+  it("returns unknown if no combination matches", () => {
     expect(
       getDocumentTypeFromMetadata(
         "regelungstext",
@@ -34,7 +34,7 @@ describe("getDocumentTypeFromMetadata", () => {
     ).toBe(UNKNOWN_DOCUMENT_TYPE)
   })
 
-  test("returns unknown if all inputs are empty", () => {
+  it("returns unknown if all inputs are empty", () => {
     // @ts-expect-error breaking on purpose for testing
     expect(getDocumentTypeFromMetadata(undefined, undefined, undefined)).toBe(
       UNKNOWN_DOCUMENT_TYPE,
@@ -45,71 +45,71 @@ describe("getDocumentTypeFromMetadata", () => {
 })
 
 describe("isMetaArtValue", () => {
-  test("identifies valid values", () => {
+  it("identifies valid values", () => {
     MetaArtValues.forEach((value) => {
       expect(isMetaArtValue(value)).toBe(true)
     })
   })
 
-  test("does not identify undefined as a valid value", () => {
+  it("does not identify undefined as a valid value", () => {
     expect(isMetaArtValue(undefined)).toBe(false)
   })
 })
 
 describe("isMetaTypValue", () => {
-  test("identifies valid values", () => {
+  it("identifies valid values", () => {
     MetaTypValues.forEach((value) => {
       expect(isMetaTypValue(value)).toBe(true)
     })
   })
 
-  test("does not identify undefined as a valid value", () => {
+  it("does not identify undefined as a valid value", () => {
     expect(isMetaTypValue(undefined)).toBe(false)
   })
 })
 
 describe("isMetaSubtypValue", () => {
-  test("identifies valid values", () => {
+  it("identifies valid values", () => {
     MetaSubtypValues.forEach((value) => {
       expect(isMetaSubtypValue(value)).toBe(true)
     })
   })
 
-  test("does not identify undefined as a valid value", () => {
+  it("does not identify undefined as a valid value", () => {
     expect(isMetaSubtypValue(undefined)).toBe(false)
   })
 })
 
 describe("isArtNormTypPresent", () => {
-  test("finds type with defined artNorm", () => {
+  it("finds type with defined artNorm", () => {
     const artNorm = "SN,ÄN,ÜN"
     expect(isArtNormTypePresent(artNorm, "SN")).toBeTruthy()
   })
-  test("does not find type with defined artNorm", () => {
+  it("does not find type with defined artNorm", () => {
     const artNorm = "SN,ÜN"
     expect(isArtNormTypePresent(artNorm, "ÄN")).toBeFalsy()
   })
-  test("does not find type with undefined artNorm", () => {
+  it("does not find type with undefined artNorm", () => {
     expect(isArtNormTypePresent(undefined, "SN")).toBeFalsy()
   })
 })
 
 describe("udpateArtNorm", () => {
-  test("adds type with defined artNorm", () => {
+  it("adds type with defined artNorm", () => {
     const artNorm = "ÄN,ÜN"
     expect(udpateArtNorm(artNorm, "SN", true)).toContain("SN")
   })
-  test("adds type with undefined artNorm", () => {
+  it("adds type with undefined artNorm", () => {
     expect(udpateArtNorm(undefined, "SN", true)).toContain("SN")
   })
-  test("removes type with defined artNorm", () => {
+  it("removes type with defined artNorm", () => {
     const artNorm = "SN,ÄN,ÜN"
     expect(udpateArtNorm(artNorm, "SN", false)).not.toContain("SN")
   })
-  test("does not remove type with undefined artNorm", () => {
+  it("does not remove type with undefined artNorm", () => {
     expect(udpateArtNorm(undefined, "SN", false)).toBeUndefined()
   })
-  test("does not add type because is already present", () => {
+  it("does not add type because is already present", () => {
     const artNorm = "ÄN,ÜN"
     expect(udpateArtNorm(artNorm, "ÜN", true)).toBe(artNorm)
   })

--- a/frontend/src/lib/ref.spec.ts
+++ b/frontend/src/lib/ref.spec.ts
@@ -1,10 +1,10 @@
-import { describe, expect, test } from "vitest"
+import { describe, expect, it } from "vitest"
 import { createNewRefElement, deleteRef, getNextRefEId } from "@/lib/ref"
 import { xmlNodeToString, xmlStringToDocument } from "@/services/xmlService"
 import { getNodeByEid } from "@/services/ldmldeService"
 
 describe("getNextRefEId", () => {
-  test("creates the correct eId if no ref exists", () => {
+  it("creates the correct eId if no ref exists", () => {
     const ldmlDocument = xmlStringToDocument(
       `<akn:quotedText xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="quot-1"></akn:quotedText>`,
     )
@@ -14,7 +14,7 @@ describe("getNextRefEId", () => {
     expect(result).toEqual("quot-1_ref-1")
   })
 
-  test("creates the correct eId if a ref already exists", () => {
+  it("creates the correct eId if a ref already exists", () => {
     const ldmlDocument = xmlStringToDocument(
       `<akn:quotedText xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="quot-1">
                     <akn:ref eId="quot-1_ref-1">Test</akn:ref>
@@ -26,7 +26,7 @@ describe("getNextRefEId", () => {
     expect(result).toEqual("quot-1_ref-2")
   })
 
-  test("creates the correct eId if the parent is a text node and it's parent has an eId", () => {
+  it("creates the correct eId if the parent is a text node and it's parent has an eId", () => {
     const ldmlDocument = xmlStringToDocument(
       `<akn:quotedText xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="quot-1">
                     <akn:ref eId="quot-1_ref-1">Test</akn:ref>
@@ -40,7 +40,7 @@ describe("getNextRefEId", () => {
 })
 
 describe("createNewRefElement", () => {
-  test("creates a akn:ref element with an eId and GUID", () => {
+  it("creates a akn:ref element with an eId and GUID", () => {
     const ldmlDocument = xmlStringToDocument(
       `<akn:quotedText xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="quot-1">
                 </akn:quotedText>`,
@@ -55,7 +55,7 @@ describe("createNewRefElement", () => {
 })
 
 describe("deleteRef", () => {
-  test("deletes a akn:ref element", () => {
+  it("deletes a akn:ref element", () => {
     const ldmlDocument = xmlStringToDocument(
       "<akn:quotedText xmlns:akn=\"http://Inhaltsdaten.LegalDocML.de/1.7/\" eId='quot-1'>Render of <akn:ref eId='quot-1_ref-1'>a ref</akn:ref> and <akn:ref eId='quot-1_ref-2'>a second ref</akn:ref></akn:quotedText>",
     )

--- a/frontend/src/services/apiService.spec.ts
+++ b/frontend/src/services/apiService.spec.ts
@@ -1,6 +1,6 @@
 import { INVALID_URL } from "@/services/apiService"
 import { flushPromises } from "@vue/test-utils"
-import { beforeEach, describe, expect, test, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 describe("useApiFetch", () => {
   beforeEach(() => {
@@ -8,7 +8,7 @@ describe("useApiFetch", () => {
     vi.resetModules()
   })
 
-  test("defaults to JSON for request and response bodies", async () => {
+  it("defaults to JSON for request and response bodies", async () => {
     const fetchSpy = vi
       .spyOn(window, "fetch")
       .mockResolvedValue(new Response("{}"))
@@ -30,7 +30,7 @@ describe("useApiFetch", () => {
     )
   })
 
-  test("allows replacing the content headers", async () => {
+  it("allows replacing the content headers", async () => {
     const fetchSpy = vi
       .spyOn(window, "fetch")
       .mockResolvedValue(new Response("{}"))
@@ -60,7 +60,7 @@ describe("useApiFetch", () => {
     )
   })
 
-  test("redirects to the 404 page if the API returns a 404", async () => {
+  it("redirects to the 404 page if the API returns a 404", async () => {
     vi.spyOn(window, "fetch").mockResolvedValue(
       new Response("{}", { status: 404 }),
     )
@@ -79,7 +79,7 @@ describe("useApiFetch", () => {
     vi.doUnmock("@/router")
   })
 
-  test("aborts the request if the URL is marked as invalid", async () => {
+  it("aborts the request if the URL is marked as invalid", async () => {
     const fetchSpy = vi
       .spyOn(window, "fetch")
       .mockResolvedValue(new Response("{}"))
@@ -92,7 +92,7 @@ describe("useApiFetch", () => {
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
-  test("does not set error if it is an abort error", async () => {
+  it("does not set error if it is an abort error", async () => {
     const fetchSpy = vi
       .spyOn(window, "fetch")
       .mockRejectedValue(new DOMException("aborted", "AbortError"))
@@ -105,7 +105,7 @@ describe("useApiFetch", () => {
     expect(error.value).toBeNull()
   })
 
-  test("replaces the exception in case of an error with the response data", async () => {
+  it("replaces the exception in case of an error with the response data", async () => {
     vi.spyOn(window, "fetch").mockResolvedValue(
       new Response('{"type":"/errors/example"}', { status: 404 }),
     )
@@ -119,7 +119,7 @@ describe("useApiFetch", () => {
     })
   })
 
-  test("replaces the exception with a fallback error if the response does not contain data", async () => {
+  it("replaces the exception with a fallback error if the response does not contain data", async () => {
     vi.spyOn(window, "fetch").mockResolvedValue(
       new Response(null, { status: 404 }),
     )

--- a/frontend/src/services/articleService.spec.ts
+++ b/frontend/src/services/articleService.spec.ts
@@ -1,10 +1,10 @@
-import { describe, expect, test, vi } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { nextTick, ref } from "vue"
 import { useArticles } from "@/services/articleService"
 
 describe("articleService", () => {
   describe("useArticles", () => {
-    test("should provide the articles", async () => {
+    it("should provide the articles", async () => {
       const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce(
         new Response(
           JSON.stringify([
@@ -45,7 +45,7 @@ describe("articleService", () => {
       )
     })
 
-    test("should load the articles when the ELI changes", async () => {
+    it("should load the articles when the ELI changes", async () => {
       const fetchSpy = vi
         .spyOn(global, "fetch")
         .mockResolvedValueOnce(new Response())

--- a/frontend/src/services/ldmldeEventRefService.spec.ts
+++ b/frontend/src/services/ldmldeEventRefService.spec.ts
@@ -9,7 +9,7 @@ describe("ldmldeEventRefService", () => {
           <akn:eventRef xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30" eId="meta-1_lebzykl-1_ereignis-2" refersTo="inkrafttreten" source="attributsemantik-noch-undefiniert" type="generation"/>
       `).childNodes.item(0)
 
-      expect(getEventRefDate(node)).to.eq("2023-12-30")
+      expect(getEventRefDate(node)).toBe("2023-12-30")
     })
   })
 })

--- a/frontend/src/services/ldmldeModService.spec.ts
+++ b/frontend/src/services/ldmldeModService.spec.ts
@@ -55,7 +55,7 @@ describe("ldmldeModService", () => {
         </akn:mod>
       `).childNodes.item(0)
 
-      expect(getQuotedTextSecond(node)).to.eq("nach Ablauf von fünf Jahren")
+      expect(getQuotedTextSecond(node)).toBe("nach Ablauf von fünf Jahren")
     })
   })
 
@@ -73,7 +73,7 @@ describe("ldmldeModService", () => {
         </akn:mod>
       `).childNodes.item(0)
 
-      expect(getQuotedTextFirst(node)).to.eq(
+      expect(getQuotedTextFirst(node)).toBe(
         "am Ende des Kalenderjahres, das dem Jahr der Protokollierung folgt,",
       )
     })
@@ -93,7 +93,7 @@ describe("ldmldeModService", () => {
         </akn:mod>
       `).childNodes.item(0)
 
-      expect(getDestinationHref(node)).to.eq(
+      expect(getDestinationHref(node)).toBe(
         "eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1/hauptteil-1_abschnitt-erster_art-6_abs-3_inhalt-3_text-1/100-126.xml",
       )
     })
@@ -113,7 +113,7 @@ describe("ldmldeModService", () => {
         </akn:mod>
       `).documentElement
 
-      expect(getTextualModType(node)).to.eq("aenderungsbefehl-ersetzen")
+      expect(getTextualModType(node)).toEqual("aenderungsbefehl-ersetzen")
     })
   })
 
@@ -152,7 +152,7 @@ describe("ldmldeModService", () => {
           xml,
           "hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1",
         ),
-      ).to.deep.equal({
+      ).toEqual({
         date: "2023-12-30",
         temporalGroupEid: "meta-1_geltzeiten-1_geltungszeitgr-1",
       })
@@ -337,7 +337,7 @@ describe("ldmldeModService", () => {
             </akn:mod>
       `).childNodes.item(0)
 
-      expect(getDestinationRangeFrom(node)).to.be.eq(
+      expect(getDestinationRangeFrom(node)).toBe(
         "eli/bund/bgbl-1/1999/66/1999-01-01/1/deu/regelungstext-1/hauptteil-1_art-2_abs-1.xml",
       )
     })
@@ -367,7 +367,7 @@ describe("ldmldeModService", () => {
             </akn:mod>
       `).childNodes.item(0)
 
-      expect(getDestinationRangeUpto(node)).to.be.eq(
+      expect(getDestinationRangeUpto(node)).toBe(
         "eli/bund/bgbl-1/1999/66/1999-01-01/1/deu/regelungstext-1/hauptteil-1_art-2_abs-2.xml",
       )
     })

--- a/frontend/src/services/ldmldeService.spec.ts
+++ b/frontend/src/services/ldmldeService.spec.ts
@@ -26,7 +26,7 @@ describe("ldmldeService", () => {
       `)
 
       const node = getNodeByEid(document, "hauptteil-1_art-1_bezeichnung-1")
-      expect(node?.textContent?.trim()).to.eq("Artikel 1")
+      expect(node?.textContent?.trim()).toBe("Artikel 1")
     })
   })
 
@@ -76,7 +76,7 @@ describe("ldmldeService", () => {
       )
 
       expect(node).not.toBeNull()
-      expect(evaluateXPathOnce("@eId", node!)?.nodeValue).to.eq(
+      expect(evaluateXPathOnce("@eId", node!)?.nodeValue).toBe(
         "meta-1_analysis-1_activemod-1_textualmod-1",
       )
     })

--- a/frontend/src/services/ldmldeTemporalGroupService.spec.ts
+++ b/frontend/src/services/ldmldeTemporalGroupService.spec.ts
@@ -17,7 +17,7 @@ describe("ldmldeTemporalGroupModService", () => {
         </akn:temporalGroup>
       `).childNodes.item(0)
 
-      expect(getStartEventRefEid(node)).to.eq("meta-1_lebzykl-1_ereignis-2")
+      expect(getStartEventRefEid(node)).toBe("meta-1_lebzykl-1_ereignis-2")
     })
   })
 
@@ -29,7 +29,7 @@ describe("ldmldeTemporalGroupModService", () => {
         </akn:temporalGroup>
       `).childNodes.item(0)
 
-      expect(getTemporalGroupEId(node)).to.eq(
+      expect(getTemporalGroupEId(node)).toBe(
         "meta-1_geltzeiten-1_geltungszeitgr-1",
       )
     })
@@ -66,7 +66,7 @@ describe("ldmldeTemporalGroupModService", () => {
       `)
 
       const node = getNodeByEid(xml, "meta-1_geltzeiten-1_geltungszeitgr-1")!
-      expect(getTemporalGroupDate(node)).to.equal("2023-12-30")
+      expect(getTemporalGroupDate(node)).toBe("2023-12-30")
     })
   })
 
@@ -105,10 +105,10 @@ describe("ldmldeTemporalGroupModService", () => {
 
       const nodes = getTemporalGroupNodes(xml)
       expect(nodes).toHaveLength(2)
-      expect(getTemporalGroupEId(nodes[0])).to.eq(
+      expect(getTemporalGroupEId(nodes[0])).toBe(
         "meta-1_geltzeiten-1_geltungszeitgr-1",
       )
-      expect(getTemporalGroupEId(nodes[1])).to.eq(
+      expect(getTemporalGroupEId(nodes[1])).toBe(
         "meta-1_geltzeiten-1_geltungszeitgr-2",
       )
     })

--- a/frontend/src/services/ldmldeTextualModService.spec.ts
+++ b/frontend/src/services/ldmldeTextualModService.spec.ts
@@ -13,7 +13,7 @@ describe("ldmldeTextualModService", () => {
         </akn:textualMod>
       `).childNodes.item(0)
 
-      expect(getForcePeriod(node)).to.eq("meta-1_geltzeiten-1_geltungszeitgr-1")
+      expect(getForcePeriod(node)).toBe("meta-1_geltzeiten-1_geltungszeitgr-1")
     })
   })
 })

--- a/frontend/src/services/temporalDataService.spec.ts
+++ b/frontend/src/services/temporalDataService.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { nextTick, ref } from "vue"
 
-describe("TemporalDataService", () => {
+describe("temporalDataService", () => {
   beforeEach(() => {
     vi.resetModules()
     vi.resetAllMocks()

--- a/frontend/src/services/xmlService.spec.ts
+++ b/frontend/src/services/xmlService.spec.ts
@@ -22,8 +22,8 @@ describe("xmlService", () => {
         </akn:akomaNtoso>
       `)
 
-      expect(document.getRootNode().childNodes.length).to.eq(2)
-      expect(document.getRootNode().childNodes.item(1).nodeName).eq(
+      expect(document.getRootNode().childNodes.length).toBe(2)
+      expect(document.getRootNode().childNodes.item(1).nodeName).toBe(
         "akn:akomaNtoso",
       )
     })
@@ -59,7 +59,7 @@ describe("xmlService", () => {
       `)
 
       const result = evaluateXPathOnce("//akn:act/@name", document)
-      expect(result?.nodeValue).to.eq("regelungstext")
+      expect(result?.nodeValue).toBe("regelungstext")
     })
   })
 
@@ -78,8 +78,8 @@ describe("xmlService", () => {
 
       const result = evaluateXPath("//akn:act/@name", document)
       expect(result).toHaveLength(2)
-      expect(result[0].nodeValue).to.eq("regelungstext")
-      expect(result[1].nodeValue).to.eq("regelungstext-2")
+      expect(result[0].nodeValue).toBe("regelungstext")
+      expect(result[1].nodeValue).toBe("regelungstext-2")
     })
   })
 })


### PR DESCRIPTION
This PR:

- Installs the ESLint plugin for Testing Library again after we removed it during the ESLint v9 upgrade due to incompatibility
- Installs the ESLint plugin for Vitest to help us write better, more consistent tests
- Fixes all problems reported by the new linter rules