### PR TITLE
chore: pinned dependencies because of CVEs removed

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -71,7 +71,6 @@ dependencies {
     implementation(libs.saxon.he)
     implementation(libs.bouncycastle.bcprov)
     implementation(libs.bouncycastle.bcpkix)
-    implementation(libs.google.protobuf.java)
     implementation(platform(libs.aws.bom))
     implementation(libs.aws.s3)
     implementation(libs.squareup.okio.jvm)

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -16,8 +16,6 @@ bouncycastle-bcprov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref 
 errorprone = "com.google.errorprone:error_prone_core:2.38.0"
 flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
 flyway-postgres = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }
-# CVE-2024-7254
-google-protobuf-java = "com.google.protobuf:protobuf-java:4.31.1"
 jobrunr = "org.jobrunr:jobrunr-spring-boot-3-starter:7.5.2"
 # CVE-2023-51775
 jose4j = "org.bitbucket.b_c:jose4j:0.9.6"


### PR DESCRIPTION
This PR removes pinned dependencies that are no longer needed because their associated CVEs were resolved.