### PR TITLE
fix: constrain body scrolling for splitter components

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -69,6 +69,10 @@
 }
 
 @layer base {
+  body:has([data-pc-name="splitter"]) {
+    overflow: hidden;
+  }
+
   body {
     background: var(--color-gray-100);
   }


### PR DESCRIPTION
- Add overflow: hidden to body when splitter is present

RISDEV-7941