### PR TITLE
Simplify EliService::findNextExpressionEli

### DIFF
--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/EliServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/EliServiceTest.java
@@ -5,21 +5,25 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import de.bund.digitalservice.ris.norms.application.port.output.LoadNormPort;
-import de.bund.digitalservice.ris.norms.domain.entity.Fixtures;
+import de.bund.digitalservice.ris.norms.application.port.output.LoadNormExpressionElisPort;
+import de.bund.digitalservice.ris.norms.domain.entity.eli.NormExpressionEli;
 import de.bund.digitalservice.ris.norms.domain.entity.eli.NormWorkEli;
 import java.time.LocalDate;
-import java.util.Optional;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class EliServiceTest {
 
-  private final LoadNormPort loadNormPort = mock(LoadNormPort.class);
-  private final EliService eliService = new EliService(loadNormPort);
+  private final LoadNormExpressionElisPort loadNormExpressionElisPort = mock(
+    LoadNormExpressionElisPort.class
+  );
+  private final EliService eliService = new EliService(loadNormExpressionElisPort);
 
   @Test
   void findNextExpressionEli() {
-    when(loadNormPort.loadNorm(any())).thenReturn(Optional.empty());
+    when(loadNormExpressionElisPort.loadNormExpressionElis(any())).thenReturn(
+      List.of(NormExpressionEli.fromString("eli/bund/bgbl-1/1964/s593/1900-08-05/1/deu"))
+    );
 
     var eli = eliService.findNextExpressionEli(
       NormWorkEli.fromString("eli/bund/bgbl-1/1990/s2954"),
@@ -31,14 +35,13 @@ class EliServiceTest {
   }
 
   @Test
-  void findNextExpressionEliVersion1AlreadyInUse() {
-    when(loadNormPort.loadNorm(any()))
-      .thenReturn(
-        Optional.of(
-          Fixtures.loadNormFromDisk("eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05")
-        )
+  void findNextExpressionEliVersionIfOneIsAlreadyInUse() {
+    when(loadNormExpressionElisPort.loadNormExpressionElis(any())).thenReturn(
+      List.of(
+        NormExpressionEli.fromString("eli/bund/bgbl-1/1964/s593/1900-08-05/1/deu"),
+        NormExpressionEli.fromString("eli/bund/bgbl-1/1964/s593/2025-01-01/4/deu")
       )
-      .thenReturn(Optional.empty());
+    );
 
     var eli = eliService.findNextExpressionEli(
       NormWorkEli.fromString("eli/bund/bgbl-1/1990/s2954"),
@@ -46,6 +49,6 @@ class EliServiceTest {
       "deu"
     );
 
-    assertThat(eli).hasToString("eli/bund/bgbl-1/1990/s2954/2025-01-01/2/deu");
+    assertThat(eli).hasToString("eli/bund/bgbl-1/1990/s2954/2025-01-01/5/deu");
   }
 }


### PR DESCRIPTION
Instead of searching for a free eli we load the existing elis and calculate the next free one from that.
This hopefully reduces the db-requests for loading the list for expressionen-erzeugen quite a bit. (Especially as we do not need to load the Dokumente and Binary Files for this step)

RISDEV-0000