### PR TITLE
fix: reset TOC on navigation

### DIFF
--- a/frontend/src/components/RisViewLayout.vue
+++ b/frontend/src/components/RisViewLayout.vue
@@ -7,13 +7,15 @@ import type {
 import RisHeader from "@/components/RisHeader.vue"
 import RisLoadingSpinner from "@/components/RisLoadingSpinner.vue"
 import { use404Redirect } from "@/composables/use404Redirect"
-import { computed } from "vue"
+import { watchDebounced } from "@vueuse/core"
+import { computed, ref } from "vue"
 
 const {
   breadcrumbs = undefined,
   errors = [],
   headerBackDestination = undefined,
   redirectOn404 = true,
+  loading = false,
 } = defineProps<{
   /**
    * Destination of the back button of the header component. A header will be
@@ -60,6 +62,17 @@ const hasHeader = computed(
 const errorToShow = computed(() => errors.find((e) => !!e))
 
 if (redirectOn404) use404Redirect(() => errors)
+
+const debouncedLoading = ref(loading)
+
+watchDebounced(
+  () => loading,
+  (newVal) => {
+    console.log(newVal)
+    debouncedLoading.value = newVal
+  },
+  { debounce: 300 },
+)
 </script>
 
 <template>
@@ -67,7 +80,7 @@ if (redirectOn404) use404Redirect(() => errors)
     class="grid h-[calc(100dvh-5rem)] grid-cols-1 grid-rows-[5rem_1fr] overflow-hidden bg-gray-100 has-[[data-pc-name=splitter]]:bg-white"
   >
     <div
-      v-if="loading"
+      v-if="debouncedLoading"
       class="row-span-2 flex items-center justify-center p-24"
     >
       <RisLoadingSpinner />

--- a/frontend/src/views/verkuendungen/verkuendungDetail/RisZielnormenList.vue
+++ b/frontend/src/views/verkuendungen/verkuendungDetail/RisZielnormenList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import RisHighlightColorSwatch from "@/components/RisHighlightColorSwatch.vue"
+import { formatDate } from "@/lib/dateTime"
 import { NormExpressionEli } from "@/lib/eli/NormExpressionEli"
 import type { Norm } from "@/types/norm"
 import Accordion from "primevue/accordion"
@@ -39,16 +40,6 @@ const { items, verkuendungEli } = defineProps<{
   items: RisZielnormenListItem[]
   verkuendungEli: string
 }>()
-
-function formatDate(dateString: string | undefined): string {
-  return dateString
-    ? new Date(dateString).toLocaleDateString("de-DE", {
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-      })
-    : ""
-}
 
 const mappedItems = computed<MappedRisZielnormenListItem[]>(() =>
   items.map<MappedRisZielnormenListItem>((item) => ({

--- a/frontend/src/views/verkuendungen/verkuendungDetail/expressionenErzeugen/RisZielnormExpressionsTable.vue
+++ b/frontend/src/views/verkuendungen/verkuendungDetail/expressionenErzeugen/RisZielnormExpressionsTable.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import RisHighlightColorSwatch from "@/components/RisHighlightColorSwatch.vue"
+import { formatDate } from "@/lib/dateTime"
 import type { NormExpressionEli } from "@/lib/eli/NormExpressionEli"
 import dayjs from "dayjs"
 import { Badge, Column, DataTable } from "primevue"
@@ -57,19 +58,7 @@ const internalItems = computed(() => {
 })
 
 function formatDateString(dateString: string | undefined): string {
-  return formatDate(dateString ? new Date(dateString) : undefined)
-}
-
-function formatDate(date: Date | undefined): string {
-  if (date === undefined) {
-    return ""
-  }
-
-  return date.toLocaleDateString("de-DE", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  })
+  return dateString ? formatDate(dateString) : ""
 }
 </script>
 

--- a/frontend/src/views/verkuendungen/verkuendungDetail/textkonsolidierung/ExpressionTextkonsolidierungEditor.view.vue
+++ b/frontend/src/views/verkuendungen/verkuendungDetail/textkonsolidierung/ExpressionTextkonsolidierungEditor.view.vue
@@ -403,7 +403,7 @@ const isGegenstandslosExpression = computed(() => {
           <RisLoadingSpinner />
         </div>
         <Message
-          v-if="isGegenstandslosExpression"
+          v-else-if="isGegenstandslosExpression"
           severity="warn"
           class="mb-16"
         >
@@ -415,6 +415,7 @@ const isGegenstandslosExpression = computed(() => {
           class="m-16 mt-8"
         />
         <RisCodeEditor
+          v-else
           ref="codeEditorRef"
           v-model="currentXml"
           class="h-full border-2 border-blue-800"

--- a/frontend/src/views/verkuendungen/verkuendungDetail/textkonsolidierung/ExpressionTextkonsolidierungEditor.view.vue
+++ b/frontend/src/views/verkuendungen/verkuendungDetail/textkonsolidierung/ExpressionTextkonsolidierungEditor.view.vue
@@ -1,43 +1,47 @@
 <script setup lang="ts">
+import RisCodeEditor from "@/components/editor/RisCodeEditor.vue"
+import RisDokumentExplorer from "@/components/RisDokumentExplorer.vue"
 import RisEmptyState from "@/components/RisEmptyState.vue"
 import RisErrorCallout from "@/components/RisErrorCallout.vue"
 import { type HeaderBreadcrumb } from "@/components/RisHeader.vue"
+import RisHighlightColorSwatch from "@/components/RisHighlightColorSwatch.vue"
 import RisLoadingSpinner from "@/components/RisLoadingSpinner.vue"
 import RisViewLayout from "@/components/RisViewLayout.vue"
 import { useDokumentExpressionEliPathParameter } from "@/composables/useDokumentExpressionEliPathParameter"
 import { useElementId } from "@/composables/useElementId"
+import { useNormXml } from "@/composables/useNormXml"
+import { useSentryTraceId } from "@/composables/useSentryTraceId"
+import { useToast } from "@/composables/useToast"
 import { useZeitgrenzenHighlightClasses } from "@/composables/useZeitgrenzenHighlightClasses"
 import {
   useZielnormReferences,
   type EditableZielnormReference,
 } from "@/composables/useZielnormReferences"
+import { NormExpressionEli } from "@/lib/eli/NormExpressionEli"
 import { getFrbrDisplayText } from "@/lib/frbr"
+import { useGetNorm } from "@/services/normService"
+import { useGetNormToc } from "@/services/tocService"
 import {
   useGetVerkuendungService,
   useGetZielnormReferences,
 } from "@/services/verkuendungService"
-import IcBaselineCheck from "~icons/ic/baseline-check"
 import { useGetZeitgrenzen } from "@/services/zeitgrenzenService"
-import { ConfirmDialog, Splitter, SplitterPanel } from "primevue"
-import { computed, ref, watch } from "vue"
-import RisDokumentExplorer from "@/components/RisDokumentExplorer.vue"
-import Button from "primevue/button"
-import Tree from "primevue/tree"
-import { useGetNormToc } from "@/services/tocService"
+import { useGetZielnormPreview } from "@/services/zielnormExpressionsService"
+import { useGroupedZielnormen } from "@/views/verkuendungen/verkuendungDetail/useGroupedZielnormen"
+import {
+  Button,
+  ConfirmDialog,
+  Message,
+  Splitter,
+  SplitterPanel,
+  Tree,
+} from "primevue"
 import type { TreeNode } from "primevue/treenode"
-import { useGetNorm } from "@/services/normService"
-import RisCodeEditor from "@/components/editor/RisCodeEditor.vue"
-import { useNormXml } from "@/composables/useNormXml"
-import { useToast } from "@/composables/useToast"
-import { useSentryTraceId } from "@/composables/useSentryTraceId"
-import RisHighlightColorSwatch from "@/components/RisHighlightColorSwatch.vue"
+import { computed, ref, watch } from "vue"
+import { RouterLink } from "vue-router"
 import IcBaselineArrowBack from "~icons/ic/baseline-arrow-back"
 import IcBaselineArrowForward from "~icons/ic/baseline-arrow-forward"
-import { useGroupedZielnormen } from "@/views/verkuendungen/verkuendungDetail/useGroupedZielnormen"
-import { RouterLink } from "vue-router"
-import { NormExpressionEli } from "@/lib/eli/NormExpressionEli"
-import { useGetZielnormPreview } from "@/services/zielnormExpressionsService"
-import Message from "primevue/message"
+import IcBaselineCheck from "~icons/ic/baseline-check"
 
 const verkuendungEli = useDokumentExpressionEliPathParameter("verkuendung")
 const expressionEli = useDokumentExpressionEliPathParameter("expression")
@@ -96,15 +100,24 @@ const treeNodes = computed<TreeNode[]>(() =>
       }))
     : [],
 )
-const { tocHeadingId, expressionPointInTimeLabelId } = useElementId()
 
+const { tocHeadingId, expressionPointInTimeLabelId } = useElementId()
 const expandedKeys = ref<Record<string, boolean>>({})
 const selectionKeys = ref<Record<string, boolean>>({})
+
+watch(expressionEli, (newVal, oldVal) => {
+  if (newVal !== oldVal) {
+    expandedKeys.value = {}
+    selectionKeys.value = {}
+  }
+})
+
 const handleNodeSelect = (node: TreeNode) => {
   selectionKeys.value = { [node.key]: true }
   toggleNode(node)
   gotoEid(node.key)
 }
+
 function toggleNode(node: TreeNode) {
   expandedKeys.value[node.key] = !expandedKeys.value[node.key]
 }
@@ -133,6 +146,7 @@ const groupedZielnormen = useGroupedZielnormen(zielnormen)
 
 // NAVIGATION
 const currentEli = computed(() => expressionEli.value.toString())
+
 const currentZielnormGroup = computed(() => {
   return groupedZielnormen.value?.find((group) =>
     group.expressions.some((expr) => expr.eli === currentEli.value),
@@ -153,11 +167,14 @@ const sequence = computed(() => {
 })
 
 const currentIndex = computed(() => sequence.value.indexOf(currentEli.value))
+
 const hasPrev = computed(() => currentIndex.value > 0)
+
 const hasNext = computed(
   () =>
     currentIndex.value >= 0 && currentIndex.value < sequence.value.length - 1,
 )
+
 const previousGuid = computed(() => normExpression.value?.vorherigeVersionId)
 const nextGuid = computed(() => normExpression.value?.nachfolgendeVersionId)
 
@@ -169,6 +186,7 @@ const { add: addToast, addError: addErrorToast } = useToast()
 const gotoEid = (eid: string) => {
   codeEditorRef.value?.scrollToText(`eId="${eid}"`)
 }
+
 function showToast() {
   if (saveError.value) {
     addErrorToast(saveError, { traceId: sentryTraceId })
@@ -194,6 +212,7 @@ const {
 } = useNormXml(expressionEli, newExpressionXml)
 
 const currentXml = ref("")
+
 watch(xml, (xml) => {
   if (xml) {
     currentXml.value = xml

--- a/frontend/src/views/verkuendungen/verkuendungDetail/textkonsolidierung/ExpressionTextkonsolidierungEditor.view.vue
+++ b/frontend/src/views/verkuendungen/verkuendungDetail/textkonsolidierung/ExpressionTextkonsolidierungEditor.view.vue
@@ -17,6 +17,7 @@ import {
   useZielnormReferences,
   type EditableZielnormReference,
 } from "@/composables/useZielnormReferences"
+import { formatDate } from "@/lib/dateTime"
 import { NormExpressionEli } from "@/lib/eli/NormExpressionEli"
 import { getFrbrDisplayText } from "@/lib/frbr"
 import { useGetNorm } from "@/services/normService"
@@ -126,16 +127,6 @@ const pointInTime = computed(() => {
   return NormExpressionEli.fromString(expressionEli.value.toString())
     .pointInTime
 })
-
-function formatDate(dateString: string | undefined): string {
-  return dateString
-    ? new Date(dateString).toLocaleDateString("de-DE", {
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-      })
-    : ""
-}
 
 const formattedDate = computed(() => formatDate(pointInTime.value))
 


### PR DESCRIPTION
Just a hotfix until we have properly defined behavior for this case. For now: reset, otherwise the TOC is out of sync with the editor.

RISDEV-0000