### PR TITLE
Add generated norm-eli columns to database

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/NormDto.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/NormDto.java
@@ -46,16 +46,28 @@ public class NormDto {
   private UUID guid;
 
   @Generated(event = { INSERT, UPDATE })
-  @Column(name = "eli_work", updatable = false, insertable = false)
-  private String eliWork;
+  @Column(name = "eli_dokument_work", updatable = false, insertable = false)
+  private String eliDokumentWork;
 
   @Generated(event = { INSERT, UPDATE })
-  @Column(name = "eli_expression", updatable = false, insertable = false)
-  private String eliExpression;
+  @Column(name = "eli_dokument_expression", updatable = false, insertable = false)
+  private String eliDokumentExpression;
 
   @Generated(event = { INSERT, UPDATE })
-  @Column(name = "eli_manifestation", updatable = false, insertable = false)
-  private String eliManifestation;
+  @Column(name = "eli_dokument_manifestation", updatable = false, insertable = false)
+  private String eliDokumentManifestation;
+
+  @Generated(event = { INSERT, UPDATE })
+  @Column(name = "eli_norm_work", updatable = false, insertable = false)
+  private String eliNormWork;
+
+  @Generated(event = { INSERT, UPDATE })
+  @Column(name = "eli_norm_expression", updatable = false, insertable = false)
+  private String eliNormExpression;
+
+  @Generated(event = { INSERT, UPDATE })
+  @Column(name = "eli_norm_manifestation", updatable = false, insertable = false)
+  private String eliNormManifestation;
 
   @NotNull
   @Column

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/ReleaseDto.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/ReleaseDto.java
@@ -44,7 +44,7 @@ public class ReleaseDto {
     joinColumns = @JoinColumn(name = "release_id"),
     inverseJoinColumns = @JoinColumn(
       name = "norm_eli_manifestation",
-      referencedColumnName = "eli_manifestation"
+      referencedColumnName = "eli_dokument_manifestation"
     )
   )
   @Builder.Default

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/repository/NormRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/repository/NormRepository.java
@@ -25,7 +25,9 @@ public interface NormRepository extends JpaRepository<NormDto, UUID> {
    * @param expressionEli The ELI to search for.
    * @return An {@link Optional} containing the found {@link NormDto} if exists, or empty if not found.
    */
-  Optional<NormDto> findFirstByEliExpressionOrderByEliManifestationDesc(final String expressionEli);
+  Optional<NormDto> findFirstByEliDokumentExpressionOrderByEliDokumentManifestationDesc(
+    final String expressionEli
+  );
 
   /**
    * Finds a {@link NormDto} by its manifestation ELI (European Legislation Identifier).
@@ -33,7 +35,7 @@ public interface NormRepository extends JpaRepository<NormDto, UUID> {
    * @param manifestationEli The ELI to search for.
    * @return An {@link Optional} containing the found {@link NormDto} if exists, or empty if not found.
    */
-  Optional<NormDto> findByEliManifestation(final String manifestationEli);
+  Optional<NormDto> findByEliDokumentManifestation(final String manifestationEli);
 
   /**
    * Finds a {@link NormDto} by its GUID.
@@ -42,7 +44,7 @@ public interface NormRepository extends JpaRepository<NormDto, UUID> {
    * @param guid The GUID to search for.
    * @return An {@link Optional} containing the found {@link NormDto} if exists, or empty if not found.
    */
-  Optional<NormDto> findFirstByGuidOrderByEliManifestation(final UUID guid);
+  Optional<NormDto> findFirstByGuidOrderByEliDokumentManifestation(final UUID guid);
 
   /**
    * Deletes all {@link NormDto} with the given GUID
@@ -58,7 +60,7 @@ public interface NormRepository extends JpaRepository<NormDto, UUID> {
    * @param manifestationEli The ELI to search for.
    * @param publishState The publishState to search for.
    */
-  void deleteByEliManifestationAndPublishState(
+  void deleteByEliDokumentManifestationAndPublishState(
     final String manifestationEli,
     final NormPublishState publishState
   );
@@ -68,7 +70,10 @@ public interface NormRepository extends JpaRepository<NormDto, UUID> {
    * @param workEli The ELI to search for.
    * @param publishState The publishState to search for.
    */
-  void deleteAllByEliWorkAndPublishState(final String workEli, final NormPublishState publishState);
+  void deleteAllByEliDokumentWorkAndPublishState(
+    final String workEli,
+    final NormPublishState publishState
+  );
 
   /**
    * Retrieves the ids of all {@link NormDto} with a specific {@link NormPublishState}.
@@ -76,7 +81,6 @@ public interface NormRepository extends JpaRepository<NormDto, UUID> {
    * @param normPublishState the publish state to filter the norms by (e.g., {@link NormPublishState#QUEUED_FOR_PUBLISH})
    * @return a {@link List} of {@link UUID}s of the {@link NormDto}s matching the specified publish state
    */
-
   @Query("SELECT n.id FROM NormDto n WHERE n.publishState = :publishState")
   List<UUID> findNormIdsByPublishState(
     @Param("publishState") final NormPublishState normPublishState

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/service/DBService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/service/DBService.java
@@ -70,7 +70,9 @@ public class DBService
   public Optional<Norm> loadNorm(LoadNormPort.Command command) {
     return switch (command.eli()) {
       case DokumentExpressionEli expressionEli -> normRepository
-        .findFirstByEliExpressionOrderByEliManifestationDesc(expressionEli.toString())
+        .findFirstByEliDokumentExpressionOrderByEliDokumentManifestationDesc(
+          expressionEli.toString()
+        )
         .map(NormMapper::mapToDomain);
       case DokumentManifestationEli manifestationEli -> {
         if (!manifestationEli.hasPointInTimeManifestation()) {
@@ -79,7 +81,7 @@ public class DBService
         }
 
         yield normRepository
-          .findByEliManifestation(manifestationEli.toString())
+          .findByEliDokumentManifestation(manifestationEli.toString())
           .map(NormMapper::mapToDomain);
       }
       case DokumentWorkEli workEli -> throw new IllegalArgumentException(
@@ -91,7 +93,7 @@ public class DBService
   @Override
   public Optional<Norm> loadNormByGuid(LoadNormByGuidPort.Command command) {
     return normRepository
-      .findFirstByGuidOrderByEliManifestation(command.guid())
+      .findFirstByGuidOrderByEliDokumentManifestation(command.guid())
       .map(NormMapper::mapToDomain);
   }
 
@@ -122,7 +124,7 @@ public class DBService
   public Optional<Norm> updateNorm(UpdateNormPort.Command command) {
     var normXml = XmlMapper.toString(command.norm().getDocument());
     return normRepository
-      .findByEliManifestation(command.norm().getManifestationEli().toString())
+      .findByEliDokumentManifestation(command.norm().getManifestationEli().toString())
       .map(normDto -> {
         normDto.setXml(normXml);
         normDto.setPublishState(command.norm().getPublishState());
@@ -173,7 +175,7 @@ public class DBService
   @Override
   @Transactional
   public void deleteNorm(DeleteNormPort.Command command) {
-    normRepository.deleteByEliManifestationAndPublishState(
+    normRepository.deleteByEliDokumentManifestationAndPublishState(
       command.eli().toString(),
       command.publishState()
     );
@@ -182,7 +184,7 @@ public class DBService
   @Override
   @Transactional
   public void deleteQueuedForPublishNorms(DeleteQueuedNormsPort.Command command) {
-    normRepository.deleteAllByEliWorkAndPublishState(
+    normRepository.deleteAllByEliDokumentWorkAndPublishState(
       command.eli().toString(),
       NormPublishState.QUEUED_FOR_PUBLISH
     );
@@ -208,7 +210,7 @@ public class DBService
       .getPublishedNorms()
       .forEach(norm ->
         normRepository
-          .findByEliManifestation(norm.getManifestationEli().toString())
+          .findByEliDokumentManifestation(norm.getManifestationEli().toString())
           .ifPresent(normDto -> releaseDto.getNorms().add(normDto))
       );
 

--- a/backend/src/main/resources/db/data/R__001_2017_s419_2017-03-15_Vereinsgesetzes.sql
+++ b/backend/src/main/resources/db/data/R__001_2017_s419_2017-03-15_Vereinsgesetzes.sql
@@ -2,7 +2,7 @@
 -- TARGET LAW
 DELETE
 FROM norms
-WHERE eli_expression = 'eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1';
+WHERE eli_dokument_expression = 'eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1';
 
 INSERT INTO norms (publish_state, xml)
 VALUES ('PUBLISHED', '<?xml version="1.0" encoding="UTF-8"?>

--- a/backend/src/main/resources/db/data/R__002_2023_413_2023-12-29_Nachrichtendienstrechts.sql
+++ b/backend/src/main/resources/db/data/R__002_2023_413_2023-12-29_Nachrichtendienstrechts.sql
@@ -2,7 +2,7 @@
 -- TARGET LAW
 DELETE
 FROM norms
-WHERE eli_expression = 'eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1';
+WHERE eli_dokument_expression = 'eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-1';
 
 INSERT INTO norms (publish_state, xml)
 VALUES ('PUBLISHED', '<?xml version="1.0" encoding="UTF-8"?>

--- a/backend/src/main/resources/db/data/R__003_1000_1_1000-01-01_Formatting.sql
+++ b/backend/src/main/resources/db/data/R__003_1000_1_1000-01-01_Formatting.sql
@@ -2,7 +2,7 @@
 -- TARGET LAW
 DELETE
 FROM norms
-WHERE eli_expression = 'eli/bund/bgbl-1/1000/s1/1000-01-01/1/deu/regelungstext-1';
+WHERE eli_dokument_expression = 'eli/bund/bgbl-1/1000/s1/1000-01-01/1/deu/regelungstext-1';
 
 INSERT INTO norms (publish_state, xml)
 VALUES ('PUBLISHED', '<akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.7.1/ ../../schema/legalDocML.de-metadaten.xsd http://MetadatenBundesregierung.LegalDocML.de/1.7.1/ ../../schema/legalDocML.de-metadaten-bundesregierung.xsd http://Inhaltsdaten.LegalDocML.de/1.7.1/ ../../schema/legalDocML.de-regelungstextverkuendungsfassung.xsd">

--- a/backend/src/main/resources/db/data/R__004_2024_108_2024-03-27_Wachstumschancengesetz.sql
+++ b/backend/src/main/resources/db/data/R__004_2024_108_2024-03-27_Wachstumschancengesetz.sql
@@ -2,7 +2,7 @@
 -- TARGET LAW
 DELETE
 FROM norms
-where eli_expression = 'eli/bund/bgbl-1/2024/108/2024-03-27/1/deu/regelungstext-1';
+where eli_dokument_expression = 'eli/bund/bgbl-1/2024/108/2024-03-27/1/deu/regelungstext-1';
 
 INSERT INTO norms (publish_state, xml)
 VALUES ('PUBLISHED', '<?xml version="1.0" encoding="UTF-8"?>

--- a/backend/src/main/resources/db/data/R__007_1001_11_1001-01-01_Mods.sql
+++ b/backend/src/main/resources/db/data/R__007_1001_11_1001-01-01_Mods.sql
@@ -2,7 +2,7 @@
 -- TARGET LAW
 DELETE
 FROM norms
-WHERE eli_expression = 'eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1';
+WHERE eli_dokument_expression = 'eli/bund/bgbl-1/1001/1/1001-01-01/1/deu/regelungstext-1';
 
 INSERT INTO norms (publish_state, xml)
 VALUES ('PUBLISHED', '<?xml version="1.0" encoding="UTF-8"?>

--- a/backend/src/main/resources/db/data/R__008_1002_10_1002-01-10_Mods_Substitution_01.sql
+++ b/backend/src/main/resources/db/data/R__008_1002_10_1002-01-10_Mods_Substitution_01.sql
@@ -2,7 +2,7 @@
 -- TARGET LAW
 DELETE
 FROM norms
-WHERE eli_expression = 'eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1';
+WHERE eli_dokument_expression = 'eli/bund/bgbl-1/1002/1/1002-01-01/1/deu/regelungstext-1';
 
 INSERT INTO norms (publish_state, xml)
 VALUES ('PUBLISHED', '<?xml version="1.0" encoding="UTF-8"?>

--- a/backend/src/main/resources/db/data/R__009_bgbl-1_2024_10.sql
+++ b/backend/src/main/resources/db/data/R__009_bgbl-1_2024_10.sql
@@ -2,7 +2,7 @@
 -- TARGET LAW
 DELETE
 FROM norms
-WHERE eli_expression = 'eli/bund/bgbl-1/2021/s818/2021-04-16/1/deu/regelungstext-1';
+WHERE eli_dokument_expression = 'eli/bund/bgbl-1/2021/s818/2021-04-16/1/deu/regelungstext-1';
 
 INSERT INTO norms (publish_state, xml)
 VALUES ('PUBLISHED', '<akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.7.1/ ../../schema/legalDocML.de-metadaten.xsd http://MetadatenBundesregierung.LegalDocML.de/1.7.1/ ../../schema/legalDocML.de-metadaten-bundesregierung.xsd http://Inhaltsdaten.LegalDocML.de/1.7.1/ ../../schema/legalDocML.de-regelungstextverkuendungsfassung.xsd">

--- a/backend/src/main/resources/db/migration/V0.21__normeli_and_documenteli.sql
+++ b/backend/src/main/resources/db/migration/V0.21__normeli_and_documenteli.sql
@@ -1,0 +1,18 @@
+ALTER TABLE norms RENAME COLUMN eli_manifestation TO eli_dokument_manifestation;
+-- For the FRBRManifestation the FRBRuri contains the subtype and format, this is different, than for FRBRExpression or FRBRWork. Therefore, we need to additionally remove those part from it.
+ALTER TABLE norms
+    ADD COLUMN eli_norm_manifestation text GENERATED ALWAYS AS (regexp_replace((xpath(
+            '(//*[local-name()="act"]/*[local-name()="meta"]/*[local-name()="identification"]/*[local-name()="FRBRManifestation"]/*[local-name()="FRBRuri"]/@value)',
+            xml))[1]::text, '/[^/]*$', '')) STORED NOT NULL;
+
+ALTER TABLE norms RENAME COLUMN eli_expression TO eli_dokument_expression;
+ALTER TABLE norms
+    ADD COLUMN eli_norm_expression text GENERATED ALWAYS AS ((xpath(
+            '//*[local-name()="act"]/*[local-name()="meta"]/*[local-name()="identification"]/*[local-name()="FRBRExpression"]/*[local-name()="FRBRuri"]/@value',
+            xml))[1]::text) STORED NOT NULL;
+
+ALTER TABLE norms RENAME COLUMN eli_work TO eli_dokument_work;
+ALTER TABLE norms
+    ADD COLUMN eli_norm_work text GENERATED ALWAYS AS ((xpath(
+            '//*[local-name()="act"]/*[local-name()="meta"]/*[local-name()="identification"]/*[local-name()="FRBRWork"]/*[local-name()="FRBRuri"]/@value',
+            xml))[1]::text) STORED NOT NULL;

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/AnnouncementControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/AnnouncementControllerIntegrationTest.java
@@ -19,7 +19,6 @@ import java.io.ByteArrayInputStream;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -69,70 +68,7 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
     @Test
     void itReturnsAllAnnouncementsNorm() throws Exception {
       // Given
-      var norm = Norm
-        .builder()
-        .regelungstexte(
-          Set.of(
-            new Regelungstext(
-              XmlMapper.toDocument(
-                """
-                                <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                    <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                                       xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                                           http://Inhaltsdaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                                   <akn:act name="regelungstext">
-                                      <!-- Metadaten -->
-                                      <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                                         <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                                            <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="3385defa-f0e5-4c6d-a2d4-17388afd5d51">
-                                               <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c7a" value="eli/bund/bgbl-1/2023/413/regelungstext-1" />
-                                               <akn:FRBRnumber eId="meta-1_ident-1_frbrwork-1_frbrnumber-1" GUID="b82cc174-8fff-43bf-a434-5646de09e807" value="413" />
-                                               <akn:FRBRname eId="meta-1_ident-1_frbrwork-1_frbrname-1" GUID="374e5873-9c62-4e3d-9dbe-1b865ba0b327" value="BGBl. I" />
-                                               <akn:FRBRdate eId="meta-1_ident-1_frbrwork-1_frbrdate-1" GUID="5a628f8c-65d0-4854-87cc-6fd01a2d7a9a" date="2023-12-29" name="verkuendungsfassung" />
-                                            </akn:FRBRWork>
-                                            <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                               <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
-                                               <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                                               <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                                               <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                                            </akn:FRBRExpression>
-                                                <akn:FRBRManifestation eId="meta-1_ident-1_frbrmanifestation-1"
-                                                                       GUID="ea61dfec-d89c-442a-9f6d-cb65d8ed2dc3">
-                                                   <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1"
-                                                                 GUID="d74e4be8-c15d-4a9f-8ae6-781e522dc7a4"
-                                                                     value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/2022-08-23/regelungstext-1.xml"/>
-                                                   <akn:FRBRuri eId="meta-1_ident-1_frbrmanifestation-1_frbruri-1"
-                                                                GUID="6e12c94c-f206-4144-bedf-dcab30867f4c"
-                                                                    value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/2022-08-23/regelungstext-1.xml"/>
-                                                   <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1"
-                                                                 GUID="791a8124-d12e-45e1-9c80-5f0438e4d046"
-                                                                 date="2022-08-23"
-                                                                 name="generierung"/>
-                                                   <akn:FRBRauthor eId="meta-1_ident-1_frbrmanifestation-1_frbrauthor-1"
-                                                                   GUID="f9d34cba-d819-4468-b6a7-4a3d76046a26"
-                                                                   href="recht.bund.de"/>
-                                                   <akn:FRBRformat eId="meta-1_ident-1_frbrmanifestation-1_frbrformat-1"
-                                                                   GUID="dcf3aa47-de13-4ef6-9dce-1325a121fb4d"
-                                                                   value="xml"/>
-                                                </akn:FRBRManifestation>
-                                        </akn:identification>
-                                      </akn:meta>
-
-                                      <akn:preface eId="einleitung-1" GUID="fc10e89f-fde4-44bf-aa98-b6bdea01f0ea">
-                                         <akn:longTitle eId="einleitung-1_doktitel-1" GUID="abbb08de-e7e2-40ab-aba0-079ce786e6d6">
-                                            <akn:p eId="einleitung-1_doktitel-1_text-1" GUID="3e7c2134-d82c-44ba-b50d-bad9790375a0">
-                                               <akn:docTitle eId="einleitung-1_doktitel-1_text-1_doctitel-1" GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Gesetz zum ersten Teil der Reform des Nachrichtendienstrechts</akn:docTitle>
-                                            </akn:p>
-                                         </akn:longTitle>
-                                      </akn:preface>
-                                   </akn:act>
-                                </akn:akomaNtoso>
-                """
-              )
-            )
-          )
-        )
-        .build();
+      var norm = Fixtures.loadNormFromDisk("Vereinsgesetz.xml");
       var announcement = Announcement.builder().eli(norm.getExpressionEli()).build();
       normRepository.save(NormMapper.mapToDto(norm));
       announcementRepository.save(AnnouncementMapper.mapToDto(announcement));
@@ -145,13 +81,13 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
         .andExpect(jsonPath("$[0]").exists())
         .andExpect(jsonPath("$[1]").doesNotExist())
         .andExpect(
-          jsonPath(
-            "$[0].title",
-            equalTo("Gesetz zum ersten Teil der Reform des Nachrichtendienstrechts")
-          )
+          jsonPath("$[0].title", equalTo("Gesetz zur Regelung des öffentlichen Vereinsrechts"))
         )
         .andExpect(
-          jsonPath("$[0].eli", equalTo("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1"))
+          jsonPath(
+            "$[0].eli",
+            equalTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1")
+          )
         );
     }
   }
@@ -196,94 +132,7 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
     @Test
     void itDoesReturnNoReleasesIfNoneFound() throws Exception {
       // Given
-      var amendingNorm = Norm
-        .builder()
-        .regelungstexte(
-          Set.of(
-            new Regelungstext(
-              XmlMapper.toDocument(
-                """
-                     <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                    <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                       xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                           http://Inhaltsdaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                   <akn:act name="regelungstext">
-
-                      <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                         <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                            <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8a">
-                               <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c7a" value="eli/bund/bgbl-1/2023/413/regelungstext-1" />
-                            </akn:FRBRWork>
-                            <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                               <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
-                               <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                               <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                            </akn:FRBRExpression>
-                                <akn:FRBRManifestation eId="meta-1_ident-1_frbrmanifestation-1"
-                                                       GUID="ea61dfec-d89c-442a-9f6d-cb65d8ed2dc3">
-                                   <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1"
-                                                 GUID="d74e4be8-c15d-4a9f-8ae6-781e522dc7a4"
-                                                     value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/2022-08-23/regelungstext-1.xml"/>
-                                   <akn:FRBRuri eId="meta-1_ident-1_frbrmanifestation-1_frbruri-1"
-                                                GUID="6e12c94c-f206-4144-bedf-dcab30867f4c"
-                                                    value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/2022-08-23/regelungstext-1.xml"/>
-                                   <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1"
-                                                 GUID="791a8124-d12e-45e1-9c80-5f0438e4d046"
-                                                 date="2022-08-23"
-                                                 name="generierung"/>
-                                   <akn:FRBRauthor eId="meta-1_ident-1_frbrmanifestation-1_frbrauthor-1"
-                                                   GUID="f9d34cba-d819-4468-b6a7-4a3d76046a26"
-                                                   href="recht.bund.de"/>
-                                   <akn:FRBRformat eId="meta-1_ident-1_frbrmanifestation-1_frbrformat-1"
-                                                   GUID="dcf3aa47-de13-4ef6-9dce-1325a121fb4d"
-                                                   value="xml"/>
-                                </akn:FRBRManifestation>
-                         </akn:identification>
-                      </akn:meta>
-                      <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                         <!-- Artikel 1 : Hauptänderung -->
-                         <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#meta-1_geltzeiten-1_geltungszeitgr-1" refersTo="hauptaenderung">
-                            <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                   Artikel 1</akn:num>
-                            <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                            <!-- Absatz (1) -->
-                            <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                               <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-
-                               </akn:num>
-                               <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                  <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                     <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                           href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                  </akn:intro>
-                               </akn:list>
-                            </akn:paragraph>
-                         </akn:article>
-                          <!-- Artikel 3: Geltungszeitregel-->
-                          <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#meta-1_geltzeiten-1_geltungszeitgr-1" refersTo="geltungszeitregel">
-                             <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                    Artikel 3</akn:num>
-                             <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                             <!-- Absatz (1) -->
-                             <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-
-                                </akn:num>
-                                <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                   <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                      nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                </akn:content>
-                             </akn:paragraph>
-                          </akn:article>
-                      </akn:body>
-                   </akn:act>
-                </akn:akomaNtoso>
-                """
-              )
-            )
-          )
-        )
-        .build();
+      var amendingNorm = Fixtures.loadNormFromDisk("SimpleNorm.xml");
       normRepository.save(NormMapper.mapToDto(amendingNorm));
 
       var announcement = Announcement.builder().eli(amendingNorm.getExpressionEli()).build();
@@ -293,7 +142,7 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
       mockMvc
         .perform(
           get(
-            "/api/v1/announcements/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/releases"
+            "/api/v1/announcements/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/releases"
           )
             .accept(MediaType.APPLICATION_JSON)
         )
@@ -304,200 +153,9 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
     @Test
     void itReturnsRelease() throws Exception {
       // Given
-      var amendingNorm = Norm
-        .builder()
-        .regelungstexte(
-          Set.of(
-            new Regelungstext(
-              XmlMapper.toDocument(
-                """
-                     <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                    <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                       xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                           http://Inhaltsdaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                   <akn:act name="regelungstext">
-
-                      <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                         <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                            <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8a">
-                               <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c7a" value="eli/bund/bgbl-1/2023/413/regelungstext-1" />
-                            </akn:FRBRWork>
-                            <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                               <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1" />
-                               <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
-                               <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
-                            </akn:FRBRExpression>
-                                <akn:FRBRManifestation eId="meta-1_ident-1_frbrmanifestation-1"
-                                                       GUID="ea61dfec-d89c-442a-9f6d-cb65d8ed2dc3">
-                                   <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1"
-                                                 GUID="d74e4be8-c15d-4a9f-8ae6-781e522dc7a4"
-                                                     value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/2022-08-23/regelungstext-1.xml"/>
-                                   <akn:FRBRuri eId="meta-1_ident-1_frbrmanifestation-1_frbruri-1"
-                                                GUID="6e12c94c-f206-4144-bedf-dcab30867f4c"
-                                                    value="eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/2022-08-23/regelungstext-1.xml"/>
-                                   <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1"
-                                                 GUID="791a8124-d12e-45e1-9c80-5f0438e4d046"
-                                                 date="2022-08-23"
-                                                 name="generierung"/>
-                                   <akn:FRBRauthor eId="meta-1_ident-1_frbrmanifestation-1_frbrauthor-1"
-                                                   GUID="f9d34cba-d819-4468-b6a7-4a3d76046a26"
-                                                   href="recht.bund.de"/>
-                                   <akn:FRBRformat eId="meta-1_ident-1_frbrmanifestation-1_frbrformat-1"
-                                                   GUID="dcf3aa47-de13-4ef6-9dce-1325a121fb4d"
-                                                   value="xml"/>
-                                </akn:FRBRManifestation>
-                         </akn:identification>
-                      </akn:meta>
-                      <akn:body eId="hauptteil-1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
-                         <!-- Artikel 1 : Hauptänderung -->
-                         <akn:article eId="hauptteil-1_art-1" GUID="cdbfc728-a070-42d9-ba2f-357945afef06" period="#meta-1_geltzeiten-1_geltungszeitgr-1" refersTo="hauptaenderung">
-                            <akn:num eId="hauptteil-1_art-1_bezeichnung-1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                                   Artikel 1</akn:num>
-                            <akn:heading eId="hauptteil-1_art-1_überschrift-1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
-                            <!-- Absatz (1) -->
-                            <akn:paragraph eId="hauptteil-1_art-1_abs-1" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
-                               <akn:num eId="hauptteil-1_art-1_abs-1_bezeichnung-1" GUID="ef3a32d2-df20-4978-914b-cd6288872208">
-
-                               </akn:num>
-                               <akn:list eId="hauptteil-1_art-1_abs-1_untergl-1" GUID="41675622-ed62-46e3-869f-94d99908b010">
-                                  <akn:intro eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1" GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                                     <akn:p eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1" GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="hauptteil-1_art-1_abs-1_untergl-1_intro-1_text-1_bezugsdoc-1" GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                           href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
-                                  </akn:intro>
-                               </akn:list>
-                            </akn:paragraph>
-                         </akn:article>
-                          <!-- Artikel 3: Geltungszeitregel-->
-                          <akn:article eId="hauptteil-1_art-3" GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b" period="#meta-1_geltzeiten-1_geltungszeitgr-1" refersTo="geltungszeitregel">
-                             <akn:num eId="hauptteil-1_art-3_bezeichnung-1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                                    Artikel 3</akn:num>
-                             <akn:heading eId="hauptteil-1_art-3_überschrift-1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
-                             <!-- Absatz (1) -->
-                             <akn:paragraph eId="hauptteil-1_art-3_abs-1" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
-                                <akn:num eId="hauptteil-1_art-3_abs-1_bezeichnung-1" GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
-
-                                </akn:num>
-                                <akn:content eId="hauptteil-1_art-3_abs-1_inhalt-1" GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
-                                   <akn:p eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1" GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="hauptteil-1_art-3_abs-1_inhalt-1_text-1_datum-1" GUID="2ee89811-5368-46e0-acf8-a598506cc956" date="2017-03-16" refersTo="inkrafttreten-datum">am Tag
-                                      nach der Verkündung</akn:date> in Kraft. </akn:p>
-                                </akn:content>
-                             </akn:paragraph>
-                          </akn:article>
-                      </akn:body>
-                   </akn:act>
-                </akn:akomaNtoso>
-                """
-              )
-            )
-          )
-        )
-        .build();
-      var affectedNorm = Norm
-        .builder()
-        .regelungstexte(
-          Set.of(
-            new Regelungstext(
-              XmlMapper.toDocument(
-                """
-                  <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                     <akn:act name="regelungstext">
-                        <!-- Metadaten -->
-                        <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                           <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                              <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8a">
-                                 <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c7a" value="eli/bund/bgbl-1/1964/s593/regelungstext-1" />
-                              </akn:FRBRWork>
-                              <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                 <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="49eec691-392b-4d77-abaf-23eb871132ad" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
-                              </akn:FRBRExpression>
-                                  <akn:FRBRManifestation eId="meta-1_ident-1_frbrmanifestation-1"
-                                                         GUID="ea61dfec-d89c-442a-9f6d-cb65d8ed2dc3">
-                                     <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1"
-                                                   GUID="d74e4be8-c15d-4a9f-8ae6-781e522dc7a4"
-                                                       value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/2022-08-23/regelungstext-1.xml"/>
-                                     <akn:FRBRuri eId="meta-1_ident-1_frbrmanifestation-1_frbruri-1"
-                                                  GUID="6e12c94c-f206-4144-bedf-dcab30867f4c"
-                                                      value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/2022-08-23/regelungstext-1.xml"/>
-                                     <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1"
-                                                   GUID="791a8124-d12e-45e1-9c80-5f0438e4d046"
-                                                   date="2022-08-23"
-                                                   name="generierung"/>
-                                     <akn:FRBRauthor eId="meta-1_ident-1_frbrmanifestation-1_frbrauthor-1"
-                                                     GUID="f9d34cba-d819-4468-b6a7-4a3d76046a26"
-                                                     href="recht.bund.de"/>
-                                     <akn:FRBRformat eId="meta-1_ident-1_frbrmanifestation-1_frbrformat-1"
-                                                     GUID="dcf3aa47-de13-4ef6-9dce-1325a121fb4d"
-                                                     value="xml"/>
-                                  </akn:FRBRManifestation>
-                          </akn:identification>
-                        </akn:meta>
-                     </akn:act>
-                  </akn:akomaNtoso>
-                """
-              )
-            )
-          )
-        )
-        .build();
-      var affectedNormZf0 = Norm
-        .builder()
-        .regelungstexte(
-          Set.of(
-            new Regelungstext(
-              XmlMapper.toDocument(
-                """
-                  <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                      <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                             http://Inhaltsdaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                     <akn:act name="regelungstext">
-                        <!-- Metadaten -->
-                        <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                           <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                              <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8a">
-                                 <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c7a" value="eli/bund/bgbl-1/1964/s593/regelungstext-1" />
-                              </akn:FRBRWork>
-                              <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                                 <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/regelungstext-1" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e" name="vorherige-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="9c086b80-be09-49e6-9230-4932cfe88c83" name="aktuelle-version-id" value="b0f315a1-620b-4eaf-922c-ea46a7d10c8b" />
-                                 <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-3" GUID="960b4c01-c81f-40b1-92c6-d0d223410a49" name="nachfolgende-version-id" value="960b4c01-c81f-40b1-92c6-ea46a7d10c8b" />
-                              </akn:FRBRExpression>
-                                  <akn:FRBRManifestation eId="meta-1_ident-1_frbrmanifestation-1"
-                                                         GUID="ea61dfec-d89c-442a-9f6d-cb65d8ed2dc3">
-                                     <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1"
-                                                   GUID="d74e4be8-c15d-4a9f-8ae6-781e522dc7a4"
-                                                       value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/2022-08-23/regelungstext-1.xml"/>
-                                     <akn:FRBRuri eId="meta-1_ident-1_frbrmanifestation-1_frbruri-1"
-                                                  GUID="6e12c94c-f206-4144-bedf-dcab30867f4c"
-                                                      value="eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/2022-08-23/regelungstext-1.xml"/>
-                                     <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1"
-                                                   GUID="791a8124-d12e-45e1-9c80-5f0438e4d046"
-                                                   date="2022-08-23"
-                                                   name="generierung"/>
-                                     <akn:FRBRauthor eId="meta-1_ident-1_frbrmanifestation-1_frbrauthor-1"
-                                                     GUID="f9d34cba-d819-4468-b6a7-4a3d76046a26"
-                                                     href="recht.bund.de"/>
-                                     <akn:FRBRformat eId="meta-1_ident-1_frbrmanifestation-1_frbrformat-1"
-                                                     GUID="dcf3aa47-de13-4ef6-9dce-1325a121fb4d"
-                                                     value="xml"/>
-                                  </akn:FRBRManifestation>
-                          </akn:identification>
-                        </akn:meta>
-                     </akn:act>
-                  </akn:akomaNtoso>
-                """
-              )
-            )
-          )
-        )
-        .build();
+      var amendingNorm = Fixtures.loadNormFromDisk("NormWithMods.xml");
+      var affectedNorm = Fixtures.loadNormFromDisk("NormWithoutPassiveModifications.xml");
+      var affectedNormZf0 = Fixtures.loadNormFromDisk("NormWithPassiveModifications.xml");
 
       var normDto1 = normRepository.save(NormMapper.mapToDto(amendingNorm));
       var normDto2 = normRepository.save(NormMapper.mapToDto(affectedNorm));
@@ -522,7 +180,7 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
       mockMvc
         .perform(
           get(
-            "/api/v1/announcements/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1/releases"
+            "/api/v1/announcements/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1/releases"
           )
             .accept(MediaType.APPLICATION_JSON)
         )
@@ -535,19 +193,19 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
         .andExpect(
           jsonPath(
             "[0].norms[0]",
-            equalTo("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/2022-08-23/regelungstext-1.xml")
+            equalTo("eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/2022-08-23/regelungstext-1.xml")
           )
         )
         .andExpect(
           jsonPath(
             "[0].norms[1]",
-            equalTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/2022-08-23/regelungstext-1.xml")
+            equalTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-1.xml")
           )
         )
         .andExpect(
           jsonPath(
             "[0].norms[2]",
-            equalTo("eli/bund/bgbl-1/1964/s593/2023-12-29/1/deu/2022-08-23/regelungstext-1.xml")
+            equalTo("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/2022-08-23/regelungstext-1.xml")
           )
         );
     }
@@ -668,7 +326,7 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
           )
         );
 
-      var publishedManifestationOfAmendingNorm = normRepository.findByEliManifestation(
+      var publishedManifestationOfAmendingNorm = normRepository.findByEliDokumentManifestation(
         "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/%s/regelungstext-1.xml".formatted(
             LocalDate.now().toString()
           )
@@ -677,7 +335,7 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
       assertThat(publishedManifestationOfAmendingNorm.get().getPublishState())
         .isEqualTo(NormPublishState.QUEUED_FOR_PUBLISH);
 
-      var publishedZf0ManifestationOfTargetNorm = normRepository.findByEliManifestation(
+      var publishedZf0ManifestationOfTargetNorm = normRepository.findByEliDokumentManifestation(
         "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/%s/regelungstext-1.xml".formatted(
             LocalDate.now().toString()
           )
@@ -687,7 +345,7 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
         .isEqualTo(NormPublishState.QUEUED_FOR_PUBLISH);
 
       var publishedManifestationOfTargetNormAtFirstTimeBoundary =
-        normRepository.findByEliManifestation(
+        normRepository.findByEliDokumentManifestation(
           "eli/bund/bgbl-1/1964/s593/2017-03-23/1/deu/%s/regelungstext-1.xml".formatted(
               LocalDate.now().toString()
             )
@@ -696,7 +354,7 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
       assertThat(publishedManifestationOfTargetNormAtFirstTimeBoundary.get().getPublishState())
         .isEqualTo(NormPublishState.QUEUED_FOR_PUBLISH);
 
-      var newUnpublishedManifestationOfAmendingNorm = normRepository.findByEliManifestation(
+      var newUnpublishedManifestationOfAmendingNorm = normRepository.findByEliDokumentManifestation(
         "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/%s/regelungstext-1.xml".formatted(
             LocalDate.now().plusDays(1).toString()
           )
@@ -705,7 +363,7 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
       assertThat(newUnpublishedManifestationOfAmendingNorm.get().getPublishState())
         .isEqualTo(NormPublishState.UNPUBLISHED);
 
-      var newUnpublishedManifestationOfTargetNorm = normRepository.findByEliManifestation(
+      var newUnpublishedManifestationOfTargetNorm = normRepository.findByEliDokumentManifestation(
         "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/%s/regelungstext-1.xml".formatted(
             LocalDate.now().plusDays(1).toString()
           )
@@ -753,7 +411,7 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
         )
         .andExpect(status().isOk());
 
-      var publishedManifestationOfAmendingNorm = normRepository.findByEliManifestation(
+      var publishedManifestationOfAmendingNorm = normRepository.findByEliDokumentManifestation(
         "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/%s/regelungstext-1.xml".formatted(
             LocalDate.now().toString()
           )
@@ -762,7 +420,7 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
       assertThat(publishedManifestationOfAmendingNorm.get().getPublishState())
         .isEqualTo(NormPublishState.QUEUED_FOR_PUBLISH);
 
-      var publishedZf0ManifestationOfTargetNorm = normRepository.findByEliManifestation(
+      var publishedZf0ManifestationOfTargetNorm = normRepository.findByEliDokumentManifestation(
         "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/%s/regelungstext-1.xml".formatted(
             LocalDate.now().toString()
           )
@@ -772,7 +430,7 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
         .isEqualTo(NormPublishState.QUEUED_FOR_PUBLISH);
 
       var publishedManifestationOfTargetNormAtFirstTimeBoundary =
-        normRepository.findByEliManifestation(
+        normRepository.findByEliDokumentManifestation(
           "eli/bund/bgbl-1/1964/s593/2017-03-23/1/deu/%s/regelungstext-1.xml".formatted(
               LocalDate.now().toString()
             )
@@ -781,7 +439,7 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
       assertThat(publishedManifestationOfTargetNormAtFirstTimeBoundary.get().getPublishState())
         .isEqualTo(NormPublishState.QUEUED_FOR_PUBLISH);
 
-      var newUnpublishedManifestationOfAmendingNorm = normRepository.findByEliManifestation(
+      var newUnpublishedManifestationOfAmendingNorm = normRepository.findByEliDokumentManifestation(
         "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/%s/regelungstext-1.xml".formatted(
             LocalDate.now().plusDays(1).toString()
           )
@@ -790,7 +448,7 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
       assertThat(newUnpublishedManifestationOfAmendingNorm.get().getPublishState())
         .isEqualTo(NormPublishState.UNPUBLISHED);
 
-      var newUnpublishedManifestationOfTargetNorm = normRepository.findByEliManifestation(
+      var newUnpublishedManifestationOfTargetNorm = normRepository.findByEliDokumentManifestation(
         "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/%s/regelungstext-1.xml".formatted(
             LocalDate.now().plusDays(1).toString()
           )
@@ -833,19 +491,19 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
       // Content of the DB should be unchanged = 3 sample norms, all unpublished
       assertThat(normRepository.findAll()).hasSize(3);
       assertThat(
-        normRepository.findByEliManifestation(
+        normRepository.findByEliDokumentManifestation(
           "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/2022-08-23/regelungstext-1.xml"
         )
       )
         .isNotEmpty();
       assertThat(
-        normRepository.findByEliManifestation(
+        normRepository.findByEliDokumentManifestation(
           "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-1.xml"
         )
       )
         .isNotEmpty();
 
-      var originalNormWithPassiveMods = normRepository.findByEliManifestation(
+      var originalNormWithPassiveMods = normRepository.findByEliDokumentManifestation(
         "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/2022-08-23/regelungstext-1.xml"
       );
 
@@ -882,19 +540,19 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
       // Content of the DB should be unchanged = 3 sample norms, all unpublished
       assertThat(normRepository.findAll()).hasSize(3);
       assertThat(
-        normRepository.findByEliManifestation(
+        normRepository.findByEliDokumentManifestation(
           "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/2022-08-23/regelungstext-1.xml"
         )
       )
         .isNotEmpty();
       assertThat(
-        normRepository.findByEliManifestation(
+        normRepository.findByEliDokumentManifestation(
           "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-1.xml"
         )
       )
         .isNotEmpty();
       assertThat(
-        normRepository.findByEliManifestation(
+        normRepository.findByEliDokumentManifestation(
           "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/2022-08-23/regelungstext-1.xml"
         )
       )
@@ -931,7 +589,7 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
 
       // Assert ZF0 was created
       assertThat(
-        normRepository.findByEliManifestation(
+        normRepository.findByEliDokumentManifestation(
           "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/%s/regelungstext-1.xml".formatted(
               LocalDate.now().toString()
             )
@@ -1196,7 +854,7 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
 
       // Assert ZF0 was created
       assertThat(
-        normRepository.findByEliManifestation(
+        normRepository.findByEliDokumentManifestation(
           "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/%s/regelungstext-1.xml".formatted(
               LocalDate.now().toString()
             )
@@ -1206,7 +864,7 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
 
       // Assert old ZF0 was deleted
       assertThat(
-        normRepository.findByEliManifestation(
+        normRepository.findByEliDokumentManifestation(
           "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/2022-08-23/regelungstext-1.xml"
         )
       )

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ArticleControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ArticleControllerIntegrationTest.java
@@ -659,9 +659,11 @@ class ArticleControllerIntegrationTest extends BaseIntegrationTest {
                          <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
                             <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8a">
                                <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b12619a" value="eli/bund/bgbl-1/1964/s593/regelungstext-1" />
+                               <akn:FRBRuri eId="meta-1_ident-1_frbrwork-1_frbruri-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b12619b" value="eli/bund/bgbl-1/1964/s593" />
                             </akn:FRBRWork>
                             <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
                                <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu/regelungstext-1" />
+                               <akn:FRBRuri eId="meta-1_ident-1_frbrexpression-1_frbruri-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126199" value="eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu" />
                                <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
                                <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
                             </akn:FRBRExpression>
@@ -766,9 +768,11 @@ class ArticleControllerIntegrationTest extends BaseIntegrationTest {
                          <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
                             <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8a">
                                <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b12619a" value="eli/bund/bgbl-1/1964/s593/regelungstext-1" />
+                               <akn:FRBRuri eId="meta-1_ident-1_frbrwork-1_frbruri-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b12619b" value="eli/bund/bgbl-1/1964/s593" />
                             </akn:FRBRWork>
                             <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
                                <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126197" value="eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu/regelungstext-1" />
+                               <akn:FRBRuri eId="meta-1_ident-1_frbrexpression-1_frbruri-1" GUID="f3805314-bbb6-4def-b82b-8b7f0b126198" value="eli/bund/bgbl-1/1964/s593/2017-03-15/1/deu" />
                                <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-1" GUID="6c99101d-6bca-41ae-9794-250bd096fead" name="aktuelle-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f" />
                                <akn:FRBRalias eId="meta-1_ident-1_frbrexpression-1_frbralias-2" GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87" />
                             </akn:FRBRExpression>

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/NormExpressionControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/NormExpressionControllerIntegrationTest.java
@@ -360,9 +360,11 @@ class NormExpressionControllerIntegrationTest extends BaseIntegrationTest {
                  <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
                     <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8e">
                        <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c70" value="eli/bund/bgbl-1/1964/s593/regelungstext-1" />
+                       <akn:FRBRuri eId="meta-1_ident-1_frbrwork-1_frbruri-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c71" value="eli/bund/bgbl-1/1964/s593" />
                     </akn:FRBRWork>
                     <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                       <akn:FRBRuri eId="meta-1_ident-1_frbrexpression-1_frbruri-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c79" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu" />
                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
                            <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="77167d15-511d-4927-adf3-3c8b0464423c"/>
                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
@@ -371,6 +373,9 @@ class NormExpressionControllerIntegrationTest extends BaseIntegrationTest {
                                                 GUID="bd2375e5-3e81-435d-a4f8-159d8572c46b">
                             <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1"
                                           GUID="9dcc818e-3ed8-4414-b562-342bd5f405b3"
+                                              value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-1.xml"/>
+                            <akn:FRBRuri eId="meta-1_ident-1_frbrmanifestation-1_frbruri-1"
+                                          GUID="9dcc818e-3ed8-4414-b562-342bd5f405b4"
                                               value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-1.xml"/>
                             <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1"
                                           GUID="f3288a2a-3511-454e-ada1-9de8c33f6dbe"
@@ -457,9 +462,11 @@ class NormExpressionControllerIntegrationTest extends BaseIntegrationTest {
                   <akn:identification GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" eId="meta-1_ident-1" source="attributsemantik-noch-undefiniert">
                       <akn:FRBRWork GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8e" eId="meta-1_ident-1_frbrwork-1">
                         <akn:FRBRthis GUID="c01334e2-f12b-4055-ac82-15ac03c74c70" eId="meta-1_ident-1_frbrwork-1_frbrthis-1" value="eli/bund/bgbl-1/1964/s593/regelungstext-1"/>
+                        <akn:FRBRuri GUID="c01334e2-f12b-4055-ac82-15ac03c74c71" eId="meta-1_ident-1_frbrwork-1_frbruri-1" value="eli/bund/bgbl-1/1964/s593"/>
                      </akn:FRBRWork>
                      <akn:FRBRExpression GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d" eId="meta-1_ident-1_frbrexpression-1">
                         <akn:FRBRthis GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"/>
+                        <akn:FRBRuri GUID="c01334e2-f12b-4055-ac82-15ac03c74c79" eId="meta-1_ident-1_frbrexpression-1_frbruri-1" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu"/>
                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
                         <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
                         <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ProprietaryControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ProprietaryControllerIntegrationTest.java
@@ -256,7 +256,9 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
         .andExpect(jsonPath("organisationsEinheit").value("Andere Organisationseinheit"));
 
       final Norm normLoaded = NormMapper.mapToDomain(
-        normRepository.findFirstByEliExpressionOrderByEliManifestationDesc(eli).get()
+        normRepository
+          .findFirstByEliDokumentExpressionOrderByEliDokumentManifestationDesc(eli)
+          .get()
       );
 
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getFna(date)).contains("new-fna");
@@ -322,7 +324,9 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
         .andExpect(jsonPath("organisationsEinheit").isEmpty());
 
       final Norm normLoaded = NormMapper.mapToDomain(
-        normRepository.findFirstByEliExpressionOrderByEliManifestationDesc(eli).get()
+        normRepository
+          .findFirstByEliDokumentExpressionOrderByEliDokumentManifestationDesc(eli)
+          .get()
       );
 
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getFna(date)).contains("754-28-1");
@@ -386,7 +390,9 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
         .andExpect(jsonPath("organisationsEinheit").isEmpty());
 
       final Norm normLoaded = NormMapper.mapToDomain(
-        normRepository.findFirstByEliExpressionOrderByEliManifestationDesc(eli).get()
+        normRepository
+          .findFirstByEliDokumentExpressionOrderByEliDokumentManifestationDesc(eli)
+          .get()
       );
 
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getFna(date)).contains("754-28-1");
@@ -450,7 +456,9 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // then
       final Norm normLoaded = NormMapper.mapToDomain(
-        normRepository.findFirstByEliExpressionOrderByEliManifestationDesc(eli).get()
+        normRepository
+          .findFirstByEliDokumentExpressionOrderByEliDokumentManifestationDesc(eli)
+          .get()
       );
 
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getFna(date)).contains("fna");
@@ -515,7 +523,9 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
 
       // then
       final Norm normLoaded = NormMapper.mapToDomain(
-        normRepository.findFirstByEliExpressionOrderByEliManifestationDesc(eli).get()
+        normRepository
+          .findFirstByEliDokumentExpressionOrderByEliDokumentManifestationDesc(eli)
+          .get()
       );
 
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getFna(date)).contains("fna");
@@ -581,7 +591,9 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
         .andExpect(jsonPath("organisationsEinheit").value("Andere Organisationseinheit"));
 
       final Norm normLoaded = NormMapper.mapToDomain(
-        normRepository.findFirstByEliExpressionOrderByEliManifestationDesc(eli).get()
+        normRepository
+          .findFirstByEliDokumentExpressionOrderByEliDokumentManifestationDesc(eli)
+          .get()
       );
 
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getFna(date)).contains("new-fna");
@@ -642,7 +654,9 @@ public class ProprietaryControllerIntegrationTest extends BaseIntegrationTest {
         .andExpect(jsonPath("organisationsEinheit").value("Organisationseinheit"));
 
       final Norm normLoaded = NormMapper.mapToDomain(
-        normRepository.findFirstByEliExpressionOrderByEliManifestationDesc(eli).get()
+        normRepository
+          .findFirstByEliDokumentExpressionOrderByEliDokumentManifestationDesc(eli)
+          .get()
       );
 
       assertThat(normLoaded.getMeta().getOrCreateProprietary().getFna(date)).contains("new-fna");

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/TimeBoundaryControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/TimeBoundaryControllerIntegrationTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import de.bund.digitalservice.ris.norms.adapter.output.database.mapper.NormMapper;
 import de.bund.digitalservice.ris.norms.adapter.output.database.repository.NormRepository;
+import de.bund.digitalservice.ris.norms.domain.entity.Fixtures;
 import de.bund.digitalservice.ris.norms.domain.entity.Norm;
 import de.bund.digitalservice.ris.norms.domain.entity.Regelungstext;
 import de.bund.digitalservice.ris.norms.integration.BaseIntegrationTest;
@@ -71,68 +72,25 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
     @Test
     void itCallsGetTimeBoundariesAndReturnsJson() throws Exception {
       // Given
-      final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
-      final String xml =
-        """
-          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-             <akn:act name="regelungstext">
-                <!-- Metadaten -->
-                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                  <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                     <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8a">
-                        <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c7a" value="eli/bund/bgbl-1/1964/s593/regelungstext-1" />
-                     </akn:FRBRWork>
-                     <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                        <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                     </akn:FRBRExpression>
-                        <akn:FRBRManifestation eId="meta-1_ident-1_frbrmanifestation-1" GUID="ea61dfec-d89c-442a-9f6d-cb65d8ed2dc3">
-                               <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1" GUID="d74e4be8-c15d-4a9f-8ae6-781e522dc7a4" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/2022-08-23/regelungstext-1.xml"/>
-                           <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1" GUID="791a8124-d12e-45e1-9c80-5f0438e4d046" date="2022-08-23" name="generierung"/>
-                        </akn:FRBRManifestation>
-                 </akn:identification>
-                   <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-01-01"
-                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                   </akn:lifecycle>
-                   <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                               <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                  <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                               </akn:temporalGroup>
-                               <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
-                                  <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
-                               </akn:temporalGroup>
-                   </akn:temporalData>
-                </akn:meta>
-             </akn:act>
-          </akn:akomaNtoso>
-        """.strip();
-
-      // When
-      var norm = Norm
-        .builder()
-        .regelungstexte(Set.of(new Regelungstext(XmlMapper.toDocument(xml))))
-        .build();
+      var norm = Fixtures.loadNormFromDisk("NormWithPassiveModifications.xml");
       normRepository.save(NormMapper.mapToDto(norm));
 
       // When // Then
       mockMvc
-        .perform(get("/api/v1/norms/{eli}/timeBoundaries", eli).accept(MediaType.APPLICATION_JSON))
+        .perform(
+          get("/api/v1/norms/{eli}/timeBoundaries", norm.getExpressionEli())
+            .accept(MediaType.APPLICATION_JSON)
+        )
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$", hasSize(2)))
-        .andExpect(jsonPath("$[0].date", is("2023-12-30")))
+        .andExpect(jsonPath("$", hasSize(4)))
+        .andExpect(jsonPath("$[0].date", is("1964-09-21")))
         .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")))
-        .andExpect(jsonPath("$[1].date", is("2024-01-01")))
-        .andExpect(jsonPath("$[1].eventRefEid", is("meta-1_lebzykl-1_ereignis-3")));
+        .andExpect(jsonPath("$[1].date", is("2017-03-23")))
+        .andExpect(jsonPath("$[1].eventRefEid", is("meta-1_lebzykl-1_ereignis-4")))
+        .andExpect(jsonPath("$[2].date", is("2019-01-01")))
+        .andExpect(jsonPath("$[2].eventRefEid", is("meta-1_lebzykl-1_ereignis-5")))
+        .andExpect(jsonPath("$[3].date", is("2017-03-01")))
+        .andExpect(jsonPath("$[3].eventRefEid", is("meta-1_lebzykl-1_ereignis-6")));
     }
   }
 
@@ -175,92 +133,19 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
     @Test
     void itCallsGetTimeBoundariesAmendedByAndReturnsEmpty() throws Exception {
       // Given
-      final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
       var amendedBy = "eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/non-in-norm";
 
-      var norm = Norm
-        .builder()
-        .regelungstexte(
-          Set.of(
-            new Regelungstext(
-              XmlMapper.toDocument(
-                """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                    <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                                                                        http://Inhaltsdaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                   <akn:act name="regelungstext">
-                      <!-- Metadaten -->
-                      <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                         <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                           <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8a">
-                               <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c7a" value="eli/bund/bgbl-1/1964/s593/regelungstext-1" />
-                           </akn:FRBRWork>
-                           <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                              <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                              <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                              <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                              <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                           </akn:FRBRExpression>
-                               <akn:FRBRManifestation eId="meta-1_ident-1_frbrmanifestation-1" GUID="ea61dfec-d89c-442a-9f6d-cb65d8ed2dc3">
-                                      <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1" GUID="d74e4be8-c15d-4a9f-8ae6-781e522dc7a4" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/2022-08-23/regelungstext-1.xml"/>
-                                  <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1" GUID="791a8124-d12e-45e1-9c80-5f0438e4d046" date="2022-08-23" name="generierung"/>
-                               </akn:FRBRManifestation>
-                        </akn:identification>
-                         <akn:analysis eId="meta-1_analysis-1" GUID="5a5d264e-431e-4dc1-b971-4bd81af8a0f4" source="attributsemantik-noch-undefiniert">
-                            <akn:passiveModifications eId="meta-1_analysis-1_pasmod-1" GUID="77aae58f-06c9-4189-af80-a5f3ada6432c">
-                               <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-1" GUID="06fb52c3-fce1-4be8-accc-3035452378ff" type="substitution">
-                                  <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-1_source-1" GUID="5384f580-110b-4f8a-8794-8b85c29aabdf" href="eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1.xml" />
-                                          <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-1_destination-1" GUID="2c26512f-fb04-45f2-8283-660274e52fdb" href="#art-9_abs-3" />
-                                  <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-1_gelzeitnachw-1" GUID="45331583-4386-4e3f-b68f-5af327347874" period="#meta-1_geltzeiten-1_geltungszeitgr-2" />
-                               </akn:textualMod>
-                               <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-2" GUID="26b091d0-1bb9-4c83-b940-f6788b2922f2" type="substitution">
-                                  <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-2_source-1" GUID="a5e43d31-65e1-4d99-a1aa-fb4695a94cf5" href="eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml" />
-                                          <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-2_destination-1" GUID="8c0418f1-b6fa-4110-8820-cf0db752c5bd" href="#art-20_abs-1/100-126" />
-                                  <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-2_gelzeitnachw-1" GUID="e5962d3b-9bb8-4eb0-8d8f-131a5114fddb" period="#meta-1_geltzeiten-1_geltungszeitgr-3" />
-                               </akn:textualMod>
-                               <!-- Passive mod from different amending law -->
-                               <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-2" GUID="26b091d0-1bb9-4c83-b940-f6788b2922f2" type="substitution">
-                                  <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-2_source-1" GUID="a5e43d31-65e1-4d99-a1aa-fb4695a94cf5" href="eli/bund/bgbl-1/2024/120/2024-06-28/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml" />
-                                          <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-2_destination-1" GUID="8c0418f1-b6fa-4110-8820-cf0db752c5bd" href="#art-20_abs-1/100-126" />
-                                  <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-2_gelzeitnachw-1" GUID="e5962d3b-9bb8-4eb0-8d8f-131a5114fddb" period="#meta-1_geltzeiten-1_geltungszeitgr-4" />
-                               </akn:textualMod>
-                            </akn:passiveModifications>
-                         </akn:analysis>
-                         <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                            <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29" source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                            <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                            <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-01-01" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                            <akn:eventRef eId="meta-1_lebzykl-1_ereignis-4" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-02-28" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                         </akn:lifecycle>
-                         <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                            <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                               <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                            </akn:temporalGroup>
-                            <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
-                               <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
-                            </akn:temporalGroup>
-                            <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-3" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
-                               <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4" />
-                            </akn:temporalGroup>
-                            <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-4" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
-                               <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-4_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4" />
-                            </akn:temporalGroup>
-                         </akn:temporalData>
-                      </akn:meta>
-                   </akn:act>
-                </akn:akomaNtoso>
-                """
-              )
-            )
-          )
-        )
-        .build();
+      var norm = Fixtures.loadNormFromDisk("NormWithPassiveModifications.xml");
       normRepository.save(NormMapper.mapToDto(norm));
 
       // When // Then
       mockMvc
         .perform(
-          get("/api/v1/norms/{eli}/timeBoundaries?amendedBy={amendedBy}", eli, amendedBy)
+          get(
+            "/api/v1/norms/{eli}/timeBoundaries?amendedBy={amendedBy}",
+            norm.getExpressionEli(),
+            amendedBy
+          )
             .accept(MediaType.APPLICATION_JSON)
         )
         .andExpect(status().isOk())
@@ -270,102 +155,26 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
     @Test
     void itCallsGetTimeBoundariesAmendedByAndReturnsJson() throws Exception {
       // Given
-      final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
-      var amendedBy = "eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/regelungstext-1";
+      var amendedBy = "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1";
 
-      var norm = Norm
-        .builder()
-        .regelungstexte(
-          Set.of(
-            new Regelungstext(
-              XmlMapper.toDocument(
-                """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-                    <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-metadaten.xsd                                                                        http://Inhaltsdaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-                   <akn:act name="regelungstext">
-                      <!-- Metadaten -->
-                      <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                         <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                           <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8a">
-                              <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c7a" value="eli/bund/bgbl-1/1964/s593/regelungstext-1" />
-                           </akn:FRBRWork>
-                           <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                              <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                              <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                              <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                              <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                           </akn:FRBRExpression>
-                               <akn:FRBRManifestation eId="meta-1_ident-1_frbrmanifestation-1" GUID="ea61dfec-d89c-442a-9f6d-cb65d8ed2dc3">
-                                      <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1" GUID="d74e4be8-c15d-4a9f-8ae6-781e522dc7a4" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/2022-08-23/regelungstext-1.xml"/>
-                                  <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1" GUID="791a8124-d12e-45e1-9c80-5f0438e4d046" date="2022-08-23" name="generierung"/>
-                               </akn:FRBRManifestation>
-                        </akn:identification>
-                         <akn:analysis eId="meta-1_analysis-1" GUID="5a5d264e-431e-4dc1-b971-4bd81af8a0f4" source="attributsemantik-noch-undefiniert">
-                            <akn:passiveModifications eId="meta-1_analysis-1_pasmod-1" GUID="77aae58f-06c9-4189-af80-a5f3ada6432c">
-                               <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-1" GUID="06fb52c3-fce1-4be8-accc-3035452378ff" type="substitution">
-                                  <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-1_source-1" GUID="5384f580-110b-4f8a-8794-8b85c29aabdf" href="eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-1_inhalt-1_text-1_ändbefehl-1.xml" />
-                                          <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-1_destination-1" GUID="2c26512f-fb04-45f2-8283-660274e52fdb" href="#art-9_abs-3" />
-                                  <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-1_gelzeitnachw-1" GUID="45331583-4386-4e3f-b68f-5af327347874" period="#meta-1_geltzeiten-1_geltungszeitgr-2" />
-                               </akn:textualMod>
-                               <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-2" GUID="26b091d0-1bb9-4c83-b940-f6788b2922f2" type="substitution">
-                                  <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-2_source-1" GUID="a5e43d31-65e1-4d99-a1aa-fb4695a94cf5" href="eli/bund/bgbl-1/2024/81/2024-03-05/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml" />
-                                          <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-2_destination-1" GUID="8c0418f1-b6fa-4110-8820-cf0db752c5bd" href="#art-20_abs-1/100-126" />
-                                  <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-2_gelzeitnachw-1" GUID="e5962d3b-9bb8-4eb0-8d8f-131a5114fddb" period="#meta-1_geltzeiten-1_geltungszeitgr-3" />
-                               </akn:textualMod>
-                               <!-- Passive mod from different amending law -->
-                               <akn:textualMod eId="meta-1_analysis-1_pasmod-1_textualmod-2" GUID="26b091d0-1bb9-4c83-b940-f6788b2922f2" type="substitution">
-                                  <akn:source eId="meta-1_analysis-1_pasmod-1_textualmod-2_source-1" GUID="a5e43d31-65e1-4d99-a1aa-fb4695a94cf5" href="eli/bund/bgbl-1/2024/120/2024-06-28/1/deu/regelungstext-1/art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1_ändbefehl-1.xml" />
-                                          <akn:destination eId="meta-1_analysis-1_pasmod-1_textualmod-2_destination-1" GUID="8c0418f1-b6fa-4110-8820-cf0db752c5bd" href="#art-20_abs-1/100-126" />
-                                  <akn:force eId="meta-1_analysis-1_pasmod-1_textualmod-2_gelzeitnachw-1" GUID="e5962d3b-9bb8-4eb0-8d8f-131a5114fddb" period="#meta-1_geltzeiten-1_geltungszeitgr-4" />
-                               </akn:textualMod>
-                            </akn:passiveModifications>
-                         </akn:analysis>
-                         <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                            <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29" source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                            <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                            <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-01-01" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                            <akn:eventRef eId="meta-1_lebzykl-1_ereignis-4" GUID="4539e3ee-3b35-4921-a249-93a98dbd7339" date="2024-02-28" source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                         </akn:lifecycle>
-                         <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                            <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                               <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                            </akn:temporalGroup>
-                            <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
-                               <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
-                            </akn:temporalGroup>
-                            <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-3" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
-                               <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-3_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4" />
-                            </akn:temporalGroup>
-                            <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-4" GUID="fdfaeef0-0300-4e5b-9e8b-14d2162bfb00">
-                               <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-4_gelzeitintervall-1" GUID="8118030a-5fa4-4f9c-a880-b7ba19e5edfb" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-4" />
-                            </akn:temporalGroup>
-                         </akn:temporalData>
-                      </akn:meta>
-                   </akn:act>
-                </akn:akomaNtoso>
-                """
-              )
-            )
-          )
-        )
-        .build();
+      var norm = Fixtures.loadNormFromDisk("NormWithPassiveModifications.xml");
       normRepository.save(NormMapper.mapToDto(norm));
 
       // When // Then
       mockMvc
         .perform(
-          get("/api/v1/norms/{eli}/timeBoundaries?amendedBy={amendedBy}", eli, amendedBy)
+          get(
+            "/api/v1/norms/{eli}/timeBoundaries?amendedBy={amendedBy}",
+            norm.getExpressionEli(),
+            amendedBy
+          )
             .accept(MediaType.APPLICATION_JSON)
         )
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$", hasSize(2)))
-        .andExpect(jsonPath("$[0].date", is("2024-01-01")))
-        .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-3")))
-        .andExpect(jsonPath("$[0].temporalGroupEid", is("meta-1_geltzeiten-1_geltungszeitgr-2")))
-        .andExpect(jsonPath("$[1].date", is("2024-02-28")))
-        .andExpect(jsonPath("$[1].eventRefEid", is("meta-1_lebzykl-1_ereignis-4")))
-        .andExpect(jsonPath("$[1].temporalGroupEid", is("meta-1_geltzeiten-1_geltungszeitgr-3")));
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0].date", is("2017-03-23")))
+        .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-4")))
+        .andExpect(jsonPath("$[0].temporalGroupEid", is("meta-1_geltzeiten-1_geltungszeitgr-2")));
     }
   }
 
@@ -409,129 +218,15 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    void itCallsUpdateTimeBoundaries() throws Exception {
-      final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
-      final String xml =
-        """
-          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-             <akn:act name="regelungstext">
-                <!-- Metadaten -->
-                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                  <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                     <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8a">
-                        <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c7a" value="eli/bund/bgbl-1/1964/s593/regelungstext-1" />
-                     </akn:FRBRWork>
-                     <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                        <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                     </akn:FRBRExpression>
-                         <akn:FRBRManifestation eId="meta-1_ident-1_frbrmanifestation-1" GUID="ea61dfec-d89c-442a-9f6d-cb65d8ed2dc3">
-                                <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1" GUID="d74e4be8-c15d-4a9f-8ae6-781e522dc7a4" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/2022-08-23/regelungstext-1.xml"/>
-                            <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1" GUID="791a8124-d12e-45e1-9c80-5f0438e4d046" date="2022-08-23" name="generierung"/>
-                         </akn:FRBRManifestation>
-                 </akn:identification>
-                   <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                   </akn:lifecycle>
-                   <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                               <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                  <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                               </akn:temporalGroup>
-                   </akn:temporalData>
-                </akn:meta>
-             </akn:act>
-          </akn:akomaNtoso>
-        """.strip();
-
-      // When
-      var norm = Norm
-        .builder()
-        .regelungstexte(Set.of(new Regelungstext(XmlMapper.toDocument(xml))))
-        .build();
-      normRepository.save(NormMapper.mapToDto(norm));
-
-      // Then
-      mockMvc
-        .perform(
-          put("/api/v1/norms/{eli}/timeBoundaries", eli)
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(
-              "[{\"date\": \"2023-12-30\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-2\"},{\"date\": \"2024-01-01\", \"eventRefEid\": null}]"
-            )
-        )
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$", hasSize(2)))
-        // still there
-        .andExpect(jsonPath("$[0].date", is("2023-12-30")))
-        .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")))
-        // expect new
-        .andExpect(jsonPath("$[1].date", is("2024-01-01")))
-        .andExpect(jsonPath("$[1].eventRefEid", is("meta-1_lebzykl-1_ereignis-3")));
-    }
-
-    @Test
     void itCallsUpdateTimeBoundariesDateNull() throws Exception {
-      final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
-      final String xml =
-        """
-          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-             <akn:act name="regelungstext">
-                <!-- Metadaten -->
-                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                      <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8a">
-                        <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c7a" value="eli/bund/bgbl-1/1964/s593/regelungstext-1" />
-                     </akn:FRBRWork>
-                     <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                        <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                     </akn:FRBRExpression>
-                         <akn:FRBRManifestation eId="meta-1_ident-1_frbrmanifestation-1" GUID="ea61dfec-d89c-442a-9f6d-cb65d8ed2dc3">
-                                <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1" GUID="d74e4be8-c15d-4a9f-8ae6-781e522dc7a4" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/2022-08-23/regelungstext-1.xml"/>
-                            <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1" GUID="791a8124-d12e-45e1-9c80-5f0438e4d046" date="2022-08-23" name="generierung"/>
-                         </akn:FRBRManifestation>
-                   </akn:identification>
-                   <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                   </akn:lifecycle>
-                   <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                       <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                       </akn:temporalGroup>
-                   </akn:temporalData>
-                </akn:meta>
-             </akn:act>
-          </akn:akomaNtoso>
-        """.strip();
-
       // When
-      var norm = Norm
-        .builder()
-        .regelungstexte(Set.of(new Regelungstext(XmlMapper.toDocument(xml))))
-        .build();
+      var norm = Fixtures.loadNormFromDisk("SimpleNorm.xml");
       normRepository.save(NormMapper.mapToDto(norm));
 
       // Then
       mockMvc
         .perform(
-          put("/api/v1/norms/{eli}/timeBoundaries", eli)
+          put("/api/v1/norms/{eli}/timeBoundaries", norm.getExpressionEli())
             .accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON)
             .content("[{\"date\": null, \"eventRefEid\": null}]")
@@ -552,51 +247,9 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
     @Test
     void itCallsUpdateTimeBoundariesDateMalformed() throws Exception {
       final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
-      final String xml =
-        """
-          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-             <akn:act name="regelungstext">
-                <!-- Metadaten -->
-                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                   <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                     <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8a">
-                        <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c7a" value="eli/bund/bgbl-1/1964/s593/regelungstext-1" />
-                     </akn:FRBRWork>
-                     <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                        <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                     </akn:FRBRExpression>
-                         <akn:FRBRManifestation eId="meta-1_ident-1_frbrmanifestation-1" GUID="ea61dfec-d89c-442a-9f6d-cb65d8ed2dc3">
-                                <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1" GUID="d74e4be8-c15d-4a9f-8ae6-781e522dc7a4" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/2022-08-23/regelungstext-1.xml"/>
-                            <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1" GUID="791a8124-d12e-45e1-9c80-5f0438e4d046" date="2022-08-23" name="generierung"/>
-                         </akn:FRBRManifestation>
-                   </akn:identification>
-                   <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                   </akn:lifecycle>
-                   <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                       <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                          <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                       </akn:temporalGroup>
-                   </akn:temporalData>
-                </akn:meta>
-             </akn:act>
-          </akn:akomaNtoso>
-        """.strip();
 
       // When
-      var norm = Norm
-        .builder()
-        .regelungstexte(Set.of(new Regelungstext(XmlMapper.toDocument(xml))))
-        .build();
+      var norm = Fixtures.loadNormFromDisk("SimpleNorm.xml");
       normRepository.save(NormMapper.mapToDto(norm));
 
       // Then
@@ -622,51 +275,9 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
     @Test
     void itCallsUpdateTimeBoundariesMultipleSameDates() throws Exception {
       final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
-      final String xml =
-        """
-          <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-              <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                     http://Inhaltsdaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-             <akn:act name="regelungstext">
-                <!-- Metadaten -->
-                <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                  <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                     <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8a">
-                        <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c7a" value="eli/bund/bgbl-1/1964/s593/regelungstext-1" />
-                     </akn:FRBRWork>
-                     <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                        <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                        <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                        <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                     </akn:FRBRExpression>
-                         <akn:FRBRManifestation eId="meta-1_ident-1_frbrmanifestation-1" GUID="ea61dfec-d89c-442a-9f6d-cb65d8ed2dc3">
-                                <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1" GUID="d74e4be8-c15d-4a9f-8ae6-781e522dc7a4" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/2022-08-23/regelungstext-1.xml"/>
-                            <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1" GUID="791a8124-d12e-45e1-9c80-5f0438e4d046" date="2022-08-23" name="generierung"/>
-                         </akn:FRBRManifestation>
-                 </akn:identification>
-                   <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                      <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                          source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                   </akn:lifecycle>
-                   <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                               <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                                  <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                               </akn:temporalGroup>
-                   </akn:temporalData>
-                </akn:meta>
-             </akn:act>
-          </akn:akomaNtoso>
-        """.strip();
 
       // When
-      var norm = Norm
-        .builder()
-        .regelungstexte(Set.of(new Regelungstext(XmlMapper.toDocument(xml))))
-        .build();
+      var norm = Fixtures.loadNormFromDisk("SimpleNorm.xml");
       normRepository.save(NormMapper.mapToDto(norm));
 
       // Then
@@ -694,218 +305,6 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
               "/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/timeBoundaries"
             )
         );
-    }
-
-    @Test
-    void itCallsUpdateTimeBoundariesDelete() throws Exception {
-      final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
-      final String xml =
-        """
-        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                   http://Inhaltsdaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-           <akn:act name="regelungstext">
-              <!-- Metadaten -->
-              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                   <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8a">
-                      <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c7a" value="eli/bund/bgbl-1/1964/s593/regelungstext-1" />
-                   </akn:FRBRWork>
-                   <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                      <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                      <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                   </akn:FRBRExpression>
-                       <akn:FRBRManifestation eId="meta-1_ident-1_frbrmanifestation-1" GUID="ea61dfec-d89c-442a-9f6d-cb65d8ed2dc3">
-                              <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1" GUID="d74e4be8-c15d-4a9f-8ae6-781e522dc7a4" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/2022-08-23/regelungstext-1.xml"/>
-                          <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1" GUID="791a8124-d12e-45e1-9c80-5f0438e4d046" date="2022-08-23" name="generierung"/>
-                       </akn:FRBRManifestation>
-               </akn:identification>
-                 <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="860d4338-04a0-419f-a3d1-e7dbefd36d8b" date="2024-12-01"
-                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                 </akn:lifecycle>
-                 <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                     <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                     </akn:temporalGroup>
-                     <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="f49f536c-57e9-4c5e-9edd-4b827340279e">
-                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="63eedd45-6a2c-4213-bbc4-27596255c1b7" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
-                     </akn:temporalGroup>
-                 </akn:temporalData>
-              </akn:meta>
-           </akn:act>
-        </akn:akomaNtoso>
-        """.strip();
-
-      // When
-      var norm = Norm
-        .builder()
-        .regelungstexte(Set.of(new Regelungstext(XmlMapper.toDocument(xml))))
-        .build();
-      normRepository.save(NormMapper.mapToDto(norm));
-
-      // Then
-      mockMvc
-        .perform(
-          put("/api/v1/norms/{eli}/timeBoundaries", eli)
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(
-              "[{\"date\": \"2023-12-30\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-2\"}]"
-            )
-        )
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$", hasSize(1)))
-        // still there
-        .andExpect(jsonPath("$[0].date", is("2023-12-30")))
-        .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")));
-    }
-
-    @Test
-    void itCallsUpdateTimeBoundariesAddAndDelete() throws Exception {
-      final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
-      final String xml =
-        """
-        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                   http://Inhaltsdaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-           <akn:act name="regelungstext">
-              <!-- Metadaten -->
-              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                   <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8a">
-                      <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c7a" value="eli/bund/bgbl-1/1964/s593/regelungstext-1" />
-                   </akn:FRBRWork>
-                   <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                      <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                      <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                   </akn:FRBRExpression>
-                       <akn:FRBRManifestation eId="meta-1_ident-1_frbrmanifestation-1" GUID="ea61dfec-d89c-442a-9f6d-cb65d8ed2dc3">
-                              <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1" GUID="d74e4be8-c15d-4a9f-8ae6-781e522dc7a4" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/2022-08-23/regelungstext-1.xml"/>
-                          <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1" GUID="791a8124-d12e-45e1-9c80-5f0438e4d046" date="2022-08-23" name="generierung"/>
-                       </akn:FRBRManifestation>
-               </akn:identification>
-                 <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                 </akn:lifecycle>
-                 <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                     <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                     </akn:temporalGroup>
-                 </akn:temporalData>
-              </akn:meta>
-           </akn:act>
-        </akn:akomaNtoso>
-        """.strip();
-
-      // When
-      var norm = Norm
-        .builder()
-        .regelungstexte(Set.of(new Regelungstext(XmlMapper.toDocument(xml))))
-        .build();
-      normRepository.save(NormMapper.mapToDto(norm));
-
-      // Then
-      mockMvc
-        .perform(
-          put("/api/v1/norms/{eli}/timeBoundaries", eli)
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content("[{\"date\": \"2024-01-01\", \"eventRefEid\": null}]")
-        )
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$", hasSize(1)))
-        // expect new
-        .andExpect(jsonPath("$[0].date", is("2024-01-01")))
-        .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")));
-    }
-
-    @Test
-    void itCallsUpdateTimeBoundariesAddAndDeleteWithTwo() throws Exception {
-      final String eli = "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1";
-      final String xml =
-        """
-        <?xml-model href="../../../Grammatiken/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-            <akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.7.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               xsi:schemaLocation="http://Metadaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-metadaten.xsd
-                                   http://Inhaltsdaten.LegalDocML.de/1.7.1/ ../../../Grammatiken/legalDocML.de-regelungstextverkuendungsfassung.xsd">
-           <akn:act name="regelungstext">
-              <!-- Metadaten -->
-              <akn:meta eId="meta-1" GUID="82a65581-0ea7-4525-9190-35ff86c977af">
-                <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
-                   <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8a">
-                      <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c7a" value="eli/bund/bgbl-1/1964/s593/regelungstext-1" />
-                   </akn:FRBRWork>
-                   <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
-                      <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
-                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
-                      <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
-                      <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
-                   </akn:FRBRExpression>
-                       <akn:FRBRManifestation eId="meta-1_ident-1_frbrmanifestation-1" GUID="ea61dfec-d89c-442a-9f6d-cb65d8ed2dc3">
-                              <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1" GUID="d74e4be8-c15d-4a9f-8ae6-781e522dc7a4" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/2022-08-23/regelungstext-1.xml"/>
-                          <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1" GUID="791a8124-d12e-45e1-9c80-5f0438e4d046" date="2022-08-23" name="generierung"/>
-                       </akn:FRBRManifestation>
-               </akn:identification>
-                 <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
-                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2023-12-29"
-                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="ausfertigung" />
-                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-2" GUID="176435e5-1324-4718-b09a-ef4b63bcacf0" date="2023-12-30"
-                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                    <akn:eventRef eId="meta-1_lebzykl-1_ereignis-3" GUID="860d4338-04a0-419f-a3d1-e7dbefd36d8b" date="2024-12-01"
-                        source="attributsemantik-noch-undefiniert" type="generation" refersTo="inkrafttreten" />
-                 </akn:lifecycle>
-                 <akn:temporalData eId="meta-1_geltzeiten-1" GUID="82854d32-d922-43d7-ac8c-612c07219336" source="attributsemantik-noch-undefiniert">
-                     <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-1" GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
-                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-1_gelzeitintervall-1" GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-2" />
-                     </akn:temporalGroup>
-                     <akn:temporalGroup eId="meta-1_geltzeiten-1_geltungszeitgr-2" GUID="f49f536c-57e9-4c5e-9edd-4b827340279e">
-                        <akn:timeInterval eId="meta-1_geltzeiten-1_geltungszeitgr-2_gelzeitintervall-1" GUID="63eedd45-6a2c-4213-bbc4-27596255c1b7" refersTo="geltungszeit" start="#meta-1_lebzykl-1_ereignis-3" />
-                     </akn:temporalGroup>
-                 </akn:temporalData>
-              </akn:meta>
-           </akn:act>
-        </akn:akomaNtoso>
-        """.strip();
-
-      // When
-      var norm = Norm
-        .builder()
-        .regelungstexte(Set.of(new Regelungstext(XmlMapper.toDocument(xml))))
-        .build();
-      normRepository.save(NormMapper.mapToDto(norm));
-
-      // Then
-      mockMvc
-        .perform(
-          put("/api/v1/norms/{eli}/timeBoundaries", eli)
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(
-              "[{\"date\": \"2023-12-30\", \"eventRefEid\": \"meta-1_lebzykl-1_ereignis-2\"},{\"date\": \"2024-01-01\", \"eventRefEid\": null}]"
-            )
-        )
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$", hasSize(2)))
-        // still there
-        .andExpect(jsonPath("$[0].date", is("2023-12-30")))
-        .andExpect(jsonPath("$[0].eventRefEid", is("meta-1_lebzykl-1_ereignis-2")))
-        // expect new
-        .andExpect(jsonPath("$[1].date", is("2024-01-01")))
-        .andExpect(jsonPath("$[1].eventRefEid", is("meta-1_lebzykl-1_ereignis-3")));
     }
 
     @Test
@@ -949,17 +348,20 @@ public class TimeBoundaryControllerIntegrationTest extends BaseIntegrationTest {
                 <akn:identification eId="meta-1_ident-1" GUID="100a364a-4680-4c7a-91ad-1b0ad9b68e7f" source="attributsemantik-noch-undefiniert">
                    <akn:FRBRWork eId="meta-1_ident-1_frbrwork-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8a">
                       <akn:FRBRthis eId="meta-1_ident-1_frbrwork-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c7a" value="eli/bund/bgbl-1/1964/s593/regelungstext-1" />
+                      <akn:FRBRuri eId="meta-1_ident-1_frbrwork-1_frbruri-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c7b" value="eli/bund/bgbl-1/1964/s593" />
                    </akn:FRBRWork>
                    <akn:FRBRExpression eId="meta-1_ident-1_frbrexpression-1" GUID="4cce38bb-236b-4947-bee1-e90f3b6c2b8d">
                       <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c78" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1" />
+                      <akn:FRBRuri eId="meta-1_ident-1_frbrexpression-1_frbruri-1" GUID="c01334e2-f12b-4055-ac82-15ac03c74c79" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu" />
                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="vorgaenger-version-id" value="ba44d2ae-0e73-44ba-850a-932ab2fa553f"/>
                       <akn:FRBRalias GUID="6c99101d-6bca-41ae-9794-250bd096fead" eId="meta-1_ident-1_frbrexpression-1_frbralias-1" name="aktuelle-version-id" value="91238a23-4321-31ac-34ad-87ad62e89f01"/>
                       <akn:FRBRalias GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37" eId="meta-1_ident-1_frbrexpression-1_frbralias-2" name="nachfolgende-version-id" value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
                    </akn:FRBRExpression>
-                       <akn:FRBRManifestation eId="meta-1_ident-1_frbrmanifestation-1" GUID="ea61dfec-d89c-442a-9f6d-cb65d8ed2dc3">
-                              <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1" GUID="d74e4be8-c15d-4a9f-8ae6-781e522dc7a4" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/2022-08-23/regelungstext-1.xml"/>
-                          <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1" GUID="791a8124-d12e-45e1-9c80-5f0438e4d046" date="2022-08-23" name="generierung"/>
-                       </akn:FRBRManifestation>
+                   <akn:FRBRManifestation eId="meta-1_ident-1_frbrmanifestation-1" GUID="ea61dfec-d89c-442a-9f6d-cb65d8ed2dc3">
+                      <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1" GUID="d74e4be8-c15d-4a9f-8ae6-781e522dc7a4" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/2022-08-23/regelungstext-1.xml"/>
+                      <akn:FRBRuri eId="meta-1_ident-1_frbrmanifestation-1_frbruri-1" GUID="d74e4be8-c15d-4a9f-8ae6-781e522dc7a6" value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/2022-08-23/regelungstext-1.xml"/>
+                      <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1" GUID="791a8124-d12e-45e1-9c80-5f0438e4d046" date="2022-08-23" name="generierung"/>
+                   </akn:FRBRManifestation>
                </akn:identification>
                  <akn:lifecycle eId="meta-1_lebzykl-1" GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b" source="attributsemantik-noch-undefiniert">
                     <akn:eventRef eId="meta-1_lebzykl-1_ereignis-1" GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06" date="2019-01-01"

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/DBServiceIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/DBServiceIntegrationTest.java
@@ -358,7 +358,7 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
     announcementRepository.save(
       AnnouncementDto
         .builder()
-        .eli(norm.getEliExpression())
+        .eli(norm.getEliDokumentExpression())
         .releases(List.of(release1, release2))
         .build()
     );
@@ -410,7 +410,13 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
       assertThat(savedAnnouncement.get().getReleases()).hasSize(1);
       assertThat(savedAnnouncement.get().getReleases().getFirst().getNorms()).hasSize(1);
       assertThat(
-        savedAnnouncement.get().getReleases().getFirst().getNorms().getFirst().getEliManifestation()
+        savedAnnouncement
+          .get()
+          .getReleases()
+          .getFirst()
+          .getNorms()
+          .getFirst()
+          .getEliDokumentManifestation()
       )
         .isEqualTo(norm.getManifestationEli().toString());
     }
@@ -445,7 +451,9 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
       assertThat(savedAnnouncement).isPresent();
       assertThat(savedAnnouncement.get().getReleases()).isEmpty();
 
-      var savedNorm = normRepository.findByEliManifestation(norm.getManifestationEli().toString());
+      var savedNorm = normRepository.findByEliDokumentManifestation(
+        norm.getManifestationEli().toString()
+      );
       assertThat(savedNorm).isPresent();
     }
   }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/application/PublishServiceIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/application/PublishServiceIntegrationTest.java
@@ -36,7 +36,7 @@ class PublishServiceIntegrationTest extends BaseS3MockIntegrationTest {
     publishService.processQueuedFilesForPublish();
 
     // Then
-    final Optional<NormDto> loaded = normRepository.findByEliManifestation(
+    final Optional<NormDto> loaded = normRepository.findByEliDokumentManifestation(
       norm.getManifestationEli().toString()
     );
     assertThat(loaded)

--- a/backend/src/test/resources/de/bund/digitalservice/ris/norms/domain/entity/SimpleNorm.xml
+++ b/backend/src/test/resources/de/bund/digitalservice/ris/norms/domain/entity/SimpleNorm.xml
@@ -36,6 +36,9 @@
                <akn:FRBRthis eId="meta-1_ident-1_frbrexpression-1_frbrthis-1"
                              GUID="c01334e2-f12b-4055-ac82-15ac03c74c78"
                              value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1"/>
+               <akn:FRBRuri eId="meta-1_ident-1_frbrexpression-1_frbruri-1"
+                             GUID="c01334e2-f12b-4055-ac82-15ac03c74c79"
+                             value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu"/>
                <akn:FRBRalias GUID="af17d907-a88a-4081-a13a-fd4522cd5d1e"
                               eId="meta-1_ident-1_frbrexpression-1_frbralias-1"
                               name="vorherige-version-id"
@@ -53,6 +56,9 @@
                                    GUID="bd2375e5-3e81-435d-a4f8-159d8572c46b">
                <akn:FRBRthis eId="meta-1_ident-1_frbrmanifestation-1_frbrthis-1"
                              GUID="9dcc818e-3ed8-4414-b562-342bd5f405b3"
+                             value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-1.xml"/>
+               <akn:FRBRuri eId="meta-1_ident-1_frbrmanifestation-1_frbruri-1"
+                             GUID="9dcc818e-3ed8-4414-b562-342bd5f405b5"
                              value="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-1.xml"/>
                <akn:FRBRdate eId="meta-1_ident-1_frbrmanifestation-1_frbrdate-1"
                              GUID="f3288a2a-3511-454e-ada1-9de8c33f6dbe"


### PR DESCRIPTION
We removed some tests from the TimeBoundaryControllerIntegrationTest that where also covered by other tests in there. This reduces the amount of maintenance these tests require.

RISDEV-5763