### PR TITLE
Add port for finding out if norm exists without loading it

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/repository/NormManifestationRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/repository/NormManifestationRepository.java
@@ -86,4 +86,8 @@ public interface NormManifestationRepository extends JpaRepository<NormManifesta
    * @return  a {@link List} of manifestations
    */
   List<NormManifestationDto> findAllByExpressionEli(final String expressionEli);
+
+  Boolean existsByExpressionEli(String expressionEli);
+
+  Boolean existsByWorkEli(String workEli);
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/CheckNormExistencePort.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/port/output/CheckNormExistencePort.java
@@ -1,0 +1,30 @@
+package de.bund.digitalservice.ris.norms.application.port.output;
+
+import de.bund.digitalservice.ris.norms.domain.entity.Norm;
+import de.bund.digitalservice.ris.norms.domain.entity.eli.NormEli;
+import de.bund.digitalservice.ris.norms.domain.entity.eli.NormExpressionEli;
+import de.bund.digitalservice.ris.norms.domain.entity.eli.NormManifestationEli;
+import de.bund.digitalservice.ris.norms.domain.entity.eli.NormWorkEli;
+
+/**
+ * Interface representing a port for figuring out if a {@link Norm} exists.
+ */
+public interface CheckNormExistencePort {
+  /**
+   * Figures out if a norm based on the provided ELI exists.
+   * For a {@link NormWorkEli} it checks if any expression of that work exists.
+   * For a {@link NormExpressionEli} if any manifestation of that expression exists.
+   * And for a {@link NormManifestationEli} if that specific manifestation exists.
+   *
+   * @param options The options specifying the ELI to identify the norm.
+   * @return True if a norm for that eli exists, or false otherwise.
+   */
+  Boolean checkNormExistence(final Options options);
+
+  /**
+   * A record representing the options for identifying the norm.
+   *
+   * @param eli The ELI (European Legislation Identifier) used to identify the norm.
+   */
+  record Options(NormEli eli) {}
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/EliService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/EliService.java
@@ -1,6 +1,6 @@
 package de.bund.digitalservice.ris.norms.application.service;
 
-import de.bund.digitalservice.ris.norms.application.port.output.LoadNormPort;
+import de.bund.digitalservice.ris.norms.application.port.output.CheckNormExistencePort;
 import de.bund.digitalservice.ris.norms.domain.entity.eli.NormExpressionEli;
 import de.bund.digitalservice.ris.norms.domain.entity.eli.NormWorkEli;
 import java.time.LocalDate;
@@ -12,10 +12,10 @@ import org.springframework.stereotype.Service;
 @Service
 public class EliService {
 
-  private final LoadNormPort loadNormPort;
+  private final CheckNormExistencePort checkNormExistencePort;
 
-  public EliService(LoadNormPort loadNormPort) {
-    this.loadNormPort = loadNormPort;
+  public EliService(CheckNormExistencePort checkNormExistencePort) {
+    this.checkNormExistencePort = checkNormExistencePort;
   }
 
   /**
@@ -35,11 +35,15 @@ public class EliService {
     var expressionEli = NormExpressionEli.fromWorkEli(workEli, pointInTime, 1, language);
 
     for (int i = 0; i < 1000; i++) {
-      if (loadNormPort.loadNorm(new LoadNormPort.Options(expressionEli)).isEmpty()) {
+      if (
+        !checkNormExistencePort.checkNormExistence(
+          new CheckNormExistencePort.Options(expressionEli)
+        )
+      ) {
         return expressionEli;
-      } else {
-        expressionEli.setVersion(expressionEli.getVersion() + 1);
       }
+
+      expressionEli.setVersion(expressionEli.getVersion() + 1);
     }
 
     throw new RuntimeException(

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/EliServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/EliServiceTest.java
@@ -5,21 +5,19 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import de.bund.digitalservice.ris.norms.application.port.output.LoadNormPort;
-import de.bund.digitalservice.ris.norms.domain.entity.Fixtures;
+import de.bund.digitalservice.ris.norms.application.port.output.CheckNormExistencePort;
 import de.bund.digitalservice.ris.norms.domain.entity.eli.NormWorkEli;
 import java.time.LocalDate;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class EliServiceTest {
 
-  private final LoadNormPort loadNormPort = mock(LoadNormPort.class);
-  private final EliService eliService = new EliService(loadNormPort);
+  private final CheckNormExistencePort checkNormExistencePort = mock(CheckNormExistencePort.class);
+  private final EliService eliService = new EliService(checkNormExistencePort);
 
   @Test
   void findNextExpressionEli() {
-    when(loadNormPort.loadNorm(any())).thenReturn(Optional.empty());
+    when(checkNormExistencePort.checkNormExistence(any())).thenReturn(false);
 
     var eli = eliService.findNextExpressionEli(
       NormWorkEli.fromString("eli/bund/bgbl-1/1990/s2954"),
@@ -32,13 +30,7 @@ class EliServiceTest {
 
   @Test
   void findNextExpressionEliVersion1AlreadyInUse() {
-    when(loadNormPort.loadNorm(any()))
-      .thenReturn(
-        Optional.of(
-          Fixtures.loadNormFromDisk("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05")
-        )
-      )
-      .thenReturn(Optional.empty());
+    when(checkNormExistencePort.checkNormExistence(any())).thenReturn(true).thenReturn(false);
 
     var eli = eliService.findNextExpressionEli(
       NormWorkEli.fromString("eli/bund/bgbl-1/1990/s2954"),

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/NormDBServiceIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/NormDBServiceIntegrationTest.java
@@ -249,6 +249,150 @@ class NormDBServiceIntegrationTest extends BaseIntegrationTest {
   }
 
   @Nested
+  class checkNormExistence {
+
+    @Nested
+    class manifestationEli {
+
+      @Test
+      void itReturnsTrueIfExists() {
+        // Given
+        Fixtures.loadAndSaveNormFixture(
+          dokumentRepository,
+          binaryFileRepository,
+          normManifestationRepository,
+          "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05",
+          NormPublishState.UNPUBLISHED
+        );
+
+        // When
+        final var result = normDBService.checkNormExistence(
+          new CheckNormExistencePort.Options(
+            NormManifestationEli.fromString("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05")
+          )
+        );
+
+        // Then
+        assertThat(result).isTrue();
+      }
+
+      @Test
+      void itReturnsFalseIfItDoesNotExist() {
+        // Given
+        Fixtures.loadAndSaveNormFixture(
+          dokumentRepository,
+          binaryFileRepository,
+          normManifestationRepository,
+          "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05",
+          NormPublishState.UNPUBLISHED
+        );
+
+        // When
+        final var result = normDBService.checkNormExistence(
+          new CheckNormExistencePort.Options(
+            NormManifestationEli.fromString("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-06")
+          )
+        );
+
+        // Then
+        assertThat(result).isFalse();
+      }
+    }
+
+    @Nested
+    class expressionEli {
+
+      @Test
+      void itReturnsTrueIfExists() {
+        // Given
+        Fixtures.loadAndSaveNormFixture(
+          dokumentRepository,
+          binaryFileRepository,
+          normManifestationRepository,
+          "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05",
+          NormPublishState.UNPUBLISHED
+        );
+
+        // When
+        final var result = normDBService.checkNormExistence(
+          new CheckNormExistencePort.Options(
+            NormExpressionEli.fromString("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu")
+          )
+        );
+
+        // Then
+        assertThat(result).isTrue();
+      }
+
+      @Test
+      void itReturnsFalseIfItDoesNotExist() {
+        // Given
+        Fixtures.loadAndSaveNormFixture(
+          dokumentRepository,
+          binaryFileRepository,
+          normManifestationRepository,
+          "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05",
+          NormPublishState.UNPUBLISHED
+        );
+
+        // When
+        final var result = normDBService.checkNormExistence(
+          new CheckNormExistencePort.Options(
+            NormExpressionEli.fromString("eli/bund/bgbl-1/1964/s593/1964-08-05/2/deu")
+          )
+        );
+
+        // Then
+        assertThat(result).isFalse();
+      }
+    }
+
+    @Nested
+    class workEli {
+
+      @Test
+      void itReturnsTrueIfExists() {
+        // Given
+        Fixtures.loadAndSaveNormFixture(
+          dokumentRepository,
+          binaryFileRepository,
+          normManifestationRepository,
+          "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05",
+          NormPublishState.UNPUBLISHED
+        );
+
+        // When
+        final var result = normDBService.checkNormExistence(
+          new CheckNormExistencePort.Options(NormWorkEli.fromString("eli/bund/bgbl-1/1964/s593"))
+        );
+
+        // Then
+        assertThat(result).isTrue();
+      }
+
+      @Test
+      void itReturnsFalseIfItDoesNotExist() {
+        // Given
+        Fixtures.loadAndSaveNormFixture(
+          dokumentRepository,
+          binaryFileRepository,
+          normManifestationRepository,
+          "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05",
+          NormPublishState.UNPUBLISHED
+        );
+
+        // When
+        final var result = normDBService.checkNormExistence(
+          new CheckNormExistencePort.Options(NormWorkEli.fromString("eli/bund/bgbl-1/1964/s595"))
+        );
+
+        // Then
+        assertThat(result).isFalse();
+      }
+    }
+  }
+
+  @Nested
   class updateNorm {
 
     @Test


### PR DESCRIPTION
This hopefully reduces the db-requests for loading the list for expressionen-erzeugen quite a bit. (Especially as we do not need to load the Dokumente and Binary Files for this step)

RISDEV-0000