### PR TITLE
Update publish service

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/PublishService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/PublishService.java
@@ -99,9 +99,6 @@ public class PublishService implements PublishNormUseCase {
       }
     });
 
-    publishPublicChangelogsPort.publishChangelogs(new PublishChangelogPort.Command(false));
-    publishPrivateChangelogsPort.publishChangelogs(new PublishChangelogPort.Command(false));
-
     lastMigrationLog.ifPresent(migrationLog -> {
       if (migrationLogIsRelevant(migrationLog)) {
         log.info(
@@ -126,6 +123,8 @@ public class PublishService implements PublishNormUseCase {
         );
       }
     });
+    publishPublicChangelogsPort.publishChangelogs(new PublishChangelogPort.Command(false));
+    publishPrivateChangelogsPort.publishChangelogs(new PublishChangelogPort.Command(false));
     log.info("Publish job successfully completed.");
   }
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/PublishServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/PublishServiceTest.java
@@ -264,28 +264,24 @@ class PublishServiceTest {
     @Test
     void doNotdeleteAllNormsIfMigrationLogExistsButSizeIsZero() {
       // Given
-      final Norm norm = Fixtures.loadNormFromDisk(
-        "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-1.xml"
-      );
       final MigrationLog migrationLog = MigrationLog
         .builder()
         .size(0)
         .createdAt(Instant.now())
         .build();
 
-      when(
-        loadNormManifestationElisByPublishStatePort.loadNormManifestationElisByPublishState(any())
-      )
-        .thenReturn(List.of(norm.getManifestationEli()));
-      when(loadNormPort.loadNorm(new LoadNormPort.Command(norm.getManifestationEli())))
-        .thenReturn(Optional.of(norm));
       when(loadLastMigrationLogPort.loadLastMigrationLog()).thenReturn(Optional.of(migrationLog)); // Migration log found
 
       // Then When
       assertThatThrownBy(publishService::processQueuedFilesForPublish)
         .isInstanceOf(MigrationJobException.class);
 
-      // Check that deletion was not called
+      // Check that neither loading,nor publish methods nor deletion were called
+      verify(loadNormManifestationElisByPublishStatePort, times(0))
+        .loadNormManifestationElisByPublishState(any());
+      verify(loadNormPort, times(0)).loadNorm(any());
+      verify(publishNormPort, times(0)).publishNorm(any());
+      verify(publishPrivateNormPort, times(0)).publishNorm(any());
       verify(deleteAllPublishedDokumentePort, times(0)).deleteAllPublishedDokumente(any());
       verify(deleteAllPrivateDokumentePort, times(0)).deleteAllPublishedDokumente(any());
     }


### PR DESCRIPTION
I was doing some BPMN to visualize our different jobs (migration, publication, prototype) and realize that the publish service (publication job) had a potential isue:

- The raising of the `MigrationJobException` was being raised too late. The whole logic of checking the migration log was moved to the back in the last development but we forgot this aspect. Now is checked at the beginning (for sure only if the log is "relevant"). Meaning this way we would have the case that we published all new stuff but didn't delete the old stuff.

I then also put the deletion of data in the buckets and setting the migration log to complete to the same `lastMigrationLog.ifPresent()`