### PR TITLE
Add custom renovate manager for npm dependencies in build.gradle.kts

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -243,8 +243,8 @@ spotless {
         removeUnusedImports()
         prettier(
             mapOf(
-                "prettier" to "3.5.3",
-                "prettier-plugin-java" to "2.6.7",
+                "prettier" to "3.5.3", // npm dependency
+                "prettier-plugin-java" to "2.6.7", // npm dependency
             ),
         ).config(
             mapOf(
@@ -269,8 +269,8 @@ spotless {
         )
         prettier(
             mapOf(
-                "prettier" to "2.6.1",
-                "prettier-plugin-sh" to "0.7.1",
+                "prettier" to "2.6.1", // npm dependency
+                "prettier-plugin-sh" to "0.7.1", // npm dependency
             ),
         ).config(mapOf("keySeparator" to "="))
     }
@@ -279,8 +279,8 @@ spotless {
         targetExclude("**/gradle-wrapper.properties")
         prettier(
             mapOf(
-                "prettier" to "2.6.1",
-                "prettier-plugin-properties" to "0.1.0",
+                "prettier" to "2.6.1", // npm dependency
+                "prettier-plugin-properties" to "0.1.0", // npm dependency
             ),
         ).config(
             mapOf(

--- a/renovate.json5
+++ b/renovate.json5
@@ -59,5 +59,15 @@
       "platformAutomerge": false, // this would require more repository setup; also it interferes with automergeSchedule
       "automergeType": "pr"
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": "build.gradle.kts",
+      "matchStrings": [
+        "\"(?<depName>^\"+)\" to \"(?<currentValue>[^\"]+)\", // npm dependency"
+      ],
+      "datasourceTemplate": "npm",
+    }
   ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -23,7 +23,7 @@
     },
     {
       "groupName": "all non-major frontend dependencies",
-      "matchPaths": [
+      "matchFileNames": [
         "frontend/**"
       ],
       "matchUpdateTypes": [
@@ -42,7 +42,7 @@
     },
     {
       "groupName": "all non-major backend dependencies",
-      "matchPaths": [
+      "matchFileNames": [
         "backend/**"
       ],
       "matchUpdateTypes": [


### PR DESCRIPTION
Renovate can use this branch to validate the config change: https://docs.renovatebot.com/config-validation/#validation-of-renovate-config-change-prs

RISDEV-0000