### PR TITLE
Updating changelog once per bucket

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/PublishChangelogsPort.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/PublishChangelogsPort.java
@@ -1,0 +1,11 @@
+package de.bund.digitalservice.ris.norms.application.port.output;
+
+/**
+ * Interface representing the output port for publishing changelogs to public and private storages
+ */
+public interface PublishChangelogsPort {
+  /**
+   * Publishes the changelogs to designated public and private locations.
+   */
+  void publishChangelogs();
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/PublishService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/PublishService.java
@@ -33,6 +33,7 @@ public class PublishService implements PublishNormUseCase {
   private final LoadMigrationLogByDatePort loadMigrationLogByDatePort;
   private final DeleteAllPublicNormsPort deleteAllPublicNormsPort;
   private final DeleteAllPrivateNormsPort deleteAllPrivateNormsPort;
+  private final PublishChangelogsPort publishChangelogsPort;
 
   public PublishService(
     LoadNormIdsByPublishStatePort loadNormIdsByPublishStatePort,
@@ -44,7 +45,8 @@ public class PublishService implements PublishNormUseCase {
     LoadNormByIdPort loadNormByIdPort,
     LoadMigrationLogByDatePort loadMigrationLogByDatePort,
     DeleteAllPublicNormsPort deleteAllPublicNormsPort,
-    DeleteAllPrivateNormsPort deleteAllPrivateNormsPort
+    DeleteAllPrivateNormsPort deleteAllPrivateNormsPort,
+    PublishChangelogsPort publishChangelogsPort
   ) {
     this.loadNormIdsByPublishStatePort = loadNormIdsByPublishStatePort;
     this.publishPublicNormPort = publishPublicNormPort;
@@ -56,6 +58,7 @@ public class PublishService implements PublishNormUseCase {
     this.loadMigrationLogByDatePort = loadMigrationLogByDatePort;
     this.deleteAllPublicNormsPort = deleteAllPublicNormsPort;
     this.deleteAllPrivateNormsPort = deleteAllPrivateNormsPort;
+    this.publishChangelogsPort = publishChangelogsPort;
   }
 
   @Override
@@ -89,6 +92,7 @@ public class PublishService implements PublishNormUseCase {
         log.error("Norm with id {} not found", publishId);
       }
     });
+    publishChangelogsPort.publishChangelogs();
   }
 
   private void processNorm(Norm norm) {

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/PublishServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/PublishServiceTest.java
@@ -42,6 +42,8 @@ class PublishServiceTest {
     LoadMigrationLogByDatePort.class
   );
 
+  final PublishChangelogsPort publishChangelogsPort = mock(PublishChangelogsPort.class);
+
   final PublishService publishService = new PublishService(
     loadNormIdsByPublishStatePort,
     publishPublicNormPort,
@@ -52,7 +54,8 @@ class PublishServiceTest {
     loadNormByIdPort,
     loadMigrationLogByDatePort,
     deleteAllPublicNormsPort,
-    deleteAllPrivateNormsPort
+    deleteAllPrivateNormsPort,
+    publishChangelogsPort
   );
 
   @Nested
@@ -81,6 +84,7 @@ class PublishServiceTest {
       verify(publishPrivateNormPort, times(1))
         .publishPrivateNorm(new PublishPrivateNormPort.Command(norm));
       verify(updateOrSaveNormPort, times(1)).updateOrSave(new UpdateOrSaveNormPort.Command(norm));
+      verify(publishChangelogsPort, times(1)).publishChangelogs();
     }
 
     @Test
@@ -111,6 +115,7 @@ class PublishServiceTest {
       verify(deletePrivateNormPort, never())
         .deletePrivateNorm(new DeletePrivateNormPort.Command(norm));
       verify(updateOrSaveNormPort, never()).updateOrSave(any(UpdateOrSaveNormPort.Command.class));
+      verify(publishChangelogsPort, times(1)).publishChangelogs();
     }
 
     @Test
@@ -141,6 +146,7 @@ class PublishServiceTest {
       verify(deletePrivateNormPort, never())
         .deletePrivateNorm(new DeletePrivateNormPort.Command(norm));
       verify(updateOrSaveNormPort, never()).updateOrSave(any(UpdateOrSaveNormPort.Command.class));
+      verify(publishChangelogsPort, times(1)).publishChangelogs();
     }
 
     @Test
@@ -180,6 +186,7 @@ class PublishServiceTest {
       verify(publishPrivateNormPort, times(1))
         .publishPrivateNorm(new PublishPrivateNormPort.Command(norm));
       verify(updateOrSaveNormPort, times(1)).updateOrSave(new UpdateOrSaveNormPort.Command(norm));
+      verify(publishChangelogsPort, times(1)).publishChangelogs();
     }
 
     @Test
@@ -213,6 +220,7 @@ class PublishServiceTest {
       verify(publishPrivateNormPort, times(1))
         .publishPrivateNorm(new PublishPrivateNormPort.Command(norm));
       verify(updateOrSaveNormPort, times(1)).updateOrSave(new UpdateOrSaveNormPort.Command(norm));
+      verify(publishChangelogsPort, times(1)).publishChangelogs();
     }
   }
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/s3/BucketServiceIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/s3/BucketServiceIntegrationTest.java
@@ -39,6 +39,7 @@ class BucketServiceIntegrationTest extends BaseS3MockIntegrationTest {
     // When
     final PublishPublicNormPort.Command command = new PublishPublicNormPort.Command(norm);
     bucketService.publishPublicNorm(command);
+    bucketService.publishChangelogs();
 
     // Then
     final Path filePath = getPublicPath(norm);
@@ -54,10 +55,32 @@ class BucketServiceIntegrationTest extends BaseS3MockIntegrationTest {
     // When
     final PublishPrivateNormPort.Command command = new PublishPrivateNormPort.Command(norm);
     bucketService.publishPrivateNorm(command);
+    bucketService.publishChangelogs();
 
     // Then
     final Path filePath = getPrivatePath(norm);
     assertThat(Files.exists(filePath)).isTrue();
+    assertChangelogContains(true, PRIVATE_BUCKET, CHANGED, norm);
+  }
+
+  @Test
+  void itPublishesNormToPublicAndPrivateBucket() {
+    // Given
+    final Norm norm = NormFixtures.loadFromDisk("SimpleNorm.xml");
+
+    // When
+    final PublishPublicNormPort.Command commandPublic = new PublishPublicNormPort.Command(norm);
+    bucketService.publishPublicNorm(commandPublic);
+    final PublishPrivateNormPort.Command commandPrivate = new PublishPrivateNormPort.Command(norm);
+    bucketService.publishPrivateNorm(commandPrivate);
+    bucketService.publishChangelogs();
+
+    // Then
+    final Path publicFilePath = getPublicPath(norm);
+    assertThat(Files.exists(publicFilePath)).isTrue();
+    assertChangelogContains(true, PUBLIC_BUCKET, CHANGED, norm);
+    final Path privateFilePath = getPrivatePath(norm);
+    assertThat(Files.exists(privateFilePath)).isTrue();
     assertChangelogContains(true, PRIVATE_BUCKET, CHANGED, norm);
   }
 
@@ -71,6 +94,7 @@ class BucketServiceIntegrationTest extends BaseS3MockIntegrationTest {
     // When
     final DeletePublicNormPort.Command commandDelete = new DeletePublicNormPort.Command(norm);
     bucketService.deletePublicNorm(commandDelete);
+    bucketService.publishChangelogs();
 
     // Then
     final Path filePath = getPublicPath(norm);
@@ -89,6 +113,7 @@ class BucketServiceIntegrationTest extends BaseS3MockIntegrationTest {
     // When
     final DeletePrivateNormPort.Command commandDelete = new DeletePrivateNormPort.Command(norm);
     bucketService.deletePrivateNorm(commandDelete);
+    bucketService.publishChangelogs();
 
     // Then
     final Path filePath = getPrivatePath(norm);
@@ -109,6 +134,7 @@ class BucketServiceIntegrationTest extends BaseS3MockIntegrationTest {
 
     // When
     bucketService.deleteAllPublicNorms();
+    bucketService.publishChangelogs();
 
     // Then
     final Path filePath1 = getPublicPath(norm1);
@@ -135,6 +161,7 @@ class BucketServiceIntegrationTest extends BaseS3MockIntegrationTest {
 
     // When
     bucketService.deleteAllPrivateNorms();
+    bucketService.publishChangelogs();
 
     // Then
     final Path filePath1 = getPrivatePath(norm1);
@@ -156,7 +183,9 @@ class BucketServiceIntegrationTest extends BaseS3MockIntegrationTest {
     );
     // When
     bucketService.publishPublicNorm(command);
+    bucketService.publishChangelogs();
     bucketService.publishPublicNorm(commandAnotherNorm);
+    bucketService.publishChangelogs();
 
     // Then
     assertChangelogContains(true, PUBLIC_BUCKET, CHANGED, norm);


### PR DESCRIPTION
Do not make a S3 API call for updating the changelog on every publish.

Changes:

- Introduce new port that can be called from the publish service to signalize the changelogs (public and private) can be published.
- Change implementations of the bucket ports so that a changelog object is used in memory and then push to the bucket once signalized from the outside.
- Class variable then set to null for further runs of the publication job (so following day new changelog is used)
- Keep functionality for loading the changelog, in case the publication job is run manually (if needed for testing purposes) on the same day, so that the already published changelog is reused.