### PR TITLE
Use generic error message for unhandled exceptions

### DIFF
--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ElementControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ElementControllerIntegrationTest.java
@@ -286,7 +286,7 @@ class ElementControllerIntegrationTest extends BaseIntegrationTest {
         )
         // Then
         .andExpect(status().is5xxServerError())
-        .andExpect(jsonPath("type").value("/errors/internal-server-error"))
+        .andExpect(jsonPath("type").value("/errors/missing-required-parameter"))
         .andExpect(jsonPath("status").value(500))
         .andExpect(
           jsonPath("detail")

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/NormManifestationControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/NormManifestationControllerIntegrationTest.java
@@ -83,8 +83,8 @@ public class NormManifestationControllerIntegrationTest extends BaseIntegrationT
       mockMvc
         .perform(get("/api/v1/norms/{eli}", eli))
         .andExpect(status().isInternalServerError())
-        .andExpect(jsonPath("type").value("/errors/internal-server-error"))
-        .andExpect(jsonPath("title").value("Internal Server Error"))
+        .andExpect(jsonPath("type").value("/errors/no-static-resource"))
+        .andExpect(jsonPath("title").value("No static resource found"))
         .andExpect(jsonPath("status").value(500))
         .andExpect(
           jsonPath("detail")


### PR DESCRIPTION
This commit removes the detailed error output from the fallback exception handler that is used as controller advice for all exceptions that aren't handled explicitly. The message is replaced with a generic note that an error has occurred. If we use the exception message we might leak internal information such as DB constraints in the API response.

RISDEV-4871