### PR TITLE
Add import timestamp to announcements

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/AnnouncementDto.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/AnnouncementDto.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,4 +32,7 @@ public class AnnouncementDto {
 
   @Column(name = "eli_norm_expression")
   private String eliNormExpression;
+
+  @Column(name = "import_timestamp", updatable = false, insertable = false)
+  private Instant importTimestamp;
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/AnnouncementMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/AnnouncementMapper.java
@@ -20,6 +20,7 @@ public class AnnouncementMapper {
     return Announcement
       .builder()
       .eli(NormExpressionEli.fromString(announcementDto.getEliNormExpression()))
+      .importTimestamp(announcementDto.getImportTimestamp())
       .build();
   }
 
@@ -30,6 +31,10 @@ public class AnnouncementMapper {
    * @return A new {@link AnnouncementDto} mapped from the input {@link Announcement}.
    */
   public static AnnouncementDto mapToDto(final Announcement announcement) {
-    return AnnouncementDto.builder().eliNormExpression(announcement.getEli().toString()).build();
+    return AnnouncementDto
+      .builder()
+      .eliNormExpression(announcement.getEli().toString())
+      .importTimestamp(announcement.getImportTimestamp())
+      .build();
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Announcement.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/Announcement.java
@@ -1,6 +1,7 @@
 package de.bund.digitalservice.ris.norms.domain.entity;
 
 import de.bund.digitalservice.ris.norms.domain.entity.eli.NormExpressionEli;
+import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.experimental.SuperBuilder;
@@ -15,4 +16,6 @@ import lombok.experimental.SuperBuilder;
 public class Announcement {
 
   private NormExpressionEli eli;
+
+  private Instant importTimestamp;
 }

--- a/backend/src/main/resources/db/migration/V0.33__add_timestamp_to_announcements_table.sql
+++ b/backend/src/main/resources/db/migration/V0.33__add_timestamp_to_announcements_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE announcements
+  ADD COLUMN IF NOT EXISTS import_timestamp timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/AnnouncementMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/AnnouncementMapperTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import de.bund.digitalservice.ris.norms.adapter.output.database.dto.AnnouncementDto;
 import de.bund.digitalservice.ris.norms.domain.entity.Announcement;
 import de.bund.digitalservice.ris.norms.domain.entity.eli.NormExpressionEli;
+import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
 class AnnouncementMapperTest {
@@ -15,6 +16,7 @@ class AnnouncementMapperTest {
     var announcementDto = AnnouncementDto
       .builder()
       .eliNormExpression("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu")
+      .importTimestamp(Instant.parse("2025-03-12T12:00:00.0Z"))
       .build();
 
     // When
@@ -23,7 +25,7 @@ class AnnouncementMapperTest {
     // Then
     assertThat(announcement).isNotNull();
     assertThat(announcement.getEli()).hasToString(announcementDto.getEliNormExpression());
-    // TODO: (Malte Laukötter, 2024-10-28) test release mapping
+    assertThat(announcement.getImportTimestamp()).isEqualTo(announcementDto.getImportTimestamp());
   }
 
   @Test
@@ -32,6 +34,7 @@ class AnnouncementMapperTest {
     var announcement = Announcement
       .builder()
       .eli(NormExpressionEli.fromString("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu"))
+      .importTimestamp(Instant.parse("2025-03-12T12:00:00.0Z"))
       .build();
 
     // When
@@ -40,6 +43,6 @@ class AnnouncementMapperTest {
     // Then
     assertThat(announcementDto).isNotNull();
     assertThat(announcementDto.getEliNormExpression()).isEqualTo(announcement.getEli().toString());
-    // TODO: (Malte Laukötter, 2024-10-28) test release mapping
+    assertThat(announcementDto.getImportTimestamp()).isEqualTo(announcement.getImportTimestamp());
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/AnnouncementControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/AnnouncementControllerIntegrationTest.java
@@ -154,7 +154,7 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
         "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu"
       );
       assertThat(announcement.get().getImportTimestamp())
-        .isCloseTo(Instant.now(), new TemporalUnitWithinOffset(1, ChronoUnit.HOURS));
+        .isCloseTo(Instant.now(), new TemporalUnitWithinOffset(5, ChronoUnit.MINUTES));
     }
 
     @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/AnnouncementControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/AnnouncementControllerIntegrationTest.java
@@ -15,7 +15,10 @@ import de.bund.digitalservice.ris.norms.domain.entity.eli.NormExpressionEli;
 import de.bund.digitalservice.ris.norms.integration.BaseIntegrationTest;
 import de.bund.digitalservice.ris.norms.utils.XmlMapper;
 import java.io.ByteArrayInputStream;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
+import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -125,6 +128,33 @@ class AnnouncementControllerIntegrationTest extends BaseIntegrationTest {
         )
       )
         .isPresent();
+    }
+
+    @Test
+    void itStoresTheImportTimestamp() throws Exception {
+      // Given
+      var xmlContent = Fixtures.loadTextFromDisk("NormWithMods.xml");
+      var file = new MockMultipartFile(
+        "file",
+        "norm.xml",
+        "text/xml",
+        new ByteArrayInputStream(xmlContent.getBytes())
+      );
+
+      // When / Then
+      mockMvc
+        .perform(multipart("/api/v1/announcements").file(file).accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(
+          jsonPath("eli", equalTo("eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-1"))
+        );
+
+      // Then
+      var announcement = announcementRepository.findByEliNormExpression(
+        "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu"
+      );
+      assertThat(announcement.get().getImportTimestamp())
+        .isCloseTo(Instant.now(), new TemporalUnitWithinOffset(1, ChronoUnit.HOURS));
     }
 
     @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/DBServiceIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/DBServiceIntegrationTest.java
@@ -25,10 +25,12 @@ import de.bund.digitalservice.ris.norms.integration.BaseIntegrationTest;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -279,6 +281,9 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
       .usingRecursiveComparison()
       .ignoringFields("importTimestamp")
       .isEqualTo(announcement);
+
+    assertThat(announcementOptional.get().getImportTimestamp())
+      .isCloseTo(Instant.now(), new TemporalUnitWithinOffset(5, ChronoUnit.MINUTES));
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/DBServiceIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/DBServiceIntegrationTest.java
@@ -274,7 +274,11 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
     );
 
     // Then
-    assertThat(announcementOptional).isPresent().contains(announcement);
+    assertThat(announcementOptional)
+      .get()
+      .usingRecursiveComparison()
+      .ignoringFields("importTimestamp")
+      .isEqualTo(announcement);
   }
 
   @Test
@@ -302,7 +306,9 @@ class DBServiceIntegrationTest extends BaseIntegrationTest {
     final List<Announcement> announcements = dbService.loadAllAnnouncements();
 
     // Then
-    assertThat(announcements).containsExactly(announcement2, announcement1);
+    assertThat(announcements)
+      .usingRecursiveFieldByFieldElementComparatorIgnoringFields("importTimestamp")
+      .containsExactly(announcement2, announcement1);
   }
 
   @Nested


### PR DESCRIPTION
Implements RISDEV-7047. For now I decided to set the timestamp purely on the DB level, i.e. it is set automatically to the current time when the announcement is created. The application can read it, but it can not set the value on insertion or change it afterwards. This should be all we need and minimizes code/API surface.

Coincidentally also implements RISDEV-7048, but I added an integration test to verify that the timestamp is set correctly.