### PR TITLE
Move login/logout tests to same project as other tests

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -196,16 +196,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project:
-          [
-            chromium,
-            firefox,
-            msedge,
-            login-logout-test-chromium,
-            login-logout-test-firefox,
-            login-logout-test-msedge,
-            a11y,
-          ]
+        project: [chromium, firefox, msedge, a11y]
     uses: ./.github/workflows/end-to-end-tests.yml
     with:
       project: ${{ matrix.project }}

--- a/.talismanrc
+++ b/.talismanrc
@@ -9,8 +9,8 @@ scopeconfig:
 fileignoreconfig:
   - filename: frontend/Dockerfile
     checksum: 0db2e063587f46b2150f978f8dd9c5ce3d001fa8b89a1b67904f7a8363a6bd2a
-  - filename: frontend/e2e/login-and-logout.spec.ts
-    checksum: 01f015833d7876edb7e050874a02bc8d6041ecab56a7ef1bec05d3a514a1be63
+  - filename: frontend/e2e/loginAndLogout.spec.ts
+    checksum: e10053aeff79d0b8e22469ccf80a4a95d87775d81d1f28076fef8a8a1338c40d
   - filename: frontend/src/components/controls/RisNavbarSide.spec.ts
     checksum: e252d2546a75459a49ac1c4073dd76a3a48861b64843b11fa8271b675490cfd8
   - filename: frontend/src/main.ts

--- a/frontend/e2e/loginAndLogout.spec.ts
+++ b/frontend/e2e/loginAndLogout.spec.ts
@@ -1,53 +1,61 @@
 import { test } from "@e2e/utils/testWithAuth"
 import { expect } from "@playwright/test"
 
