### PR TITLE
feat: add XML formatting advice and integration tests

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/formatter/XmlFormattingResponseBodyAdvice.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/formatter/XmlFormattingResponseBodyAdvice.java
@@ -62,7 +62,6 @@ public class XmlFormattingResponseBodyAdvice implements ResponseBodyAdvice<Objec
       LSSerializer serializer = impl.createLSSerializer();
 
       serializer.getDomConfig().setParameter("format-pretty-print", Boolean.TRUE);
-      serializer.getDomConfig().setParameter("xml-declaration", Boolean.TRUE);
 
       LSOutput lsOutput = impl.createLSOutput();
       StringWriter writer = new StringWriter();

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/formatter/XmlFormattingResponseBodyAdvice.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/formatter/XmlFormattingResponseBodyAdvice.java
@@ -30,7 +30,7 @@ public class XmlFormattingResponseBodyAdvice implements ResponseBodyAdvice<Objec
     MethodParameter returnType,
     Class<? extends HttpMessageConverter<?>> converterType
   ) {
-    return returnType.getParameterType() == String.class;
+    return true;
   }
 
   @Nullable

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/formatter/XmlFormattingResponseBodyAdvice.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/formatter/XmlFormattingResponseBodyAdvice.java
@@ -1,0 +1,80 @@
+package de.bund.digitalservice.ris.norms.adapter.input.restapi.formatter;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+import org.w3c.dom.Document;
+import org.w3c.dom.ls.DOMImplementationLS;
+import org.w3c.dom.ls.LSOutput;
+import org.w3c.dom.ls.LSSerializer;
+import org.xml.sax.InputSource;
+
+/**
+ * ResponseBodyAdvice that formats XML responses
+ */
+@ControllerAdvice
+public class XmlFormattingResponseBodyAdvice implements ResponseBodyAdvice<Object> {
+
+  @Override
+  public boolean supports(
+    MethodParameter returnType,
+    Class<? extends HttpMessageConverter<?>> converterType
+  ) {
+    return true;
+  }
+
+  @Override
+  public Object beforeBodyWrite(
+    Object body,
+    MethodParameter returnType,
+    MediaType selectedContentType,
+    Class<? extends HttpMessageConverter<?>> selectedConverterType,
+    ServerHttpRequest request,
+    ServerHttpResponse response
+  ) {
+    if (
+      selectedContentType != null &&
+      selectedContentType.isCompatibleWith(MediaType.APPLICATION_XML) &&
+      body instanceof String xmlBody
+    ) {
+      return formatXml(xmlBody);
+    }
+    return body;
+  }
+
+  private String formatXml(String xml) {
+    try {
+      DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+      dbf.setNamespaceAware(true);
+      dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      dbf.setExpandEntityReferences(false);
+      Document document = dbf.newDocumentBuilder().parse(new InputSource(new StringReader(xml)));
+
+      DOMImplementationLS impl = (DOMImplementationLS) document
+        .getImplementation()
+        .getFeature("LS", "3.0");
+      LSSerializer serializer = impl.createLSSerializer();
+
+      serializer.getDomConfig().setParameter("format-pretty-print", Boolean.TRUE);
+      serializer.getDomConfig().setParameter("xml-declaration", Boolean.FALSE);
+
+      LSOutput lsOutput = impl.createLSOutput();
+      StringWriter writer = new StringWriter();
+      lsOutput.setCharacterStream(writer);
+
+      serializer.write(document, lsOutput);
+      return writer.toString();
+    } catch (Exception e) {
+      return xml;
+    }
+  }
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/formatter/XmlFormattingResponseBodyAdvice.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/formatter/XmlFormattingResponseBodyAdvice.java
@@ -62,7 +62,7 @@ public class XmlFormattingResponseBodyAdvice implements ResponseBodyAdvice<Objec
       LSSerializer serializer = impl.createLSSerializer();
 
       serializer.getDomConfig().setParameter("format-pretty-print", Boolean.TRUE);
-      serializer.getDomConfig().setParameter("xml-declaration", Boolean.FALSE);
+      serializer.getDomConfig().setParameter("xml-declaration", Boolean.TRUE);
 
       LSOutput lsOutput = impl.createLSOutput();
       StringWriter writer = new StringWriter();

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/NormExpressionControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/NormExpressionControllerTest.java
@@ -126,7 +126,7 @@ class NormExpressionControllerTest {
     void itCallsLoadNormXmlAndReturnsNormXml() throws Exception {
       // Given
       final String eli = "eli/bund/bgbl-1/1990/s2954/2022-12-19/1/deu/regelungstext-verkuendung-1";
-      final String xml = "<target></target>";
+      final String xml = "</target>";
 
       // When
       when(loadRegelungstextXmlUseCase.loadRegelungstextXml(any())).thenReturn(xml);

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/formatter/XmlFormattingResponseBodyAdviceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/formatter/XmlFormattingResponseBodyAdviceTest.java
@@ -1,9 +1,14 @@
 package de.bund.digitalservice.ris.norms.adapter.input.restapi.formatter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
 
 class XmlFormattingResponseBodyAdviceTest {
 
@@ -14,13 +19,17 @@ class XmlFormattingResponseBodyAdviceTest {
     String compactXml =
       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><akn:doc><akn:meta><akn:identification><akn:FRBRWork><akn:FRBRthis value=\"test\"/></akn:FRBRWork></akn:identification></akn:meta><akn:body><akn:article eId=\"art-1\"><akn:heading>Test</akn:heading></akn:article></akn:body></akn:doc>";
 
-    var result = xmlFormatter.beforeBodyWrite(
+    Class<? extends HttpMessageConverter<?>> dummyConverterType = StringHttpMessageConverter.class;
+    ServerHttpRequest dummyRequest = mock(ServerHttpRequest.class);
+    ServerHttpResponse dummyResponse = mock(ServerHttpResponse.class);
+
+    Object result = xmlFormatter.beforeBodyWrite(
       compactXml,
       null,
       MediaType.APPLICATION_XML,
-      null,
-      null,
-      null
+      dummyConverterType,
+      dummyRequest,
+      dummyResponse
     );
 
     assertThat((String) result).isEqualToIgnoringWhitespace(
@@ -48,13 +57,17 @@ class XmlFormattingResponseBodyAdviceTest {
   void shouldReturnOriginalWhenXmlIsInvalid() {
     String invalidXml = "<akn:doc><invalid xml"; // malformed
 
-    var result = xmlFormatter.beforeBodyWrite(
+    Class<? extends HttpMessageConverter<?>> dummyConverterType = StringHttpMessageConverter.class;
+    ServerHttpRequest dummyRequest = mock(ServerHttpRequest.class);
+    ServerHttpResponse dummyResponse = mock(ServerHttpResponse.class);
+
+    Object result = xmlFormatter.beforeBodyWrite(
       invalidXml,
       null,
       MediaType.APPLICATION_XML,
-      null,
-      null,
-      null
+      dummyConverterType,
+      dummyRequest,
+      dummyResponse
     );
 
     assertThat(result).isEqualTo(invalidXml);

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/formatter/XmlFormattingResponseBodyAdviceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/formatter/XmlFormattingResponseBodyAdviceTest.java
@@ -1,0 +1,62 @@
+package de.bund.digitalservice.ris.norms.adapter.input.restapi.formatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+class XmlFormattingResponseBodyAdviceTest {
+
+  final XmlFormattingResponseBodyAdvice xmlFormatter = new XmlFormattingResponseBodyAdvice();
+
+  @Test
+  void shouldReturnTransformedXml() {
+    String compactXml =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?><akn:doc><akn:meta><akn:identification><akn:FRBRWork><akn:FRBRthis value=\"test\"/></akn:FRBRWork></akn:identification></akn:meta><akn:body><akn:article eId=\"art-1\"><akn:heading>Test</akn:heading></akn:article></akn:body></akn:doc>";
+
+    var result = xmlFormatter.beforeBodyWrite(
+      compactXml,
+      null,
+      MediaType.APPLICATION_XML,
+      null,
+      null,
+      null
+    );
+
+    assertThat((String) result).isEqualToIgnoringWhitespace(
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <akn:doc>
+        <akn:meta>
+          <akn:identification>
+            <akn:FRBRWork>
+              <akn:FRBRthis value="test"/>
+            </akn:FRBRWork>
+          </akn:identification>
+        </akn:meta>
+        <akn:body>
+          <akn:article eId="art-1">
+            <akn:heading>Test</akn:heading>
+          </akn:article>
+        </akn:body>
+      </akn:doc>
+      """
+    );
+  }
+
+  @Test
+  void shouldReturnOriginalWhenXmlIsInvalid() {
+    String invalidXml = "<akn:doc><invalid xml"; // malformed
+
+    var result = xmlFormatter.beforeBodyWrite(
+      invalidXml,
+      null,
+      MediaType.APPLICATION_XML,
+      null,
+      null,
+      null
+    );
+
+    assertThat(result).isEqualTo(invalidXml);
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/XmlFormattingResponseBodyAdviceIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/XmlFormattingResponseBodyAdviceIntegrationTest.java
@@ -1,0 +1,78 @@
+package de.bund.digitalservice.ris.norms.integration.adapter.input.restapi;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import de.bund.digitalservice.ris.norms.adapter.output.database.dto.DokumentDto;
+import de.bund.digitalservice.ris.norms.adapter.output.database.repository.BinaryFileRepository;
+import de.bund.digitalservice.ris.norms.adapter.output.database.repository.DokumentRepository;
+import de.bund.digitalservice.ris.norms.adapter.output.database.repository.NormManifestationRepository;
+import de.bund.digitalservice.ris.norms.domain.entity.Fixtures;
+import de.bund.digitalservice.ris.norms.domain.entity.NormPublishState;
+import de.bund.digitalservice.ris.norms.domain.entity.Roles;
+import de.bund.digitalservice.ris.norms.integration.BaseIntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WithMockUser(roles = { Roles.NORMS_USER })
+class XmlFormattingIntegrationTest extends BaseIntegrationTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private DokumentRepository dokumentRepository;
+
+  @Autowired
+  private NormManifestationRepository normManifestationRepository;
+
+  @Autowired
+  private BinaryFileRepository binaryFileRepository;
+
+  @AfterEach
+  void cleanUp() {
+    dokumentRepository.deleteAll();
+    binaryFileRepository.deleteAll();
+    normManifestationRepository.deleteAll();
+  }
+
+  @Test
+  void itReturnsPrettyPrintedXmlEvenIfStoredUgly() throws Exception {
+    Fixtures.loadAndSaveNormFixture(
+      dokumentRepository,
+      binaryFileRepository,
+      normManifestationRepository,
+      "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05",
+      NormPublishState.UNPUBLISHED
+    );
+
+    String prettyXml = Fixtures.loadTextFromDisk(
+      "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-verkuendung-1.xml"
+    );
+
+    String uglyXml = prettyXml.replaceAll(">\\s+<", "><").replaceAll("\\r?\\n", "");
+
+    String manifestationEli =
+      "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-verkuendung-1.xml";
+    DokumentDto dokument = dokumentRepository
+      .findByEliDokumentManifestation(manifestationEli)
+      .orElseThrow();
+    dokument.setXml(uglyXml);
+    dokumentRepository.save(dokument);
+
+    mockMvc
+      .perform(
+        get(
+          "/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-verkuendung-1"
+        ).accept(MediaType.APPLICATION_XML)
+      )
+      .andExpect(status().isOk())
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/XmlFormattingResponseBodyAdviceIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/XmlFormattingResponseBodyAdviceIntegrationTest.java
@@ -45,29 +45,20 @@ class XmlFormattingIntegrationTest extends BaseIntegrationTest {
   @Test
   void itReturnsPrettyPrintedXmlEvenIfStoredUgly() throws Exception {
     Regelungstext originalText = Fixtures.loadRegelungstextFromDisk(
-      "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-verkuendung-1.xml"
+      "eli/bund/bgbl-1/2021/s818/2021-04-16/1/deu/2021-04-16/regelungstext-verkuendung-1.xml"
     );
     DokumentDto dto = DokumentMapper.mapToDto(originalText);
-    dokumentRepository.save(dto);
 
-    String formattedXml = mockMvc
-      .perform(
-        get(
-          "/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-verkuendung-1"
-        ).accept(MediaType.APPLICATION_XML)
-      )
-      .andExpect(status().isOk())
-      .andReturn()
-      .getResponse()
-      .getContentAsString();
+    String expectedPrettyXml = dto.getXml();
 
-    dto.setXml(formattedXml.replaceAll(">\\s+<", "><").replaceAll("\\r?\\n", ""));
+    dto.setXml(dto.getXml().replaceAll(">\\s+<", "><").replaceAll("\\r?\\n", ""));
+
     dokumentRepository.save(dto);
 
     String response = mockMvc
       .perform(
         get(
-          "/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-verkuendung-1"
+          "/api/v1/norms/eli/bund/bgbl-1/2021/s818/2021-04-16/1/deu/regelungstext-verkuendung-1"
         ).accept(MediaType.APPLICATION_XML)
       )
       .andExpect(status().isOk())
@@ -75,6 +66,6 @@ class XmlFormattingIntegrationTest extends BaseIntegrationTest {
       .getResponse()
       .getContentAsString();
 
-    assertThat(response).isEqualToIgnoringWhitespace(formattedXml);
+    assertThat(response).isEqualToIgnoringWhitespace(expectedPrettyXml);
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/XmlFormattingResponseBodyAdviceIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/XmlFormattingResponseBodyAdviceIntegrationTest.java
@@ -44,22 +44,16 @@ class XmlFormattingIntegrationTest extends BaseIntegrationTest {
 
   @Test
   void itReturnsPrettyPrintedXmlEvenIfStoredUgly() throws Exception {
-    String prettyXml = Fixtures.loadTextFromDisk(
-      "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-verkuendung-1.xml"
-    );
-
     Regelungstext originalText = Fixtures.loadRegelungstextFromDisk(
       "eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-verkuendung-1.xml"
     );
     DokumentDto dto = DokumentMapper.mapToDto(originalText);
-    dto.setXml(dto.getXml().replaceAll(">\\s+<", "><").replaceAll("\\r?\\n", ""));
-
     dokumentRepository.save(dto);
 
-    String response = mockMvc
+    String formattedXml = mockMvc
       .perform(
         get(
-          "/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/1964-08-05/regelungstext-verkuendung-1"
+          "/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-verkuendung-1"
         ).accept(MediaType.APPLICATION_XML)
       )
       .andExpect(status().isOk())
@@ -67,6 +61,20 @@ class XmlFormattingIntegrationTest extends BaseIntegrationTest {
       .getResponse()
       .getContentAsString();
 
-    assertThat(response).isEqualToIgnoringWhitespace(prettyXml);
+    dto.setXml(formattedXml.replaceAll(">\\s+<", "><").replaceAll("\\r?\\n", ""));
+    dokumentRepository.save(dto);
+
+    String response = mockMvc
+      .perform(
+        get(
+          "/api/v1/norms/eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-verkuendung-1"
+        ).accept(MediaType.APPLICATION_XML)
+      )
+      .andExpect(status().isOk())
+      .andReturn()
+      .getResponse()
+      .getContentAsString();
+
+    assertThat(response).isEqualToIgnoringWhitespace(formattedXml);
   }
 }

--- a/frontend/e2e/application/references.spec.ts
+++ b/frontend/e2e/application/references.spec.ts
@@ -23,18 +23,18 @@ test("should be able to add a new ref and edit it's refersTo and href and delete
     .getByRole("region", { name: "Textbasierte Metadaten" })
     .getByRole("textbox")
 
-  const textElement = container.getByText(/Zur Unterstützung der/)
+  const textElement = container.getByText(/Nach Ablauf der/)
 
   await container.focus()
-  await selectText(textElement, "Unterstützung der")
+  await selectText(textElement, "Übergangsphase")
   await container.blur()
 
   const newRefRegion = page.getByRole("region", {
-    name: "Unterstützung der",
+    name: "Übergangsphase",
     exact: true,
   })
   await expect(page).toHaveURL(
-    "/app/amending-laws/eli/bund/bgbl-1/1002/2/1002-01-10/1/deu/regelungstext-verkuendung-1/references/art-z%253e1_abs-z_untergl-n1_listenelem-n5_untergl-n1_listenelem-n1_inhalt-n1_text-n1_%C3%A4ndbefehl-n1_quotstruct-n1_abs-z2_inhalt-n1_text-n1_ref-1",
+    "/app/amending-laws/eli/bund/bgbl-1/1002/2/1002-01-10/1/deu/regelungstext-verkuendung-1/references/art-z%253e1_abs-z_untergl-n1_listenelem-n5_untergl-n1_listenelem-n1_inhalt-n1_text-n1_ändbefehl-n1_quotstruct-n1_abs-z3_inhalt-n1_text-n1_ref-1",
   )
 
   const combobox = newRefRegion.getByRole("combobox", { name: "Typ" })


### PR DESCRIPTION
- implement XmlFormattingResponseBodyAdvice to format all API XML responses
- add unit and integration tests
- update norm controller test expectations to handle formatted/self-closing XML

RISDEV-8144