### PR TITLE
Rename /{workEli}/releases to /norms/{workEli}/releases

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ReleaseController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ReleaseController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 /** Controller for release-related actions. */
 @RestController
-@RequestMapping("/api/v1/eli/bund/{agent}/{year}/{naturalIdentifier}")
+@RequestMapping("/api/v1/norms/eli/bund/{agent}/{year}/{naturalIdentifier}")
 public class ReleaseController {
 
   private final ReleaseAllNormExpressionsUseCase releaseAllNormExpressionsUseCase;

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ReleaseControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/adapter/input/restapi/controller/ReleaseControllerTest.java
@@ -53,7 +53,7 @@ class ReleaseControllerTest {
       // When // Then
       mockMvc
         .perform(
-          post("/api/v1/eli/bund/bgbl-1/2023/413/releases")
+          post("/api/v1/norms/eli/bund/bgbl-1/2023/413/releases")
             .content(
               """
               {"releasetype": "praetext"}

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ReleaseControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ReleaseControllerIntegrationTest.java
@@ -57,7 +57,7 @@ class ReleaseControllerIntegrationTest extends BaseIntegrationTest {
       // when
       mockMvc
         .perform(
-          post("/api/v1/eli/bund/bgbl-1/2023/413/releases")
+          post("/api/v1/norms/eli/bund/bgbl-1/2023/413/releases")
             .content(
               """
               {"releaseType": "praetext"}
@@ -74,7 +74,7 @@ class ReleaseControllerIntegrationTest extends BaseIntegrationTest {
         .andExpect(
           jsonPath("detail").value("Norm with eli eli/bund/bgbl-1/2023/413 does not exist")
         )
-        .andExpect(jsonPath("instance").value("/api/v1/eli/bund/bgbl-1/2023/413/releases"))
+        .andExpect(jsonPath("instance").value("/api/v1/norms/eli/bund/bgbl-1/2023/413/releases"))
         .andExpect(jsonPath("eli").value("eli/bund/bgbl-1/2023/413"));
     }
 
@@ -92,7 +92,7 @@ class ReleaseControllerIntegrationTest extends BaseIntegrationTest {
       // When // Then
       mockMvc
         .perform(
-          post("/api/v1/eli/bund/bgbl-1/2017/s419/releases")
+          post("/api/v1/norms/eli/bund/bgbl-1/2017/s419/releases")
             .content(
               """
               {"releaseType": "praetext"}
@@ -156,7 +156,7 @@ class ReleaseControllerIntegrationTest extends BaseIntegrationTest {
       // When // Then
       mockMvc
         .perform(
-          post("/api/v1/eli/bund/bgbl-1/2017/s419/releases")
+          post("/api/v1/norms/eli/bund/bgbl-1/2017/s419/releases")
             .content(
               """
               {"releaseType": "praetext"}
@@ -170,7 +170,7 @@ class ReleaseControllerIntegrationTest extends BaseIntegrationTest {
       // release norm a second time
       mockMvc
         .perform(
-          post("/api/v1/eli/bund/bgbl-1/2017/s419/releases")
+          post("/api/v1/norms/eli/bund/bgbl-1/2017/s419/releases")
             .content(
               """
               {"releaseType": "praetext"}
@@ -218,7 +218,7 @@ class ReleaseControllerIntegrationTest extends BaseIntegrationTest {
       // Request is refused
       mockMvc
         .perform(
-          post("/api/v1/eli/bund/bgbl-1/1964/s593/releases")
+          post("/api/v1/norms/eli/bund/bgbl-1/1964/s593/releases")
             .content(
               """
               {"releaseType": "praetext"}
@@ -264,7 +264,7 @@ class ReleaseControllerIntegrationTest extends BaseIntegrationTest {
       // Request is refused
       mockMvc
         .perform(
-          post("/api/v1/eli/bund/bgbl-1/1964/s593/releases")
+          post("/api/v1/norms/eli/bund/bgbl-1/1964/s593/releases")
             .content(
               """
               {"releaseType": "praetext"}
@@ -311,7 +311,7 @@ class ReleaseControllerIntegrationTest extends BaseIntegrationTest {
       //when
       mockMvc
         .perform(
-          get("/api/v1/eli/bund/bgbl-1/1964/s593/releases").accept(MediaType.APPLICATION_JSON)
+          get("/api/v1/norms/eli/bund/bgbl-1/1964/s593/releases").accept(MediaType.APPLICATION_JSON)
         )
         //then
         .andExpect(status().isOk())
@@ -342,7 +342,7 @@ class ReleaseControllerIntegrationTest extends BaseIntegrationTest {
       //when
       mockMvc
         .perform(
-          get("/api/v1/eli/bund/bgbl-1/1964/s593/releases").accept(MediaType.APPLICATION_JSON)
+          get("/api/v1/norms/eli/bund/bgbl-1/1964/s593/releases").accept(MediaType.APPLICATION_JSON)
         )
         //then
         .andExpect(status().isOk())
@@ -357,7 +357,7 @@ class ReleaseControllerIntegrationTest extends BaseIntegrationTest {
       //when
       mockMvc
         .perform(
-          get("/api/v1/eli/bund/bgbl-1/1111/s593/releases").accept(MediaType.APPLICATION_JSON)
+          get("/api/v1/norms/eli/bund/bgbl-1/1111/s593/releases").accept(MediaType.APPLICATION_JSON)
         )
         //then
         .andExpect(status().isNotFound())
@@ -367,7 +367,7 @@ class ReleaseControllerIntegrationTest extends BaseIntegrationTest {
         .andExpect(
           jsonPath("detail").value("Norm with eli eli/bund/bgbl-1/1111/s593 does not exist")
         )
-        .andExpect(jsonPath("instance").value("/api/v1/eli/bund/bgbl-1/1111/s593/releases"))
+        .andExpect(jsonPath("instance").value("/api/v1/norms/eli/bund/bgbl-1/1111/s593/releases"))
         .andExpect(jsonPath("eli").value("eli/bund/bgbl-1/1111/s593"));
     }
   }

--- a/doc/backend/norms-api-v1.yaml
+++ b/doc/backend/norms-api-v1.yaml
@@ -161,8 +161,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
-  # TODO: (Malte Laukötter, 2025-06-26) for concitency: rename to norms/{workEli}/releases
-  /{workEli}/releases:
+  /norms/{workEli}/releases:
     get:
       tags:
         - Releases

--- a/frontend/e2e/application/abgabe.spec.ts
+++ b/frontend/e2e/application/abgabe.spec.ts
@@ -42,7 +42,7 @@ test.describe("Abgabe view with expressions", { tag: ["@RISDEV-7186"] }, () => {
 
   test("shows empty state when no expressions exist", async ({ page }) => {
     await page.route(
-      "**/api/v1/eli/bund/bgbl-1/1964/0000/releases",
+      "**/api/v1/norms/eli/bund/bgbl-1/1964/0000/releases",
       async (route) => {
         await route.fulfill({
           status: 200,

--- a/frontend/src/services/releaseService.spec.ts
+++ b/frontend/src/services/releaseService.spec.ts
@@ -45,7 +45,7 @@ describe("releaseService", () => {
       expect(data.value).toEqual(expectedReleases)
 
       expect(fetchSpy).toHaveBeenCalledWith(
-        `/api/v1/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-verkuendung-1/releases`,
+        `/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-verkuendung-1/releases`,
         expect.objectContaining({
           method: "GET",
           headers: expect.objectContaining({
@@ -92,12 +92,12 @@ describe("releaseService", () => {
       expect(data.value).toEqual([])
 
       expect(fetchSpy).toHaveBeenCalledWith(
-        `/api/v1/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-verkuendung-1/releases`,
+        `/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-verkuendung-1/releases`,
         expect.anything(),
       )
 
       expect(fetchSpy).toHaveBeenCalledWith(
-        `/api/v1/eli/bund/bgbl-1/2022/s12/2022-01-23/1/deu/regelungstext-verkuendung-1/releases`,
+        `/api/v1/norms/eli/bund/bgbl-1/2022/s12/2022-01-23/1/deu/regelungstext-verkuendung-1/releases`,
         expect.anything(),
       )
     })
@@ -129,7 +129,7 @@ describe("releaseService", () => {
       expect(data.value).toEqual(mockReleaseResponse)
 
       expect(fetchSpy).toHaveBeenCalledWith(
-        `/api/v1/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-verkuendung-1/releases`,
+        `/api/v1/norms/eli/bund/bgbl-1/2023/413/2023-12-29/1/deu/regelungstext-verkuendung-1/releases`,
         expect.objectContaining({
           method: "POST",
           headers: expect.objectContaining({
@@ -172,7 +172,7 @@ describe("releaseService", () => {
 
       expect(fetchSpy).toHaveBeenCalledOnce()
       expect(fetchSpy).toHaveBeenCalledWith(
-        `/api/v1/eli/bund/bgbl-1/2022/s12/2022-01-23/1/deu/regelungstext-verkuendung-1/releases`,
+        `/api/v1/norms/eli/bund/bgbl-1/2022/s12/2022-01-23/1/deu/regelungstext-verkuendung-1/releases`,
         expect.objectContaining({
           method: "POST",
         }),

--- a/frontend/src/services/releaseService.ts
+++ b/frontend/src/services/releaseService.ts
@@ -10,7 +10,7 @@ function useReleaseService<T>(
   fetchOptions: UseFetchOptions = {},
 ): UseFetchReturn<T> {
   return useApiFetch(
-    computed(() => `/${toValue(eli)}/releases`),
+    computed(() => `/norms/${toValue(eli)}/releases`),
     fetchOptions,
   ).json()
 }

--- a/frontend/src/services/zielnormReleaseService.ts
+++ b/frontend/src/services/zielnormReleaseService.ts
@@ -68,7 +68,7 @@ export function useGetZielnormReleaseStatus(
   const url = computed(() => {
     const eliVal = toValue(eli)
     if (!eliVal) return INVALID_URL
-    return `/${eliVal}/releases`
+    return `/norms/${eliVal}/releases`
   })
 
   const { data, ...rest } = useApiFetch(url, {
@@ -98,7 +98,7 @@ export function usePostZielnormRelease(
   const url = computed(() => {
     const eliVal = toValue(eli)
     if (!eliVal) return INVALID_URL
-    return `/${eliVal}/releases`
+    return `/norms/${eliVal}/releases`
   })
 
   const {


### PR DESCRIPTION
This is more consistent with our other endpoints

RISDEV-0000