### PR TITLE
E2E tests: keep token in memory instead of writing to file

### DIFF
--- a/frontend/e2e/globalSetup/login-and-create-sample-data.setup.ts
+++ b/frontend/e2e/globalSetup/login-and-create-sample-data.setup.ts
@@ -17,8 +17,7 @@ setup("login", async ({ page }) => {
 
   await page.context().storageState({ path: `e2e/storage/state.json` })
 
-  await page.waitForURL("/")
-  await page.unrouteAll({ behavior: "wait" })
+  await page.waitForURL(/\/amending-laws/)
 })
 
 setup("create sample data", async ({ authenticatedRequest: request }) => {

--- a/frontend/e2e/globalSetup/login-and-create-sample-data.setup.ts
+++ b/frontend/e2e/globalSetup/login-and-create-sample-data.setup.ts
@@ -3,15 +3,17 @@ import { test as setup } from "@e2e/utils/test-with-auth"
 import fs from "fs"
 import path from "node:path"
 
-setup("login", async ({ page }) => {
+setup("login", async ({ page, appCredentials }) => {
   await page.goto("/")
   await page.waitForURL(/localhost:8443/)
 
   await page
     .getByRole("textbox", { name: "Username or email" })
-    .fill("jane.doe")
+    .fill(appCredentials.username)
 
-  await page.getByRole("textbox", { name: "Password" }).fill("test")
+  await page
+    .getByRole("textbox", { name: "Password" })
+    .fill(appCredentials.password)
 
   await page.getByRole("button", { name: "Sign In" }).click()
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,9 +1,11 @@
-import { devices, PlaywrightTestConfig } from "@playwright/test"
+import { defineConfig, devices } from "@playwright/test"
 import dotenv from "dotenv"
 
 dotenv.config({ path: [".env.local", ".env"] })
 
-const config: PlaywrightTestConfig = {
+const config = defineConfig<{
+  appCredentials: { username: string; password: string }
+}>({
   testDir: "./e2e",
   timeout: 10000,
   retries: process.env.CI === "true" ? 1 : 0,
@@ -85,6 +87,6 @@ const config: PlaywrightTestConfig = {
       testMatch: "e2e/login-and-logout.spec.ts",
     },
   ],
-}
+})
 
 export default config

--- a/local/keycloak/realm.json
+++ b/local/keycloak/realm.json
@@ -3,6 +3,7 @@
   "realm": "ris",
   "revokeRefreshToken": true,
   "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 1800,
   "sslRequired": "none",
   "ssoSessionIdleTimeout": 432000,
   "ssoSessionMaxLifespan": 7776000,

--- a/local/keycloak/realm.json
+++ b/local/keycloak/realm.json
@@ -20,6 +20,7 @@
       "clientId": "ris-norms-local",
       "name": "ris-norms-local",
       "enabled": true,
+      "directAccessGrantsEnabled": true,
       "publicClient": true,
       "rootUrl": "http://localhost:8080",
       "baseUrl": "http://localhost:8080",


### PR DESCRIPTION
Writing the token to a file causes flaky tests, and it might not actually be necessary.

RISDEV-0000