### PR TITLE
Add column for size of migrated binary files

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/MigrationLogDto.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/dto/MigrationLogDto.java
@@ -30,8 +30,11 @@ public class MigrationLogDto {
   @GeneratedValue
   private UUID id;
 
-  @Column(name = "size", nullable = false)
-  private Integer size;
+  @Column(name = "xml_size", nullable = false)
+  private Integer xmlSize;
+
+  @Column(name = "binary_size", nullable = false)
+  private Integer binarySize;
 
   @Column(name = "created_at", nullable = false)
   private Instant createdAt;

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/MigrationLogMapper.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/MigrationLogMapper.java
@@ -20,7 +20,8 @@ public class MigrationLogMapper {
   public static MigrationLog mapToDomain(final MigrationLogDto migrationLogDto) {
     return MigrationLog.builder()
       .id(migrationLogDto.getId())
-      .size(migrationLogDto.getSize())
+      .xmlSize(migrationLogDto.getXmlSize())
+      .binarySize(migrationLogDto.getBinarySize())
       .createdAt(migrationLogDto.getCreatedAt())
       .completed(migrationLogDto.isCompleted())
       .build();
@@ -36,7 +37,8 @@ public class MigrationLogMapper {
     return MigrationLogDto.builder()
       .id(migrationLog.getId())
       .createdAt(migrationLog.getCreatedAt())
-      .size(migrationLog.getSize())
+      .xmlSize(migrationLog.getXmlSize())
+      .binarySize(migrationLog.getBinarySize())
       .completed(migrationLog.isCompleted())
       .build();
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/PublishService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/PublishService.java
@@ -81,7 +81,7 @@ public class PublishService implements PublishNormUseCase {
       .loadLastMigrationLog()
       .filter(migrationLog -> !migrationLog.isCompleted());
     lastMigrationLog.ifPresent(log -> {
-      if (migrationLogIsRelevant(log) && log.getSize() <= 0) {
+      if (migrationLogIsRelevant(log) && log.getXmlSize() <= 0) {
         throw new MigrationJobException();
       }
     });
@@ -107,7 +107,7 @@ public class PublishService implements PublishNormUseCase {
         log.info(
           "Migration log found with timestamp {} (UTC) and {} dokumente.",
           formatMigrationLogTimestamp(migrationLog.getCreatedAt()),
-          migrationLog.getSize()
+          migrationLog.getXmlSize()
         );
         log.info("Deleting all old dokumente in both buckets");
         deleteAllPublishedDokumentePort.deleteAllPublishedDokumente(

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/MigrationLog.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/MigrationLog.java
@@ -16,7 +16,9 @@ public class MigrationLog {
 
   private UUID id;
 
-  private Integer size;
+  private Integer xmlSize;
+
+  private Integer binarySize;
 
   private Instant createdAt;
 

--- a/backend/src/main/resources/db/migration/V0.40__alter_table_migration_log_new_column_binary_size.sql
+++ b/backend/src/main/resources/db/migration/V0.40__alter_table_migration_log_new_column_binary_size.sql
@@ -1,0 +1,5 @@
+-- New column for counting also binary files migrated
+ALTER TABLE migration_log ADD COLUMN binary_size INT NOT NULL DEFAULT 0;
+
+-- Also rename the old `size` column
+ALTER TABLE migration_log RENAME COLUMN size TO xml_size;

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/MigrationLogMapperTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/output/database/mapper/MigrationLogMapperTest.java
@@ -15,7 +15,8 @@ class MigrationLogMapperTest {
     // Given
     var dtoObj = MigrationLogDto.builder()
       .id(UUID.randomUUID())
-      .size(5)
+      .xmlSize(5)
+      .binarySize(11)
       .createdAt(Instant.parse("2025-03-03T15:00:00.0Z"))
       .completed(false)
       .build();
@@ -25,7 +26,8 @@ class MigrationLogMapperTest {
 
     // Then
     assertThat(domainObj.getId()).isEqualTo(dtoObj.getId());
-    assertThat(domainObj.getSize()).isEqualTo(dtoObj.getSize());
+    assertThat(domainObj.getXmlSize()).isEqualTo(dtoObj.getXmlSize());
+    assertThat(domainObj.getBinarySize()).isEqualTo(dtoObj.getBinarySize());
     assertThat(domainObj.getCreatedAt()).isEqualTo(dtoObj.getCreatedAt());
     assertThat(domainObj.isCompleted()).isEqualTo(dtoObj.isCompleted());
   }
@@ -35,7 +37,8 @@ class MigrationLogMapperTest {
     // Given
     var domainObj = MigrationLog.builder()
       .id(UUID.randomUUID())
-      .size(5)
+      .xmlSize(5)
+      .binarySize(11)
       .createdAt(Instant.parse("2025-03-03T15:00:00.0Z"))
       .completed(false)
       .build();
@@ -45,7 +48,8 @@ class MigrationLogMapperTest {
 
     // Then
     assertThat(dtoObj.getId()).isEqualTo(domainObj.getId());
-    assertThat(dtoObj.getSize()).isEqualTo(domainObj.getSize());
+    assertThat(dtoObj.getXmlSize()).isEqualTo(domainObj.getXmlSize());
+    assertThat(dtoObj.getBinarySize()).isEqualTo(domainObj.getBinarySize());
     assertThat(dtoObj.getCreatedAt()).isEqualTo(domainObj.getCreatedAt());
     assertThat(dtoObj.isCompleted()).isEqualTo(domainObj.isCompleted());
   }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/PublishServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/PublishServiceTest.java
@@ -129,7 +129,7 @@ class PublishServiceTest {
         Set.of()
       );
       final MigrationLog migrationLog = MigrationLog.builder()
-        .size(5)
+        .xmlSize(5)
         .createdAt(Instant.now())
         .completed(false)
         .build();
@@ -245,7 +245,7 @@ class PublishServiceTest {
         "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05"
       );
       final MigrationLog migrationLog = MigrationLog.builder()
-        .size(5)
+        .xmlSize(5)
         .createdAt(Instant.now())
         .completed(false)
         .build();
@@ -293,7 +293,7 @@ class PublishServiceTest {
     void doNotdeleteAllNormsIfMigrationLogExistsButSizeIsZero() {
       // Given
       final MigrationLog migrationLog = MigrationLog.builder()
-        .size(0)
+        .xmlSize(0)
         .createdAt(Instant.now())
         .build();
 
@@ -365,7 +365,7 @@ class PublishServiceTest {
         "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05"
       );
       final MigrationLog migrationLog = MigrationLog.builder()
-        .size(5)
+        .xmlSize(5)
         .createdAt(Instant.now())
         .completed(true)
         .build();
@@ -412,7 +412,7 @@ class PublishServiceTest {
         "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05"
       );
       final MigrationLog migrationLog = MigrationLog.builder()
-        .size(5)
+        .xmlSize(5)
         .createdAt(Instant.parse("2007-12-03T10:15:30.00Z"))
         .completed(false)
         .build();

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/MigrationLogDBServiceIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/output/database/MigrationLogDBServiceIntegrationTest.java
@@ -40,14 +40,16 @@ class MigrationLogDBServiceIntegrationTest extends BaseIntegrationTest {
       var date1 = LocalDate.parse("2024-11-06");
       var migrationLog1 = MigrationLog.builder()
         .createdAt(date1.atStartOfDay().toInstant(ZoneOffset.UTC))
-        .size(5)
+        .xmlSize(5)
+        .binarySize(11)
         .completed(false)
         .build();
 
       var date2 = LocalDate.parse("2024-11-05");
       var migrationLog2 = MigrationLog.builder()
         .createdAt(date2.atStartOfDay().toInstant(ZoneOffset.UTC))
-        .size(5)
+        .xmlSize(5)
+        .binarySize(11)
         .completed(false)
         .build();
 
@@ -72,13 +74,15 @@ class MigrationLogDBServiceIntegrationTest extends BaseIntegrationTest {
       var date1 = LocalDate.parse("2024-11-06");
       var migrationLog1 = MigrationLog.builder()
         .createdAt(date1.atTime(9, 30).toInstant(ZoneOffset.UTC))
-        .size(5)
+        .xmlSize(5)
+        .binarySize(11)
         .completed(false)
         .build();
 
       var migrationLog2 = MigrationLog.builder()
         .createdAt(date1.atTime(11, 45).toInstant(ZoneOffset.UTC))
-        .size(12)
+        .xmlSize(12)
+        .binarySize(35)
         .completed(false)
         .build();
 
@@ -106,7 +110,8 @@ class MigrationLogDBServiceIntegrationTest extends BaseIntegrationTest {
       // Given
       var savedMigrationLog = migrationLogRepository.save(
         MigrationLogDto.builder()
-          .size(5)
+          .xmlSize(5)
+          .binarySize(11)
           .createdAt(Instant.parse("2025-03-03T15:00:00.0Z"))
           .completed(false)
           .build()


### PR DESCRIPTION
Extending migration_log table to also contain the size of the migrated binary files