### PR TITLE
fix: add snippet parameter for article rendering

### DIFF
--- a/frontend/src/views/amending-law/articles/editor/AmendingLawArticleEditor.view.vue
+++ b/frontend/src/views/amending-law/articles/editor/AmendingLawArticleEditor.view.vue
@@ -84,7 +84,9 @@ const {
   data: articleHtml,
   isFetching: isFetchingArticleHtml,
   error: loadArticleHtmlError,
-} = useNormRenderHtml(articleXml)
+} = useNormRenderHtml(articleXml, {
+  snippet: true,
+})
 const amendingLawActiveTab = ref("text")
 
 watch(xml, (xml) => {


### PR DESCRIPTION
- Update `useNormRenderHtml` call to include the `snippet: true` parameter. This bypasses passive modification logic and prevents an exception being thrown.

RISDEV-4916