### PR TITLE
fix: ignore invalid references when returning Zielnormen

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/AnnouncementService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/AnnouncementService.java
@@ -10,6 +10,7 @@ import de.bund.digitalservice.ris.norms.utils.XmlMapper;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.io.IOUtils;
 import org.springframework.stereotype.Service;
@@ -167,11 +168,8 @@ public class AnnouncementService
 
     return affectedExpressionElis
       .stream()
-      .map(eli ->
-        loadNormPort
-          .loadNorm(new LoadNormPort.Command(eli))
-          .orElseThrow(() -> new NormNotFoundException(eli.toString()))
-      )
+      .map(eli -> loadNormPort.loadNorm(new LoadNormPort.Command(eli)))
+      .flatMap(Optional::stream)
       .toList();
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/AnnouncementServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/AnnouncementServiceTest.java
@@ -506,5 +506,27 @@ class AnnouncementServiceTest {
           )
         );
     }
+
+    @Test
+    void itDoesntReturnNonExistingNorms() {
+      // Given
+      var verkuendungsNorm = Fixtures.loadNormFromDisk(
+        "eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/2022-08-23/regelungstext-1.xml"
+      );
+
+      when(loadNormPort.loadNorm(any()))
+        .thenReturn(Optional.of(verkuendungsNorm))
+        .thenReturn(Optional.empty());
+
+      // When
+      var norms = announcementService.loadNormExpressionsAffectedByVerkuendung(
+        new LoadNormExpressionsAffectedByVerkuendungUseCase.Query(
+          verkuendungsNorm.getExpressionEli()
+        )
+      );
+
+      // Then
+      assertThat(norms).isEmpty();
+    }
   }
 }


### PR DESCRIPTION
The Zielnormen endpoint used to throw a NormNotFoundException, resulting in a 404 response, if any of the Norms referenced by the metadata could not be found. This led to confusing behavior in the frontend. Now, instead of throwing an error, Norms that could not be loaded will simply be ignored.

RISDEV-6941