-test.describe("Login / logout functionality", { tag: ["@RISDEV-5654"] }, () => {
-  test("An unauthenticated user gets redirected to the login and then to the page they wanted to visit, after clicking Abmelden they are logged out again", async ({
-    page,
-  }) => {
-    await page.goto(
-      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1",
-    )
+test.use({ storageState: { cookies: [], origins: [] } })
 
-    await expect(
-      page.getByRole("heading", { name: "Sign in to your account" }),
-    ).toBeVisible()
+test.describe(
+  "login and logout functionality",
+  { tag: ["@RISDEV-5654"] },
+  () => {
+    test("An unauthenticated user gets redirected to the login and then to the page they wanted to visit, after clicking Abmelden they are logged out again", async ({
+      page,
+    }) => {
+      await page.goto(
+        "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1",
+      )
 
-    await page
-      .getByRole("textbox", { name: "Username or email" })
-      .fill("jane.doe")
-    await page.getByRole("textbox", { name: "Password" }).fill("test")
-    await page.getByRole("button", { name: "Sign In" }).click()
+      await expect(
+        page.getByRole("heading", { name: "Sign in to your account" }),
+      ).toBeVisible()
 
-    await page.waitForURL(
-      "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1",
-    )
+      await page
+        .getByRole("textbox", { name: "Username or email" })
+        .fill("jane.doe")
+      await page.getByRole("textbox", { name: "Password" }).fill("test")
+      await page.getByRole("button", { name: "Sign In" }).click()
 
-    const logoutLinkAfterLogin = page.getByRole("link", { name: "Abmelden" })
-    await expect(logoutLinkAfterLogin).toBeVisible()
+      await page.waitForURL(
+        "/amending-laws/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-1",
+      )
 
-    const usernameDisplay = page.getByText("Jane Doe")
-    await expect(usernameDisplay).toBeVisible()
+      const logoutLinkAfterLogin = page.getByRole("link", { name: "Abmelden" })
+      await expect(logoutLinkAfterLogin).toBeVisible()
 
-    await logoutLinkAfterLogin.click()
-    await expect(
-      page.getByRole("heading", { name: "Sign in to your account" }),
-    ).toBeVisible()
-  })
+      const usernameDisplay = page.getByText("Jane Doe")
+      await expect(usernameDisplay).toBeVisible()
 
-  test("API requests without authentication are rejected", async ({ page }) => {
-    const response = await page.request.get("/api/v1/announcements")
-    expect(response.status()).toBe(401)
-  })
-
-  test("API requests with invalid authentication are rejected", async ({
-    page,
-  }) => {
-    const response = await page.request.get("/api/v1/announcements", {
-      headers: {
-        Authorization: `Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICItTUNDSVhLSHBhQUlrd3V2dzJYOUlzWlF2N29wa3NUaDJ5dnRzbzUtUmtrIn0.eyJleHAiOjE3MzkyODcyNzMsImlhdCI6MTczOTI4Njk3MywiYXV0aF90aW1lIjoxNzM5Mjg2NDE4LCJqdGkiOiI0NjI3Mjc0MS0xZWQyLTQ0OGUtOTMyOC1jNWFlOWYxNGY0MDEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0Ojg0NDMvcmVhbG1zL3JpcyIsInN1YiI6ImphbmUuZG9lIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoicmlzLW5vcm1zLWxvY2FsIiwic2lkIjoiYmZlZWFiNDgtNDNlMi00YjZlLWI2YzUtMTY1NmZiZTYzMTcxIiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJodHRwOi8vbG9jYWxob3N0OjUxNzMiXSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJuYW1lIjoiSmFuZSBEb2UiLCJncm91cHMiOlsiL05vcm1zIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImphbmUuZG9lIiwiZ2l2ZW5fbmFtZSI6IkphbmUiLCJmYW1pbHlfbmFtZSI6IkRvZSIsImVtYWlsIjoiamFuZS5kb2VAZXhhbXBsZS5jb20ifQ.D_VERSumrkPC6C5WNvSC6VW776tt5q5Cud_LZGqBG1eGLr_kPz8ovCXslIwlwpsXfDO162mAkbXHV2pI3hwIBXJzetg6cghOdxzm6uLgBCwCZ1kBSkMAMRUEzP9MCKSexDPMLxeUn-w9RjNtPx9ZU6wYoFjrGG0W0wLLpQ9NfEWJhqRovs7Na97lD7HuaO0R5m2YcRsTuSopJkbSCFea4Gi2Hwb1ovuerXDDlFBLSQWNvK2Ek_heT8Q0FKhCLija1xti4RKdiIIh8nygN4ldaoOIucdBt9iuA5TNz-R2DkN1dYNvRyTk0YbIBI7dA57JkpOIOnbe7YDkOGGbESXAAQ`,
-      },
+      await logoutLinkAfterLogin.click()
+      await expect(
+        page.getByRole("heading", { name: "Sign in to your account" }),
+      ).toBeVisible()
     })
-    expect(response.status()).toBe(401)
-  })
-})
+
+    test("API requests without authentication are rejected", async ({
+      page,
+    }) => {
+      const response = await page.request.get("/api/v1/announcements")
+      expect(response.status()).toBe(401)
+    })
+
+    test("API requests with invalid authentication are rejected", async ({
+      page,
+    }) => {
+      const response = await page.request.get("/api/v1/announcements", {
+        headers: {
+          Authorization: `Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICItTUNDSVhLSHBhQUlrd3V2dzJYOUlzWlF2N29wa3NUaDJ5dnRzbzUtUmtrIn0.eyJleHAiOjE3MzkyODcyNzMsImlhdCI6MTczOTI4Njk3MywiYXV0aF90aW1lIjoxNzM5Mjg2NDE4LCJqdGkiOiI0NjI3Mjc0MS0xZWQyLTQ0OGUtOTMyOC1jNWFlOWYxNGY0MDEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0Ojg0NDMvcmVhbG1zL3JpcyIsInN1YiI6ImphbmUuZG9lIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoicmlzLW5vcm1zLWxvY2FsIiwic2lkIjoiYmZlZWFiNDgtNDNlMi00YjZlLWI2YzUtMTY1NmZiZTYzMTcxIiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJodHRwOi8vbG9jYWxob3N0OjUxNzMiXSwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJuYW1lIjoiSmFuZSBEb2UiLCJncm91cHMiOlsiL05vcm1zIl0sInByZWZlcnJlZF91c2VybmFtZSI6ImphbmUuZG9lIiwiZ2l2ZW5fbmFtZSI6IkphbmUiLCJmYW1pbHlfbmFtZSI6IkRvZSIsImVtYWlsIjoiamFuZS5kb2VAZXhhbXBsZS5jb20ifQ.D_VERSumrkPC6C5WNvSC6VW776tt5q5Cud_LZGqBG1eGLr_kPz8ovCXslIwlwpsXfDO162mAkbXHV2pI3hwIBXJzetg6cghOdxzm6uLgBCwCZ1kBSkMAMRUEzP9MCKSexDPMLxeUn-w9RjNtPx9ZU6wYoFjrGG0W0wLLpQ9NfEWJhqRovs7Na97lD7HuaO0R5m2YcRsTuSopJkbSCFea4Gi2Hwb1ovuerXDDlFBLSQWNvK2Ek_heT8Q0FKhCLija1xti4RKdiIIh8nygN4ldaoOIucdBt9iuA5TNz-R2DkN1dYNvRyTk0YbIBI7dA57JkpOIOnbe7YDkOGGbESXAAQ`,
+        },
+      })
+      expect(response.status()).toBe(401)
+    })
+  },
+)

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -37,6 +37,7 @@ const config = defineConfig<{
       use: { ...devices["Desktop Edge"], channel: "msedge" },
       testMatch: /.*.setup.ts$/,
     },
+
     {
       name: "chromium",
       use: {
@@ -44,7 +45,6 @@ const config = defineConfig<{
         storageState: "e2e/storage/state.json",
       },
       timeout: 30000,
-      testIgnore: "e2e/loginAndLogout.spec.ts",
       dependencies: ["setup-chromium"],
     },
     {
@@ -54,7 +54,6 @@ const config = defineConfig<{
         storageState: "e2e/storage/state.json",
       },
       timeout: 30000,
-      testIgnore: "e2e/loginAndLogout.spec.ts",
       dependencies: ["setup-firefox"],
     },
     {
@@ -65,7 +64,6 @@ const config = defineConfig<{
         storageState: "e2e/storage/state.json",
       },
       timeout: 30000,
-      testIgnore: "e2e/loginAndLogout.spec.ts",
       dependencies: ["setup-msedge"],
     },
 
@@ -78,24 +76,6 @@ const config = defineConfig<{
         storageState: "e2e/storage/state.json",
       },
       dependencies: ["setup-chromium"],
-    },
-
-    // Login-logout test projects
-    {
-      name: "login-logout-test-chromium",
-      use: { ...devices["Desktop Chrome"] },
-      testMatch: "e2e/loginAndLogout.spec.ts",
-    },
-    {
-      name: "login-logout-test-firefox",
-      use: { ...devices["Desktop Firefox"] },
-      testMatch: "e2e/loginAndLogout.spec.ts",
-    },
-    {
-      name: "login-logout-test-msedge",
-      use: { ...devices["Desktop Edge"], channel: "msedge" },
-      timeout: 30000,
-      testMatch: "e2e/loginAndLogout.spec.ts",
     },
   ],
 })


### PR DESCRIPTION
Instead of running these tests in a separate project, we can simply disable the shared state for these tests. The shared state contains auth-related information, so by disabling it, the login/logout tests are not influenced by any existing sessions created in other tests.

RISDEV-0000