### PR TITLE
Refactor usage of Optionals for mandatory eIds

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ArticleController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ArticleController.java
@@ -143,7 +143,7 @@ public class ArticleController {
     return norm
       .getArticles()
       .stream()
-      .filter(article -> article.getEid().isPresent() && article.getEid().get().equals(eid))
+      .filter(article -> article.getEid().equals(eid))
       .findFirst()
       .map(ArticleResponseMapper::fromNormArticle)
       .map(ResponseEntity::ok)

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ArticleResponseMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ArticleResponseMapper.java
@@ -19,7 +19,7 @@ public class ArticleResponseMapper {
   public static ArticleResponseSchema fromNormArticle(final Article article) {
     return new ArticleResponseSchema(
       article.getEnumeration().orElse(null),
-      article.getEid().orElse(null),
+      article.getEid(),
       article.getHeading().orElse(null),
       article.getAffectedDocumentEli().map(ExpressionEli::toString).orElse(null)
     );

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ElementResponseMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ElementResponseMapper.java
@@ -56,7 +56,7 @@ public class ElementResponseMapper {
     return ElementResponseSchema
       .builder()
       .title(getNodeTitle(node))
-      .eid(EId.fromNode(node).map(EId::value).orElseThrow())
+      .eid(EId.fromMandatoryNode(node).value())
       .type(getNodeType(node))
       .build();
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/TimeBoundaryMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/TimeBoundaryMapper.java
@@ -20,7 +20,7 @@ public class TimeBoundaryMapper {
     return TimeBoundarySchema
       .builder()
       .date(timeBoundary.getEventRef().getDate().orElse(null))
-      .eventRefEid(timeBoundary.getEventRefEid().orElse(null))
+      .eventRefEid(timeBoundary.getEventRefEid())
       .temporalGroupEid(timeBoundary.getTemporalGroupEid().orElse(null))
       .build();
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/TimeBoundaryMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/TimeBoundaryMapper.java
@@ -21,7 +21,7 @@ public class TimeBoundaryMapper {
       .builder()
       .date(timeBoundary.getEventRef().getDate().orElse(null))
       .eventRefEid(timeBoundary.getEventRefEid())
-      .temporalGroupEid(timeBoundary.getTemporalGroupEid().orElse(null))
+      .temporalGroupEid(timeBoundary.getTemporalGroupEid())
       .build();
   }
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/ArticleService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/ArticleService.java
@@ -50,7 +50,7 @@ public class ArticleService
     return norm
       .getArticles()
       .stream()
-      .filter(article -> article.getEid().isPresent() && article.getEid().get().equals(query.eid()))
+      .filter(article -> article.getEid().equals(query.eid()))
       .findFirst()
       .map(article -> XmlMapper.toString(article.getNode()))
       .map(xml ->
@@ -156,7 +156,7 @@ public class ArticleService
           // Modifications can be either on the article itself or anywhere
           // inside the article, hence the "contains" rather than exact
           // matching.
-          destinationEid.contains(article.getEid().orElseThrow())
+          destinationEid.contains(article.getEid())
         );
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/ElementService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/ElementService.java
@@ -166,7 +166,7 @@ public class ElementService
         // no amending law -> all elements are fine
         if (query.amendedBy() == null) return true;
 
-        var eId = EId.fromNode(element).map(EId::value).orElseThrow();
+        var eId = EId.fromMandatoryNode(element).value();
         return passiveModsDestinationEids.stream().anyMatch(modEid -> modEid.contains(eId));
       })
       .toList();

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/NormService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/NormService.java
@@ -209,10 +209,7 @@ public class NormService
     final Instant atDate = amendingNorm
       .getTimeBoundaries()
       .stream()
-      .filter(timeBoundary ->
-        timeBoundary.getTemporalGroupEid().isPresent() &&
-        timeBoundary.getTemporalGroupEid().get().equals(timeBoundaryEId)
-      )
+      .filter(timeBoundary -> timeBoundary.getTemporalGroupEid().equals(timeBoundaryEId))
       .findFirst()
       .map(filtered -> filtered.getEventRef().getDate())
       .flatMap(date -> date.map(d -> d.minusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant()))

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/NormService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/NormService.java
@@ -179,7 +179,7 @@ public class NormService
     final Mod selectedMod = amendingNorm
       .getMods()
       .stream()
-      .filter(m -> m.getEid().isPresent() && m.getEid().get().equals(eId))
+      .filter(m -> m.getEid().equals(eId))
       .findFirst()
       .orElseThrow(() ->
         new ValidationException(

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/SingleModValidator.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/SingleModValidator.java
@@ -69,7 +69,7 @@ public class SingleModValidator {
     Node targetNode
   ) throws ValidationException {
     final Href destinationHref = passivemod.getDestinationHref().orElseThrow();
-    final String passiveModEid = passivemod.getEid().orElseThrow();
+    final String passiveModEid = passivemod.getEid();
     final CharacterRange characterRange = destinationHref
       .getCharacterRange()
       .orElseThrow(() ->

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/SingleModValidator.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/SingleModValidator.java
@@ -23,7 +23,7 @@ public class SingleModValidator {
    * @throws ValidationException if a validation step fails
    */
   public void validate(final Norm zf0Norm, final Mod activeMod) throws ValidationException {
-    final String modEId = activeMod.getMandatoryEid();
+    final String modEId = activeMod.getEid();
     final ExpressionEli zf0NormEli = zf0Norm.getExpressionEli();
 
     final TextualMod affectedPassiveMod = zf0Norm

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeBoundaryService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeBoundaryService.java
@@ -72,7 +72,7 @@ public class TimeBoundaryService
       .getTemporalData()
       .getTemporalGroups()
       .stream()
-      .filter(f -> temporalGroupEidAmendedBy.contains(f.getEid().orElseThrow()))
+      .filter(f -> temporalGroupEidAmendedBy.contains(f.getEid()))
       .toList();
     return norm.getTimeBoundaries(temporalGroups);
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeBoundaryService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeBoundaryService.java
@@ -118,20 +118,19 @@ public class TimeBoundaryService
     List<TimeBoundary> timeBoundariesToUpdate = norm
       .getTimeBoundaries()
       .stream()
-      .filter(tb -> tb.getEventRefEid().isPresent())
       .filter(tb ->
         datesToUpdate
           .stream()
           .map(TimeBoundaryChangeData::eid)
           .toList()
-          .contains(tb.getEventRefEid().get())
+          .contains(tb.getEventRefEid())
       )
       .toList();
 
     timeBoundariesToUpdate.forEach(tb -> {
       LocalDate newDate = datesToUpdate
         .stream()
-        .filter(date -> date.eid().equals(tb.getEventRefEid().get()))
+        .filter(date -> date.eid().equals(tb.getEventRefEid()))
         .map(TimeBoundaryChangeData::date)
         .findFirst()
         .orElse(LocalDate.MIN);
@@ -149,8 +148,6 @@ public class TimeBoundaryService
       .getTimeBoundaries()
       .stream()
       .map(TimeBoundary::getEventRefEid)
-      .filter(Optional::isPresent)
-      .map(Optional::get)
       .toList();
 
     List<TimeBoundaryChangeData> timeBoundariesListedButNotUpdated = datesToUpdate
@@ -189,8 +186,6 @@ public class TimeBoundaryService
       .getTimeBoundaries()
       .stream()
       .map(TimeBoundary::getEventRefEid)
-      .filter(Optional::isPresent)
-      .map(Optional::get)
       .filter(eid -> !allChangeDateEids.contains(eid))
       .toList();
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineService.java
@@ -104,7 +104,7 @@ public class TimeMachineService implements ApplyPassiveModificationsUseCase {
         return amendingLaw
           .getMods()
           .stream()
-          .filter(mod -> mod.getEid().equals(sourceEid))
+          .filter(mod -> mod.getEid().equals(sourceEid.get()))
           .map(mod -> new ModData(passiveModification, mod));
       })
       .forEach(modData -> applyMod(modData, norm));
@@ -139,7 +139,7 @@ public class TimeMachineService implements ApplyPassiveModificationsUseCase {
         applyQuotedText(modData, targetNode.get());
       } catch (IllegalArgumentException | IndexOutOfBoundsException exception) {
         log.info(
-          "Could not apply quoted text mod (%s)".formatted(modData.mod().getMandatoryEid()),
+          "Could not apply quoted text mod (%s)".formatted(modData.mod().getEid()),
           exception
         );
       }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/TimeMachineService.java
@@ -86,7 +86,7 @@ public class TimeMachineService implements ApplyPassiveModificationsUseCase {
           .orElseThrow(() ->
             new ValidationException(
               ValidationException.ErrorType.SOURCE_HREF_IN_META_MOD_MISSING,
-              Pair.of(ValidationException.FieldName.EID, passiveModification.getEid().orElse(""))
+              Pair.of(ValidationException.FieldName.EID, passiveModification.getEid())
             )
           );
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/UpdateNormService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/UpdateNormService.java
@@ -41,7 +41,7 @@ public class UpdateNormService
           .equals(Optional.of(sourceNormEli))
       )
       .forEach(passiveModification -> {
-        norm.deleteByEId(passiveModification.getEid().orElseThrow());
+        norm.deleteByEId(passiveModification.getEid());
 
         final var temporalGroup = passiveModification
           .getForcePeriodEid()

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/UpdateNormService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/UpdateNormService.java
@@ -162,7 +162,7 @@ public class UpdateNormService
     amendingNorm
       .getMods()
       .stream()
-      .filter(mod -> mod.getEid().isPresent() && mod.getEid().get().equals(query.eId()))
+      .filter(mod -> mod.getEid().equals(query.eId()))
       .findFirst()
       .ifPresent(inTextMod -> {
         if (

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/UpdateNormService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/UpdateNormService.java
@@ -95,7 +95,7 @@ public class UpdateNormService
         final var temporalGroup = norm.addTimeBoundary(startDate.get(), EventRefType.AMENDMENT);
         amendingNormTemporalGroupEidsToNormTemporalGroupEids.put(
           forcePeriodEid,
-          temporalGroup.getEid().orElseThrow()
+          temporalGroup.getEid()
         );
       });
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Article.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Article.java
@@ -47,7 +47,7 @@ public class Article {
    * @return The eId of the article
    */
   public Optional<String> getEid() {
-    return EId.fromNode(getNode()).map(EId::value);
+    return Optional.of(EId.fromMandatoryNode(getNode()).value());
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Article.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Article.java
@@ -46,16 +46,7 @@ public class Article {
    *
    * @return The eId of the article
    */
-  public Optional<String> getEid() {
-    return Optional.of(EId.fromMandatoryNode(getNode()).value());
-  }
-
-  /**
-   * Returns the eId as {@link String} from a {@link Node} in a {@link Norm}.
-   *
-   * @return The eId of the article
-   */
-  public String getMandatoryEid() {
+  public String getEid() {
     return EId.fromMandatoryNode(getNode()).value();
   }
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/EventRef.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/EventRef.java
@@ -17,7 +17,7 @@ public class EventRef {
   private final Node node;
 
   public EId getEid() {
-    return EId.fromNode(node).orElseThrow();
+    return EId.fromMandatoryNode(node);
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Mod.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Mod.java
@@ -35,17 +35,8 @@ public class Mod {
    *
    * @return The eId of the mod
    */
-  public Optional<String> getEid() {
-    return Optional.of(EId.fromMandatoryNode(getNode()).value());
-  }
-
-  /**
-   * Returns the value of the eId as {@link String}.
-   *
-   * @return the eId of the mod
-   */
-  public String getMandatoryEid() {
-    return NodeParser.getValueFromMandatoryNodeFromExpression("./@eId", this.node);
+  public String getEid() {
+    return EId.fromMandatoryNode(getNode()).value();
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Mod.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Mod.java
@@ -36,7 +36,7 @@ public class Mod {
    * @return The eId of the mod
    */
   public Optional<String> getEid() {
-    return EId.fromNode(getNode()).map(EId::value);
+    return Optional.of(EId.fromMandatoryNode(getNode()).value());
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Norm.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Norm.java
@@ -204,9 +204,7 @@ public class Norm {
       .getTemporalData()
       .getTemporalGroups()
       .stream()
-      .filter(temporalGroup ->
-        temporalGroup.getEid().map(eid -> eid.equals(temporalGroupEid)).orElse(false)
-      )
+      .filter(temporalGroup -> temporalGroup.getEid().equals(temporalGroupEid))
       .findFirst()
       .flatMap(m -> m.getTimeInterval().getEventRefEId());
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TemporalGroup.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TemporalGroup.java
@@ -1,7 +1,6 @@
 package de.bund.digitalservice.ris.norms.domain.entity;
 
 import de.bund.digitalservice.ris.norms.utils.NodeParser;
-import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
@@ -20,8 +19,8 @@ public class TemporalGroup {
    *
    * @return The eId of the temporal group
    */
-  public Optional<String> getEid() {
-    return Optional.of(EId.fromMandatoryNode(getNode()).value());
+  public String getEid() {
+    return EId.fromMandatoryNode(getNode()).value();
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TemporalGroup.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TemporalGroup.java
@@ -21,7 +21,7 @@ public class TemporalGroup {
    * @return The eId of the temporal group
    */
   public Optional<String> getEid() {
-    return EId.fromNode(getNode()).map(EId::value);
+    return Optional.of(EId.fromMandatoryNode(getNode()).value());
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TextualMod.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TextualMod.java
@@ -22,8 +22,8 @@ public class TextualMod {
    *
    * @return The eId of the modification
    */
-  public Optional<String> getEid() {
-    return Optional.of(EId.fromMandatoryNode(getNode()).value());
+  public String getEid() {
+    return EId.fromMandatoryNode(getNode()).value();
   }
 
   /**
@@ -69,7 +69,7 @@ public class TextualMod {
         var newElement = getNode().getOwnerDocument().createElement("akn:destination");
         newElement.setAttribute(
           "eId",
-          new EId(this.getEid().orElseThrow()).addPart(new EIdPart("destination", "1")).value()
+          new EId(this.getEid()).addPart(new EIdPart("destination", "1")).value()
         );
         newElement.setAttribute("GUID", UUID.randomUUID().toString());
         getNode().appendChild(newElement);
@@ -123,7 +123,7 @@ public class TextualMod {
         var newElement = getNode().getOwnerDocument().createElement("akn:force");
         newElement.setAttribute(
           "eId",
-          new EId(this.getEid().orElseThrow()).addPart(new EIdPart("gelzeitnachw", "1")).value()
+          new EId(this.getEid()).addPart(new EIdPart("gelzeitnachw", "1")).value()
         );
         newElement.setAttribute("GUID", UUID.randomUUID().toString());
         getNode().appendChild(newElement);

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TextualMod.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TextualMod.java
@@ -23,7 +23,7 @@ public class TextualMod {
    * @return The eId of the modification
    */
   public Optional<String> getEid() {
-    return EId.fromNode(getNode()).map(EId::value);
+    return Optional.of(EId.fromMandatoryNode(getNode()).value());
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TimeBoundary.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TimeBoundary.java
@@ -23,7 +23,7 @@ public class TimeBoundary {
    * @return The eId of the eventRef
    */
   public Optional<String> getEventRefEid() {
-    return EId.fromNode(eventRef.getNode()).map(EId::value);
+    return Optional.of(EId.fromMandatoryNode(eventRef.getNode()).value());
   }
 
   /**
@@ -32,7 +32,7 @@ public class TimeBoundary {
    * @return The eId of the timeInterval
    */
   public Optional<String> getTimeIntervalEid() {
-    return EId.fromNode(timeInterval.getNode()).map(EId::value);
+    return Optional.of(EId.fromMandatoryNode(timeInterval.getNode()).value());
   }
 
   /**
@@ -41,7 +41,7 @@ public class TimeBoundary {
    * @return The eId of the temporal group
    */
   public Optional<String> getTemporalGroupEid() {
-    return EId.fromNode(temporalGroup.getNode()).map(EId::value);
+    return Optional.of(EId.fromMandatoryNode(temporalGroup.getNode()).value());
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TimeBoundary.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TimeBoundary.java
@@ -1,7 +1,6 @@
 package de.bund.digitalservice.ris.norms.domain.entity;
 
 import java.time.LocalDate;
-import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
@@ -40,8 +39,8 @@ public class TimeBoundary {
    *
    * @return The eId of the temporal group
    */
-  public Optional<String> getTemporalGroupEid() {
-    return Optional.of(EId.fromMandatoryNode(temporalGroup.getNode()).value());
+  public String getTemporalGroupEid() {
+    return EId.fromMandatoryNode(temporalGroup.getNode()).value();
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TimeBoundary.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TimeBoundary.java
@@ -31,8 +31,8 @@ public class TimeBoundary {
    *
    * @return The eId of the timeInterval
    */
-  public Optional<String> getTimeIntervalEid() {
-    return Optional.of(EId.fromMandatoryNode(timeInterval.getNode()).value());
+  public String getTimeIntervalEid() {
+    return EId.fromMandatoryNode(timeInterval.getNode()).value();
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TimeBoundary.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/TimeBoundary.java
@@ -22,8 +22,8 @@ public class TimeBoundary {
    *
    * @return The eId of the eventRef
    */
-  public Optional<String> getEventRefEid() {
-    return Optional.of(EId.fromMandatoryNode(eventRef.getNode()).value());
+  public String getEventRefEid() {
+    return EId.fromMandatoryNode(eventRef.getNode()).value();
   }
 
   /**

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ArticleControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ArticleControllerTest.java
@@ -104,7 +104,7 @@ class ArticleControllerTest {
           norm
             .getArticles()
             .stream()
-            .filter(article -> article.getEid().get().equals("hauptteil-1_art-1"))
+            .filter(article -> article.getEid().equals("hauptteil-1_art-1"))
             .toList()
         );
 
@@ -144,7 +144,7 @@ class ArticleControllerTest {
           norm
             .getArticles()
             .stream()
-            .filter(article -> article.getEid().get().equals("hauptteil-1_art-1"))
+            .filter(article -> article.getEid().equals("hauptteil-1_art-1"))
             .toList()
         );
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ElementResponseMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/mapper/ElementResponseMapperTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import de.bund.digitalservice.ris.norms.utils.XmlMapper;
-import java.util.NoSuchElementException;
+import de.bund.digitalservice.ris.norms.utils.exceptions.MandatoryNodeNotFoundException;
 import org.junit.jupiter.api.Test;
 
 class ElementResponseMapperTest {
@@ -14,7 +14,7 @@ class ElementResponseMapperTest {
     // Given
     var node = XmlMapper.toNode(
       """
-                  <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" GUID="000" eId="hauptteil-1_art-1" refersTo="stammform">
+      <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" GUID="000" eId="hauptteil-1_art-1" refersTo="stammform">
         <akn:num GUID="000" eId="hauptteil-1_bezeichnung-1">
 
               § 1
@@ -41,7 +41,7 @@ class ElementResponseMapperTest {
     // Given
     var node = XmlMapper.toNode(
       """
-                  <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" GUID="000" eId="hauptteil-1_art-1" refersTo="stammform">
+      <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" GUID="000" eId="hauptteil-1_art-1" refersTo="stammform">
         <akn:heading GUID="000" eId="hauptteil-1_überschrift-1">
           Überschrift des Artikels
         </akn:heading>
@@ -64,7 +64,7 @@ class ElementResponseMapperTest {
     // Given
     var node = XmlMapper.toNode(
       """
-                  <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" GUID="000" eId="hauptteil-1_art-1" refersTo="stammform">
+      <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" GUID="000" eId="hauptteil-1_art-1" refersTo="stammform">
         <akn:num GUID="000" eId="hauptteil-1_bezeichnung-1">
 
               § 1
@@ -88,7 +88,7 @@ class ElementResponseMapperTest {
     // Given
     var node = XmlMapper.toNode(
       """
-                  <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" GUID="000" eId="hauptteil-1_art-1" refersTo="stammform">
+      <akn:article xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" GUID="000" eId="hauptteil-1_art-1" refersTo="stammform">
         <akn:paragraph GUID="000" eId="hauptteil-1_abs-1"></akn:paragraph>
       </akn:article>
       """
@@ -108,7 +108,7 @@ class ElementResponseMapperTest {
     // Given
     var node = XmlMapper.toNode(
       """
-              <akn:book xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="hauptteil-1_buch-1" GUID="3c36aeed-d116-47c1-b475-a5e8bdfefe63">
+      <akn:book xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="hauptteil-1_buch-1" GUID="3c36aeed-d116-47c1-b475-a5e8bdfefe63">
         <akn:num
           eId="hauptteil-1_buch-1_bezeichnung-1"
           GUID="5b8320d2-2ed9-4652-aa5a-147da381f87c"
@@ -142,7 +142,7 @@ class ElementResponseMapperTest {
     // Given
     var node = XmlMapper.toNode(
       """
-              <akn:part xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/"
+      <akn:part xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/"
         eId="hauptteil-1_buch-1_teil-1"
         GUID="8afdae9b-dcf4-48c8-ba38-31f24526bcf0"
       >
@@ -179,7 +179,7 @@ class ElementResponseMapperTest {
     // Given
     var node = XmlMapper.toNode(
       """
-              <akn:chapter xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/"
+      <akn:chapter xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/"
         eId="hauptteil-1_buch-1_teil-1_kapitel-1"
         GUID="d4b23c42-acab-4220-af45-faa22820d588"
       >
@@ -216,7 +216,7 @@ class ElementResponseMapperTest {
     // Given
     var node = XmlMapper.toNode(
       """
-              <akn:section xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/"
+      <akn:section xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/"
         eId="hauptteil-1_abschnitt-1"
         GUID="f1474e45-57fe-4ba4-983e-efef589d31f3"
       >
@@ -253,7 +253,7 @@ class ElementResponseMapperTest {
     // Given
     var node = XmlMapper.toNode(
       """
-              <akn:subsection xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/"
+      <akn:subsection xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/"
         eId="hauptteil-1_abschnitt-1_uabschnitt-1"
         GUID="18F63BE0-B9AB-4464-92A0-8469EE5CE8A0"
       >
@@ -290,7 +290,7 @@ class ElementResponseMapperTest {
     // Given
     var node = XmlMapper.toNode(
       """
-              <akn:title xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/"
+      <akn:title xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/"
         eId="hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1"
         GUID="564b7bae-affe-42db-a82a-957727e75da3"
       >
@@ -321,7 +321,7 @@ class ElementResponseMapperTest {
     // Given
     var node = XmlMapper.toNode(
       """
-              <akn:subtitle xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/"
+      <akn:subtitle xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/"
         eId="hauptteil-1_buch-1_teil-1_kapitel-1_abschnitt-1_uabschnitt-1_titel-1_utitel-1"
         GUID="bdcbfaa4-faa7-48e1-89e1-951fe3181c05"
       >
@@ -359,7 +359,7 @@ class ElementResponseMapperTest {
     // Given
     var node = XmlMapper.toNode(
       """
-          <akn:preface xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="einleitung-1" GUID="000">
+      <akn:preface xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="einleitung-1" GUID="000">
         <akn:longTitle></akn:longTitle>
         <akn:block></akn:block>
       </akn:preface>
@@ -380,7 +380,7 @@ class ElementResponseMapperTest {
     // Given
     var node = XmlMapper.toNode(
       """
-          <akn:preamble xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="preambel-1" GUID="000">
+      <akn:preamble xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="preambel-1" GUID="000">
         <akn:formula></akn:formula>
       </akn:preamble>
       """
@@ -400,7 +400,7 @@ class ElementResponseMapperTest {
     // Given
     var node = XmlMapper.toNode(
       """
-              <akn:conclusions xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="schluss-1" GUID="000">
+      <akn:conclusions xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="schluss-1" GUID="000">
         <akn:formula></akn:formula>
         <akn:blockContainer></akn:blockContainer>
       </akn:conclusions>
@@ -421,7 +421,7 @@ class ElementResponseMapperTest {
     // Given
     var node = XmlMapper.toNode(
       """
-          <akn:someRandomNode xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="random-1" GUID="000">
+      <akn:someRandomNode xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" eId="random-1" GUID="000">
       </akn:someRandomNode>
       """
     );
@@ -440,7 +440,7 @@ class ElementResponseMapperTest {
     // Given
     var node = XmlMapper.toNode(
       """
-          <akn:preface xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" GUID="000">
+      <akn:preface xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7/" GUID="000">
         <akn:longTitle></akn:longTitle>
         <akn:block></akn:block>
       </akn:preface>
@@ -449,6 +449,6 @@ class ElementResponseMapperTest {
 
     // When
     assertThatThrownBy(() -> ElementResponseMapper.fromElementNode(node))
-      .isInstanceOf(NoSuchElementException.class);
+      .isInstanceOf(MandatoryNodeNotFoundException.class);
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/ArticleServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/ArticleServiceTest.java
@@ -109,8 +109,8 @@ class ArticleServiceTest {
 
       // Then
       assertThat(articles).hasSize(2);
-      assertThat(articles.get(0).getEid()).contains("hauptteil-1_art-1");
-      assertThat(articles.get(1).getEid()).contains("hauptteil-1_art-2");
+      assertThat(articles.get(0).getEid()).isEqualTo("hauptteil-1_art-1");
+      assertThat(articles.get(1).getEid()).isEqualTo("hauptteil-1_art-2");
     }
 
     @Test
@@ -135,7 +135,7 @@ class ArticleServiceTest {
 
       // Then
       assertThat(articles).hasSize(1);
-      assertThat(articles.getFirst().getEid()).contains("hauptteil-1_art-2");
+      assertThat(articles.getFirst().getEid()).isEqualTo("hauptteil-1_art-2");
     }
 
     @Test
@@ -156,7 +156,7 @@ class ArticleServiceTest {
 
       // Then
       assertThat(articles).hasSize(1);
-      assertThat(articles.getFirst().getEid()).contains("hauptteil-1_art-1");
+      assertThat(articles.getFirst().getEid()).isEqualTo("hauptteil-1_art-1");
     }
 
     @Test
@@ -179,7 +179,7 @@ class ArticleServiceTest {
 
       // Then
       assertThat(articles).hasSize(1);
-      assertThat(articles.getFirst().getEid()).contains("hauptteil-1_art-1");
+      assertThat(articles.getFirst().getEid()).isEqualTo("hauptteil-1_art-1");
     }
 
     @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/NormServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/NormServiceTest.java
@@ -799,10 +799,8 @@ class NormServiceTest {
         .getMods()
         .stream()
         .filter(m ->
-          m.getEid().isPresent() &&
           m
             .getEid()
-            .get()
             .equals("hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1")
         )
         .findFirst()
@@ -972,10 +970,8 @@ class NormServiceTest {
         .getMods()
         .stream()
         .filter(m ->
-          m.getEid().isPresent() &&
           m
             .getEid()
-            .get()
             .equals("hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1")
         )
         .findFirst()
@@ -1211,7 +1207,7 @@ class NormServiceTest {
       amendingNorm
         .getMods()
         .stream()
-        .filter(mod -> mod.getMandatoryEid().equals(eid))
+        .filter(mod -> mod.getEid().equals(eid))
         .findFirst()
         .ifPresent(m -> m.setTargetRefHref(new Href("#fake-href")));
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeBoundaryServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeBoundaryServiceTest.java
@@ -344,14 +344,14 @@ class TimeBoundaryServiceTest {
       assertThat(timeBoundaries).hasSize(2);
 
       assertThat(timeBoundaries.getFirst().getTemporalGroupEid())
-        .contains("meta-1_geltzeiten-1_geltungszeitgr-2");
+        .isEqualTo("meta-1_geltzeiten-1_geltungszeitgr-2");
       assertThat(timeBoundaries.getFirst().getTimeIntervalEid())
         .isEqualTo("meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1");
       assertThat(timeBoundaries.getFirst().getEventRefEid())
         .isEqualTo("meta-1_lebzykl-1_ereignis-3");
 
       assertThat(timeBoundaries.getLast().getTemporalGroupEid())
-        .contains("meta-1_geltzeiten-1_geltungszeitgr-3");
+        .isEqualTo("meta-1_geltzeiten-1_geltungszeitgr-3");
       assertThat(timeBoundaries.getLast().getTimeIntervalEid())
         .isEqualTo("meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1");
       assertThat(timeBoundaries.getLast().getEventRefEid())

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeBoundaryServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeBoundaryServiceTest.java
@@ -96,8 +96,8 @@ class TimeBoundaryServiceTest {
       // handle 1st time boundary
       assertThat(timeBoundaries.getFirst().getEventRef().getDate())
         .contains(LocalDate.parse("2023-12-30"));
-      assertThat(timeBoundaries.getFirst().getEventRefEid().get())
-        .contains("meta-1_lebzykl-1_ereignis-2");
+      assertThat(timeBoundaries.getFirst().getEventRefEid())
+        .isEqualTo("meta-1_lebzykl-1_ereignis-2");
       assertThat(
         timeBoundaries
           .getFirst()
@@ -151,13 +151,12 @@ class TimeBoundaryServiceTest {
           .getNamedItem("start")
           .getNodeValue()
       )
-        .contains("#" + timeBoundaries.get(0).getEventRefEid().get());
+        .contains("#" + timeBoundaries.get(0).getEventRefEid());
 
       // handle 2nd time boundary
       assertThat(timeBoundaries.get(1).getEventRef().getDate())
         .contains(LocalDate.parse("2024-01-01"));
-      assertThat(timeBoundaries.get(1).getEventRefEid().get())
-        .contains("meta-1_lebzykl-1_ereignis-3");
+      assertThat(timeBoundaries.get(1).getEventRefEid()).isEqualTo("meta-1_lebzykl-1_ereignis-3");
       assertThat(
         timeBoundaries
           .get(1)
@@ -211,7 +210,7 @@ class TimeBoundaryServiceTest {
           .getNamedItem("start")
           .getNodeValue()
       )
-        .contains("#" + timeBoundaries.get(1).getEventRefEid().get());
+        .contains("#" + timeBoundaries.get(1).getEventRefEid());
     }
 
     @Test
@@ -349,13 +348,14 @@ class TimeBoundaryServiceTest {
       assertThat(timeBoundaries.getFirst().getTimeIntervalEid())
         .contains("meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1");
       assertThat(timeBoundaries.getFirst().getEventRefEid())
-        .contains("meta-1_lebzykl-1_ereignis-3");
+        .isEqualTo("meta-1_lebzykl-1_ereignis-3");
 
       assertThat(timeBoundaries.getLast().getTemporalGroupEid())
         .contains("meta-1_geltzeiten-1_geltungszeitgr-3");
       assertThat(timeBoundaries.getLast().getTimeIntervalEid())
         .contains("meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1");
-      assertThat(timeBoundaries.getLast().getEventRefEid()).contains("meta-1_lebzykl-1_ereignis-4");
+      assertThat(timeBoundaries.getLast().getEventRefEid())
+        .isEqualTo("meta-1_lebzykl-1_ereignis-4");
     }
 
     @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeBoundaryServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/TimeBoundaryServiceTest.java
@@ -120,8 +120,8 @@ class TimeBoundaryServiceTest {
           .getNodeValue()
       )
         .contains("ac311ee1-33d3-4b9b-a974-776e55a88396");
-      assertThat(timeBoundaries.getFirst().getTimeIntervalEid().get())
-        .contains("meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1");
+      assertThat(timeBoundaries.getFirst().getTimeIntervalEid())
+        .isEqualTo("meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1");
       assertThat(
         timeBoundaries
           .getFirst()
@@ -179,8 +179,8 @@ class TimeBoundaryServiceTest {
           .getNodeValue()
       )
         .contains("fdfaeef0-0300-4e5b-9e8b-14d2162bfb00");
-      assertThat(timeBoundaries.get(1).getTimeIntervalEid().get())
-        .contains("meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1");
+      assertThat(timeBoundaries.get(1).getTimeIntervalEid())
+        .isEqualTo("meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1");
       assertThat(
         timeBoundaries
           .get(1)
@@ -346,14 +346,14 @@ class TimeBoundaryServiceTest {
       assertThat(timeBoundaries.getFirst().getTemporalGroupEid())
         .contains("meta-1_geltzeiten-1_geltungszeitgr-2");
       assertThat(timeBoundaries.getFirst().getTimeIntervalEid())
-        .contains("meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1");
+        .isEqualTo("meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1");
       assertThat(timeBoundaries.getFirst().getEventRefEid())
         .isEqualTo("meta-1_lebzykl-1_ereignis-3");
 
       assertThat(timeBoundaries.getLast().getTemporalGroupEid())
         .contains("meta-1_geltzeiten-1_geltungszeitgr-3");
       assertThat(timeBoundaries.getLast().getTimeIntervalEid())
-        .contains("meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1");
+        .isEqualTo("meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1");
       assertThat(timeBoundaries.getLast().getEventRefEid())
         .isEqualTo("meta-1_lebzykl-1_ereignis-4");
     }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/UpdateNormServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/UpdateNormServiceTest.java
@@ -335,7 +335,7 @@ class UpdateNormServiceTest {
       final Mod mod = updatedAmendingNorm
         .getMods()
         .stream()
-        .filter(f -> f.getEid().orElseThrow().equals(eId))
+        .filter(f -> f.getEid().equals(eId))
         .findFirst()
         .orElseThrow();
       assertThat(mod.getNewText()).contains(newContent);
@@ -513,7 +513,7 @@ class UpdateNormServiceTest {
       final Optional<Mod> modBeforeUpdate = amendingLaw
         .getMods()
         .stream()
-        .filter(m -> m.getMandatoryEid().equals(modEid))
+        .filter(m -> m.getEid().equals(modEid))
         .findFirst();
 
       // When
@@ -532,7 +532,7 @@ class UpdateNormServiceTest {
       final Optional<Mod> updatedMod = updatedAmendingNorm
         .getMods()
         .stream()
-        .filter(m -> m.getMandatoryEid().equals(modEid))
+        .filter(m -> m.getEid().equals(modEid))
         .findFirst();
       assertThat(updatedMod).isPresent();
       assertThat(updatedMod.get().getTargetRefHref()).isEmpty();
@@ -570,7 +570,7 @@ class UpdateNormServiceTest {
       final Optional<Mod> modBeforeUpdate = amendingLaw
         .getMods()
         .stream()
-        .filter(m -> m.getMandatoryEid().equals(modEid))
+        .filter(m -> m.getEid().equals(modEid))
         .findFirst();
 
       // When
@@ -589,7 +589,7 @@ class UpdateNormServiceTest {
       final Optional<Mod> updatedMod = updatedAmendingNorm
         .getMods()
         .stream()
-        .filter(m -> m.getMandatoryEid().equals(modEid))
+        .filter(m -> m.getEid().equals(modEid))
         .findFirst();
       assertThat(updatedMod).isPresent();
       assertThat(updatedMod.get().getTargetRrefFrom()).isEmpty();

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/AnalysisTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/AnalysisTest.java
@@ -344,7 +344,7 @@ class AnalysisTest {
     // then
     assertThat(analysis.getPassiveModifications()).hasSize(1);
     assertThat(analysis.getPassiveModifications().getFirst().getEid())
-      .contains("meta-1_analysis-1_activemod-2_textualmod-1");
+      .isEqualTo("meta-1_analysis-1_activemod-2_textualmod-1");
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/ArticleTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/ArticleTest.java
@@ -287,7 +287,7 @@ class ArticleTest {
 
     // then
     assertThat(mod).isNotEmpty();
-    assertThat(mod.get(0).getEid()).contains(expectedModEId);
+    assertThat(mod.get(0).getEid()).isEqualTo(expectedModEId);
   }
 
   @Test
@@ -400,6 +400,6 @@ class ArticleTest {
 
     // then
     assertThat(mods).isNotEmpty().hasSize(2);
-    assertThat(mods.get(0).getEid()).contains(expectedModEId);
+    assertThat(mods.get(0).getEid()).isEqualTo(expectedModEId);
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/ArticleTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/ArticleTest.java
@@ -2,19 +2,10 @@ package de.bund.digitalservice.ris.norms.domain.entity;
 
 import static de.bund.digitalservice.ris.norms.utils.XmlMapper.toNode;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import de.bund.digitalservice.ris.norms.application.port.output.LoadNormPort;
-import de.bund.digitalservice.ris.norms.utils.exceptions.MandatoryNodeNotFoundException;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class ArticleTest {
-
-  private final LoadNormPort loadNormPort = mock(LoadNormPort.class);
 
   @Test
   void getGuid() {
@@ -68,7 +59,7 @@ class ArticleTest {
     var expectedEid = "hauptteil-1_art-1";
 
     // when
-    var eid = article.getEid().get();
+    var eid = article.getEid();
 
     // then
     assertThat(eid).isEqualTo(expectedEid);
@@ -87,35 +78,10 @@ class ArticleTest {
     var expectedEid = "hauptteil-1_art-1";
 
     // when
-    var eid = article.getEid().orElseThrow();
+    var eid = article.getEid();
 
     // then
     assertThat(eid).isEqualTo(expectedEid);
-  }
-
-  @Test
-  void getEidOrThrowThrowsExceptionMandatoryEidIsMissing() {
-    // given
-    final Norm amendingNorm = NormFixtures.loadFromDisk("NormWithMods.xml");
-    when(loadNormPort.loadNorm(any())).thenReturn(Optional.of(amendingNorm));
-    amendingNorm
-      .getNodeByEId("hauptteil-1_art-1")
-      .get()
-      .getAttributes()
-      .getNamedItem("eId")
-      .setTextContent("");
-
-    var article = amendingNorm.getArticles().getFirst();
-
-    // when
-    Throwable thrown = catchThrowable(article::getMandatoryEid);
-
-    // when/then
-    assertThat(thrown)
-      .isInstanceOf(MandatoryNodeNotFoundException.class)
-      .hasMessageContaining(
-        "Element with xpath './@eId' not found in 'akn:article' of norm 'eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1'"
-      );
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/ModTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/ModTest.java
@@ -78,7 +78,7 @@ class ModTest {
 
     // then
     assertThat(eid)
-      .contains("hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1");
+      .isEqualTo("hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1");
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormTest.java
@@ -590,7 +590,7 @@ class NormTest {
     assertThat(actualArticles).hasSize(expectedNumberOfArticles);
     assertThat(actualArticles.getFirst().getHeading()).contains(firstExpectedHeading);
     assertThat(actualArticles.getFirst().getEnumeration()).contains("Artikel 1");
-    assertThat(actualArticles.get(0).getEid()).contains(firstArticleEid);
+    assertThat(actualArticles.get(0).getEid()).isEqualTo(firstArticleEid);
     assertThat(actualArticles.get(0).getAffectedDocumentEli())
       .contains(
         ExpressionEli.fromString("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
@@ -598,7 +598,7 @@ class NormTest {
 
     assertThat(actualArticles.get(1).getHeading()).contains(secondExpectedHeading);
     assertThat(actualArticles.get(1).getEnumeration()).contains("Artikel 3");
-    assertThat(actualArticles.get(1).getEid()).contains(secondArticleEid);
+    assertThat(actualArticles.get(1).getEid()).isEqualTo(secondArticleEid);
     assertThat(actualArticles.get(1).getAffectedDocumentEli()).isNotPresent();
   }
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormTest.java
@@ -839,7 +839,7 @@ class NormTest {
     assertThat(actualBoundaries.getFirst().getEventRef().getDate())
       .contains(LocalDate.parse("2023-12-30"));
     assertThat(actualBoundaries.getFirst().getEventRefEid())
-      .contains("meta-1_lebzykl-1_ereignis-2");
+      .isEqualTo("meta-1_lebzykl-1_ereignis-2");
   }
 
   @Test
@@ -878,7 +878,7 @@ class NormTest {
     assertThat(actualBoundaries.getFirst().getEventRef().getDate())
       .contains(LocalDate.parse("2023-12-30"));
     assertThat(actualBoundaries.getFirst().getEventRefEid())
-      .contains("meta-1_lebzykl-1_ereignis-2");
+      .isEqualTo("meta-1_lebzykl-1_ereignis-2");
   }
 
   @Test
@@ -943,8 +943,7 @@ class NormTest {
     // old one still there
     assertThat(timeBoundaries.get(0).getEventRef().getDate())
       .contains(LocalDate.parse("2023-12-30"));
-    assertThat(timeBoundaries.get(0).getEventRefEid().get())
-      .contains("meta-1_lebzykl-1_ereignis-2");
+    assertThat(timeBoundaries.get(0).getEventRefEid()).isEqualTo("meta-1_lebzykl-1_ereignis-2");
     assertThat(
       timeBoundaries
         .get(0)
@@ -998,13 +997,12 @@ class NormTest {
         .getNamedItem("start")
         .getNodeValue()
     )
-      .contains("#" + timeBoundaries.get(0).getEventRefEid().get());
+      .contains("#" + timeBoundaries.get(0).getEventRefEid());
 
     // new one added
     assertThat(timeBoundaries.get(1).getEventRef().getDate())
       .contains(LocalDate.parse("2024-01-02"));
-    assertThat(timeBoundaries.get(1).getEventRefEid().get())
-      .contains("meta-1_lebzykl-1_ereignis-3");
+    assertThat(timeBoundaries.get(1).getEventRefEid()).isEqualTo("meta-1_lebzykl-1_ereignis-3");
     assertThat(
       timeBoundaries
         .get(1)
@@ -1058,7 +1056,7 @@ class NormTest {
         .getNamedItem("start")
         .getNodeValue()
     )
-      .contains("#" + timeBoundaries.get(1).getEventRefEid().get());
+      .contains("#" + timeBoundaries.get(1).getEventRefEid());
   }
 
   @Test
@@ -1107,8 +1105,7 @@ class NormTest {
     assertThat(timeBoundaries).hasSize(1);
     assertThat(timeBoundaries.get(0).getEventRef().getDate())
       .contains(LocalDate.parse("2023-12-30"));
-    assertThat(timeBoundaries.get(0).getEventRefEid().get())
-      .contains("meta-1_lebzykl-1_ereignis-2");
+    assertThat(timeBoundaries.get(0).getEventRefEid()).isEqualTo("meta-1_lebzykl-1_ereignis-2");
     assertThat(
       timeBoundaries
         .get(0)
@@ -1162,7 +1159,7 @@ class NormTest {
         .getNamedItem("start")
         .getNodeValue()
     )
-      .contains("#" + timeBoundaries.get(0).getEventRefEid().get());
+      .contains("#" + timeBoundaries.get(0).getEventRefEid());
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormTest.java
@@ -966,8 +966,8 @@ class NormTest {
         .getNodeValue()
     )
       .contains("ac311ee1-33d3-4b9b-a974-776e55a88396");
-    assertThat(timeBoundaries.get(0).getTimeIntervalEid().get())
-      .contains("meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1");
+    assertThat(timeBoundaries.get(0).getTimeIntervalEid())
+      .isEqualTo("meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1");
     assertThat(
       timeBoundaries
         .get(0)
@@ -1025,8 +1025,8 @@ class NormTest {
         .getNodeValue()
     )
       .isNotEmpty();
-    assertThat(timeBoundaries.get(1).getTimeIntervalEid().get())
-      .contains("meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1");
+    assertThat(timeBoundaries.get(1).getTimeIntervalEid())
+      .isEqualTo("meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1");
     assertThat(
       timeBoundaries
         .get(1)
@@ -1128,8 +1128,8 @@ class NormTest {
         .getNodeValue()
     )
       .contains("ac311ee1-33d3-4b9b-a974-776e55a88396");
-    assertThat(timeBoundaries.get(0).getTimeIntervalEid().get())
-      .contains("meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1");
+    assertThat(timeBoundaries.get(0).getTimeIntervalEid())
+      .isEqualTo("meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1");
     assertThat(
       timeBoundaries
         .get(0)

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/TemporalGroupTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/TemporalGroupTest.java
@@ -27,7 +27,7 @@ class TemporalGroupTest {
     var eid = temporalGroup.getEid();
 
     // then
-    assertThat(eid).contains("meta-1_geltzeiten-1_geltungszeitgr-1");
+    assertThat(eid).isEqualTo("meta-1_geltzeiten-1_geltungszeitgr-1");
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/TextualModTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/TextualModTest.java
@@ -39,7 +39,7 @@ class TextualModTest {
     var eid = textualMod.getEid();
 
     // then
-    assertThat(eid).contains("meta-1_analysis-1_activemod-1_textualmod-1");
+    assertThat(eid).isEqualTo("meta-1_analysis-1_activemod-1_textualmod-1");
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/TimeBoundaryTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/TimeBoundaryTest.java
@@ -78,6 +78,6 @@ class TimeBoundaryTest {
 
     // then
     assertThat(tb.getTimeIntervalEid())
-      .contains("meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1");
+      .isEqualTo("meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1");
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/TimeBoundaryTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/TimeBoundaryTest.java
@@ -62,7 +62,7 @@ class TimeBoundaryTest {
     TimeBoundary tb = new TimeBoundary(timeInterval, eventRef, temporalGroup);
 
     // then
-    assertThat(tb.getEventRefEid()).contains("meta-1_lebzykl-1_ereignis-2");
+    assertThat(tb.getEventRefEid()).isEqualTo("meta-1_lebzykl-1_ereignis-2");
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/NormExpressionControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/NormExpressionControllerIntegrationTest.java
@@ -1828,7 +1828,7 @@ class NormExpressionControllerIntegrationTest extends BaseIntegrationTest {
         .stream()
         .filter(mod ->
           mod
-            .getMandatoryEid()
+            .getEid()
             .equals("hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1")
         )
         .findFirst()
@@ -1873,7 +1873,7 @@ class NormExpressionControllerIntegrationTest extends BaseIntegrationTest {
         .stream()
         .filter(mod ->
           mod
-            .getMandatoryEid()
+            .getEid()
             .equals("hauptteil-1_art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1")
         )
         .findFirst()


### PR DESCRIPTION
Follow up to #593 

This PR refactors (almost) all eIds to not use Optionals anymore, in places where they are required in XSD-valid documents.