### PR TITLE
Implement ADR 0020

### DIFF
--- a/LegalDocML.de/1.8.1/fixtures/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/2022-08-23/regelungstext-verkuendung-1.xml
+++ b/LegalDocML.de/1.8.1/fixtures/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/2022-08-23/regelungstext-verkuendung-1.xml
@@ -179,7 +179,7 @@
                      </norms:zielnorm-reference>
                   </norms:zielnorm-references>
                   <norms:amended-norm-expressions>
-                     <norms:norm-expression>eli/bund/bgbl-1/1964/s593/2017-03-16/1/deu</norms:norm-expression>
+                     <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/1964/s593/2017-03-16/1/deu</norms:norm-expression>
                   </norms:amended-norm-expressions>
                </norms:legalDocML.de_metadaten>
             </ris:legalDocML.de_metadaten>

--- a/LegalDocML.de/1.8.1/samples/bgbl-1_2017_s419/aenderungsgesetz/regelungstext-verkuendung-1.xml
+++ b/LegalDocML.de/1.8.1/samples/bgbl-1_2017_s419/aenderungsgesetz/regelungstext-verkuendung-1.xml
@@ -177,7 +177,7 @@
                      </norms:zielnorm-reference>
                   </norms:zielnorm-references>
                   <norms:amended-norm-expressions>
-                     <norms:norm-expression>eli/bund/bgbl-1/1964/s593/2017-03-16/1/deu</norms:norm-expression>
+                     <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/1964/s593/2017-03-16/1/deu</norms:norm-expression>
                   </norms:amended-norm-expressions>
                </norms:legalDocML.de_metadaten>
             </ris:legalDocML.de_metadaten>

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/VerkuendungService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/application/service/VerkuendungService.java
@@ -63,25 +63,25 @@ public class VerkuendungService
       .flatMap(Proprietary::getCustomModsMetadata)
       .flatMap(CustomModsMetadata::getAmendedNormExpressions);
 
-    if (affectedExpressionElis.isEmpty()) {
-      return List.of();
-    }
-
     return affectedExpressionElis
-      .get()
-      .stream()
-      .map(eli -> {
-        var norm = loadNormPort.loadNorm(new LoadNormPort.Options(eli));
-        if (norm.isEmpty()) {
-          log.warn(
-            "Norm with ELI {} could not be loaded when collecting expressions affected by Verkuendung with ELI {}",
-            eli,
-            options.eli()
-          );
-        }
-        return norm;
-      })
-      .flatMap(Optional::stream)
-      .toList();
+      .map(amendedNormExpressions ->
+        amendedNormExpressions
+          .getNormExpressions()
+          .stream()
+          .map(expr -> {
+            var norm = loadNormPort.loadNorm(new LoadNormPort.Options(expr.getNormExpressionEli()));
+            if (norm.isEmpty()) {
+              log.warn(
+                "Norm with ELI {} could not be loaded when collecting expressions affected by Verkuendung with ELI {}",
+                expr.getNormExpressionEli(),
+                options.eli()
+              );
+            }
+            return norm;
+          })
+          .flatMap(Optional::stream)
+          .toList()
+      )
+      .orElseGet(List::of);
   }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/NormExpression.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/norms/domain/entity/NormExpression.java
@@ -1,0 +1,120 @@
+package de.bund.digitalservice.ris.norms.domain.entity;
+
+import de.bund.digitalservice.ris.norms.domain.entity.eli.NormExpressionEli;
+import de.bund.digitalservice.ris.norms.utils.NodeCreator;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+/**
+ * A single norm expression that is amended by the Verkündung it belong to
+ * See also: ADR-0020
+ */
+@AllArgsConstructor
+public class NormExpression {
+
+  public static final Namespace NAMESPACE = Namespace.METADATEN_NORMS_APPLICATION_MODS;
+  public static final String TAG_NAME = "norm-expression";
+  public static final String ATTRIBUTE_NAME_CREATED_BY_ZEITGRENZE = "created-by-zeitgrenze";
+  public static final String ATTRIBUTE_NAME_CREATED_BY_REPLACING_EXISTING =
+    "created-by-replacing-existing-expression";
+
+  private final Element element;
+
+  /**
+   * Creates a new norms:norm-expression element and appends it to the parent {@link Node} of norms:amended-norm-expressions
+   * @param parentNode the element that should contain the new {@link NormExpression}
+   * @param expression the expression eli that will be placed into the text content of the new node
+   * @param createdByZeitgrenze the attribute indicating if the expression was created because of a zeitgrenze
+   * @param createdByReplacingExisting the attribute indicating if the expression was created replacing an existing one
+   * @return the newly created {@link NormExpression}
+   */
+  public static NormExpression createAndAppend(
+    Node parentNode,
+    NormExpressionEli expression,
+    boolean createdByZeitgrenze,
+    boolean createdByReplacingExisting
+  ) {
+    final var element = NodeCreator.createElement(NAMESPACE, TAG_NAME, parentNode);
+
+    final var normExpression = new NormExpression(element);
+
+    normExpression.setCreatedByZeitgrenze(createdByZeitgrenze);
+    normExpression.setCreatedByReplacingExisting(createdByReplacingExisting);
+
+    normExpression.setNormExpressionEli(expression);
+
+    return normExpression;
+  }
+
+  /**
+   * Retrieves expression eli of the {@link NormExpression} which is within the text content of the node.
+   * @return the parsed {@link NormExpression}
+   */
+  public NormExpressionEli getNormExpressionEli() {
+    final String textContent = element.getTextContent().trim();
+    if (textContent.isEmpty()) {
+      throw new IllegalArgumentException("Missing text content in <norm-expression> node");
+    }
+    return NormExpressionEli.fromString(element.getTextContent());
+  }
+
+  private void setNormExpressionEli(NormExpressionEli normExpressionEli) {
+    element.setTextContent(normExpressionEli.toString());
+  }
+
+  /**
+   * Retrieves the value of the attribute {@link #ATTRIBUTE_NAME_CREATED_BY_ZEITGRENZE} of the node.
+   * @return the parsed true/false value
+   */
+  public boolean getCreatedByZeitgrenze() {
+    return Boolean.parseBoolean(element.getAttribute(ATTRIBUTE_NAME_CREATED_BY_ZEITGRENZE));
+  }
+
+  /**
+   * Updates the attribute  {@link #ATTRIBUTE_NAME_CREATED_BY_ZEITGRENZE}
+   * @param value true/false
+   */
+  public void setCreatedByZeitgrenze(boolean value) {
+    element.setAttribute(ATTRIBUTE_NAME_CREATED_BY_ZEITGRENZE, String.valueOf(value));
+  }
+
+  /**
+   * Retrieves the value of the attribute {@link #ATTRIBUTE_NAME_CREATED_BY_REPLACING_EXISTING} of the node.
+   * @return the parsed true/false value
+   */
+  public boolean getCreatedByReplacingExistingExpression() {
+    return Boolean.parseBoolean(element.getAttribute(ATTRIBUTE_NAME_CREATED_BY_REPLACING_EXISTING));
+  }
+
+  /**
+   * Updates the attribute  {@link #ATTRIBUTE_NAME_CREATED_BY_REPLACING_EXISTING}
+   * @param value true/false
+   */
+  public void setCreatedByReplacingExisting(boolean value) {
+    element.setAttribute(ATTRIBUTE_NAME_CREATED_BY_REPLACING_EXISTING, String.valueOf(value));
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null || getClass() != obj.getClass()) return false;
+    NormExpression that = (NormExpression) obj;
+    return (
+      this.getCreatedByZeitgrenze() == that.getCreatedByZeitgrenze() &&
+      this.getCreatedByReplacingExistingExpression() ==
+      that.getCreatedByReplacingExistingExpression() &&
+      this.getNormExpressionEli().equals(that.getNormExpressionEli())
+    );
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+      getNormExpressionEli(),
+      getCreatedByZeitgrenze(),
+      getCreatedByReplacingExistingExpression()
+    );
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/AmendedNormExpressionsTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/AmendedNormExpressionsTest.java
@@ -9,81 +9,158 @@ import org.junit.jupiter.api.Test;
 class AmendedNormExpressionsTest {
 
   @Test
-  void itShouldBeASetWithNormExpressionElis() {
+  void add_addsNewNormExpressionIfNotPresent() {
     var amendedNormExpressions = new AmendedNormExpressions(
       toElement(
         """
-         <norms:amended-norm-expressions  xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/">
-              <norms:norm-expression>eli/bund/bgbl-1/2023/413/2023-12-29/1/deu</norms:norm-expression>
-              <norms:norm-expression>eli/bund/bgbl-1/2023/413/2024-01-11/2/deu</norms:norm-expression>
-              <norms:norm-expression>eli/bund/bgbl-1/2023/413/2024-02-12/1/deu</norms:norm-expression>
-              <norms:norm-expression>eli/bund/bgbl-1/2023/413/0001-01-01/24/deu</norms:norm-expression>
-              <norms:norm-expression>eli/bund/bgbl-1/2002/s1181/2023-12-29/1/deu</norms:norm-expression>
-         </norms:amended-norm-expressions>
+        <norms:amended-norm-expressions xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/">
+          <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/2023/413/2023-12-29/1/deu</norms:norm-expression>
+          <norms:norm-expression created-by-zeitgrenze="false" created-by-replacing-existing-expression="true">eli/bund/bgbl-1/2023/413/2024-01-11/2/deu</norms:norm-expression>
+          <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="true">eli/bund/bgbl-1/2023/413/2024-02-12/1/deu
+          </norms:norm-expression>
+        </norms:amended-norm-expressions>
         """
       )
     );
 
-    assertThat(amendedNormExpressions)
-      .hasSize(5)
-      .contains(NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu"))
-      .contains(NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2024-01-11/2/deu"))
-      .contains(NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2024-02-12/1/deu"))
-      .contains(NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/0001-01-01/24/deu"))
-      .contains(NormExpressionEli.fromString("eli/bund/bgbl-1/2002/s1181/2023-12-29/1/deu"));
+    assertThat(amendedNormExpressions.getNormExpressions()).hasSize(3);
+
+    amendedNormExpressions.add(
+      NormExpressionEli.fromString("eli/bund/bgbl-1/2002/s1181/2023-12-29/1/deu"),
+      true,
+      true
+    );
+
+    assertThat(amendedNormExpressions.getNormExpressions()).hasSize(4);
+
+    var added = amendedNormExpressions.find(
+      NormExpressionEli.fromString("eli/bund/bgbl-1/2002/s1181/2023-12-29/1/deu")
+    );
+
+    assertThat(added).isPresent();
+    assertThat(added.get().getCreatedByZeitgrenze()).isTrue();
+    assertThat(added.get().getCreatedByReplacingExistingExpression()).isTrue();
   }
 
   @Test
-  void itShouldAddNewNormExpressionElis() {
+  void add_updatesExistingNormExpressionIfPresent() {
     var amendedNormExpressions = new AmendedNormExpressions(
       toElement(
         """
-         <norms:amended-norm-expressions  xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/">
-              <norms:norm-expression>eli/bund/bgbl-1/2023/413/2023-12-29/1/deu</norms:norm-expression>
-              <norms:norm-expression>eli/bund/bgbl-1/2023/413/2024-01-11/2/deu</norms:norm-expression>
-         </norms:amended-norm-expressions>
+        <norms:amended-norm-expressions xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/">
+          <norms:norm-expression created-by-zeitgrenze="false" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/2023/413/2023-12-29/1/deu</norms:norm-expression>
+        </norms:amended-norm-expressions>
         """
       )
     );
 
+    assertThat(amendedNormExpressions.getNormExpressions()).hasSize(1);
+
     amendedNormExpressions.add(
-      NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2024-02-12/1/deu")
+      NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu"),
+      true,
+      true
     );
-    amendedNormExpressions.add(
+
+    var updated = amendedNormExpressions.find(
       NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu")
-    ); // duplicate: do not add
+    );
 
-    assertThat(amendedNormExpressions)
-      .hasSize(3)
-      .contains(NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu"))
-      .contains(NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2024-01-11/2/deu"))
-      .contains(NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2024-02-12/1/deu"));
+    assertThat(updated).isPresent();
+    assertThat(updated.get().getCreatedByZeitgrenze()).isTrue();
+    assertThat(updated.get().getCreatedByReplacingExistingExpression()).isTrue();
+
+    // still only 1 item in the list
+    assertThat(amendedNormExpressions.getNormExpressions()).hasSize(1);
   }
 
   @Test
-  void itShouldRemoveANormExpressionEli() {
+  void remove() {
     var amendedNormExpressions = new AmendedNormExpressions(
       toElement(
         """
-         <norms:amended-norm-expressions  xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/">
-              <norms:norm-expression>eli/bund/bgbl-1/2023/413/2023-12-29/1/deu</norms:norm-expression>
-              <norms:norm-expression>eli/bund/bgbl-1/2023/413/2024-01-11/2/deu</norms:norm-expression>
+         <norms:amended-norm-expressions xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/">
+              <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/2023/413/2023-12-29/1/deu</norms:norm-expression>
+              <norms:norm-expression created-by-zeitgrenze="false" created-by-replacing-existing-expression="true">eli/bund/bgbl-1/2023/413/2024-01-11/2/deu</norms:norm-expression>
+              <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="true">eli/bund/bgbl-1/2023/413/2024-02-12/1/deu</norms:norm-expression>
          </norms:amended-norm-expressions>
         """
       )
     );
 
-    assertThat(amendedNormExpressions)
-      .hasSize(2)
-      .contains(NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu"))
-      .contains(NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2024-01-11/2/deu"));
+    assertThat(amendedNormExpressions.getNormExpressions()).hasSize(3);
 
     amendedNormExpressions.remove(
-      NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2024-01-11/2/deu")
+      NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu")
     );
 
-    assertThat(amendedNormExpressions)
-      .hasSize(1)
-      .contains(NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu"));
+    assertThat(amendedNormExpressions.getNormExpressions()).hasSize(2);
+  }
+
+  @Test
+  void contains() {
+    var amendedNormExpressions = new AmendedNormExpressions(
+      toElement(
+        """
+          <norms:amended-norm-expressions xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/">
+            <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/2023/413/2023-12-29/1/deu</norms:norm-expression>
+          </norms:amended-norm-expressions>
+        """
+      )
+    );
+
+    var present = NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu");
+    var notPresent = NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2024-01-01/1/deu");
+
+    assertThat(amendedNormExpressions.contains(present)).isTrue();
+    assertThat(amendedNormExpressions.contains(notPresent)).isFalse();
+  }
+
+  @Test
+  void find() {
+    var amendedNormExpressions = new AmendedNormExpressions(
+      toElement(
+        """
+          <norms:amended-norm-expressions xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/">
+            <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/2023/413/2023-12-29/1/deu</norms:norm-expression>
+          </norms:amended-norm-expressions>
+        """
+      )
+    );
+
+    var found = amendedNormExpressions.find(
+      NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu")
+    );
+    var notFound = amendedNormExpressions.find(
+      NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2024-01-01/1/deu")
+    );
+
+    assertThat(found).isPresent();
+    assertThat(found.get().getCreatedByZeitgrenze()).isTrue();
+    assertThat(notFound).isEmpty();
+  }
+
+  @Test
+  void getNormExpressions() {
+    var amendedNormExpressions = new AmendedNormExpressions(
+      toElement(
+        """
+          <norms:amended-norm-expressions xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/">
+            <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/2023/413/2024-02-12/1/deu</norms:norm-expression>
+            <norms:norm-expression created-by-zeitgrenze="false" created-by-replacing-existing-expression="true">eli/bund/bgbl-1/2023/413/2023-12-29/1/deu</norms:norm-expression>
+          </norms:amended-norm-expressions>
+        """
+      )
+    );
+
+    var normExpressions = amendedNormExpressions.getNormExpressions();
+
+    assertThat(normExpressions).hasSize(2);
+    assertThat(normExpressions.get(0).getNormExpressionEli()).hasToString(
+      "eli/bund/bgbl-1/2023/413/2023-12-29/1/deu"
+    );
+    assertThat(normExpressions.get(1).getNormExpressionEli()).hasToString(
+      "eli/bund/bgbl-1/2023/413/2024-02-12/1/deu"
+    );
   }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/CustomModsMetadataTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/CustomModsMetadataTest.java
@@ -3,40 +3,52 @@ package de.bund.digitalservice.ris.norms.domain.entity;
 import static de.bund.digitalservice.ris.norms.utils.XmlMapper.toElement;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import de.bund.digitalservice.ris.norms.domain.entity.eli.NormExpressionEli;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class CustomModsMetadataTest {
 
   @Nested
-  class getAmendedNormExpressionElis {
+  class getOrCreateAmendedNormExpressions {
 
     @Test
-    void returnNormExpressionElis() {
+    void create() {
+      var customModsMetadata = new CustomModsMetadata(
+        toElement(
+          """
+          <norms:legalDocML.de_metadaten xmlns:norms='http://MetadatenMods.LegalDocML.de/1.8.1/'></norms:legalDocML.de_metadaten>
+          """
+        )
+      );
+
+      var amendedNormExpressions = customModsMetadata.getOrCreateAmendedNormExpressions();
+      assertThat(amendedNormExpressions.getNormExpressions()).isEmpty();
+    }
+
+    @Test
+    void get() {
       var customModsMetadata = new CustomModsMetadata(
         toElement(
           """
           <norms:legalDocML.de_metadaten xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/">
               <norms:amended-norm-expressions>
-                  <norms:norm-expression>eli/bund/bgbl-1/2023/413/2023-12-29/1/deu</norms:norm-expression>
-                  <norms:norm-expression>eli/bund/bgbl-1/2023/413/2024-01-11/2/deu</norms:norm-expression>
-                  <norms:norm-expression>eli/bund/bgbl-1/2023/413/2024-02-12/1/deu</norms:norm-expression>
-                  <norms:norm-expression>eli/bund/bgbl-1/2023/413/0001-01-01/24/deu</norms:norm-expression>
-                  <norms:norm-expression>eli/bund/bgbl-1/2002/s1181/2023-12-29/1/deu</norms:norm-expression>
+                  <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/2023/413/2023-12-29/1/deu</norms:norm-expression>
+                  <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/2023/413/2024-01-11/2/deu</norms:norm-expression>
               </norms:amended-norm-expressions>
           </norms:legalDocML.de_metadaten>
           """
         )
       );
 
-      assertThat(customModsMetadata.getOrCreateAmendedNormExpressions())
-        .hasSize(5)
-        .contains(NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu"))
-        .contains(NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2024-01-11/2/deu"))
-        .contains(NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2024-02-12/1/deu"))
-        .contains(NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/0001-01-01/24/deu"))
-        .contains(NormExpressionEli.fromString("eli/bund/bgbl-1/2002/s1181/2023-12-29/1/deu"));
+      var amendedNormExpressions = customModsMetadata.getAmendedNormExpressions();
+      assertThat(amendedNormExpressions).isPresent();
+
+      assertThat(
+        amendedNormExpressions.get().getNormExpressions().getFirst().getNormExpressionEli()
+      ).hasToString("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu");
+      assertThat(
+        amendedNormExpressions.get().getNormExpressions().getLast().getNormExpressionEli()
+      ).hasToString("eli/bund/bgbl-1/2023/413/2024-01-11/2/deu");
     }
   }
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormExpressionTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/domain/entity/NormExpressionTest.java
@@ -1,0 +1,143 @@
+package de.bund.digitalservice.ris.norms.domain.entity;
+
+import static de.bund.digitalservice.ris.norms.utils.XmlMapper.toElement;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import de.bund.digitalservice.ris.norms.domain.entity.eli.NormExpressionEli;
+import de.bund.digitalservice.ris.norms.utils.exceptions.InvalidEliException;
+import org.junit.jupiter.api.Test;
+
+class NormExpressionTest {
+
+  @Test
+  void createAndAppend_setsAllValuesCorrectly() {
+    var parent = toElement(
+      "<norms:amended-norm-expressions xmlns:norms=\"http://MetadatenMods.LegalDocML.de/1.8.1/\"/>"
+    );
+    var eli = NormExpressionEli.fromString("eli/bund/bgbl-1/2023/413/2023-12-29/1/deu");
+
+    var normExpression = NormExpression.createAndAppend(parent, eli, true, false);
+
+    assertThat(normExpression.getNormExpressionEli()).isEqualTo(eli);
+    assertThat(normExpression.getCreatedByZeitgrenze()).isTrue();
+    assertThat(normExpression.getCreatedByReplacingExistingExpression()).isFalse();
+  }
+
+  @Test
+  void throwsExceptionWhenTextContentIsEmpty() {
+    var normExpression = new NormExpression(
+      toElement(
+        """
+              <norms:norm-expression xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/" created-by-zeitgrenze="true" created-by-replacing-existing-expression="false"></norms:norm-expression>
+        """
+      )
+    );
+
+    assertThatThrownBy(normExpression::getNormExpressionEli)
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Missing text content in <norm-expression> node");
+  }
+
+  @Test
+  void throwsExceptionWhenNotValidExpressionEli() {
+    var normExpression = new NormExpression(
+      toElement(
+        """
+              <norms:norm-expression xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/" created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">not-valid-expression-eli</norms:norm-expression>
+        """
+      )
+    );
+
+    assertThatThrownBy(normExpression::getNormExpressionEli)
+      .isInstanceOf(InvalidEliException.class)
+      .hasMessageContaining("Invalid NormExpressionEli: \"not-valid-expression-eli\"");
+  }
+
+  @Test
+  void getNormExpressionEli() {
+    var normExpression = new NormExpression(
+      toElement(
+        """
+              <norms:norm-expression xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/" created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/2023/413/2023-12-29/1/deu</norms:norm-expression>
+        """
+      )
+    );
+    assertThat(normExpression.getNormExpressionEli()).hasToString(
+      "eli/bund/bgbl-1/2023/413/2023-12-29/1/deu"
+    );
+  }
+
+  @Test
+  void getCreatedByZeitgrenze() {
+    var normExpression = new NormExpression(
+      toElement(
+        """
+              <norms:norm-expression xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/" created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/2023/413/2023-12-29/1/deu</norms:norm-expression>
+        """
+      )
+    );
+    assertThat(normExpression.getCreatedByZeitgrenze()).isTrue();
+  }
+
+  @Test
+  void getCreatedByReplacingExistingExpression() {
+    var normExpression = new NormExpression(
+      toElement(
+        """
+              <norms:norm-expression xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/" created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/2023/413/2023-12-29/1/deu</norms:norm-expression>
+        """
+      )
+    );
+    assertThat(normExpression.getCreatedByReplacingExistingExpression()).isFalse();
+  }
+
+  @Test
+  void equalsAndHashCode_workCorrectly() {
+    var element1 = toElement(
+      """
+      <norms:norm-expression xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/"
+        created-by-zeitgrenze="true"
+        created-by-replacing-existing-expression="false">eli/bund/bgbl-1/2023/413/2023-12-29/1/deu</norms:norm-expression>
+      """
+    );
+
+    var element2 = toElement(
+      """
+      <norms:norm-expression xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/"
+        created-by-zeitgrenze="true"
+        created-by-replacing-existing-expression="false">eli/bund/bgbl-1/2023/413/2023-12-29/1/deu</norms:norm-expression>
+      """
+    );
+
+    var norm1 = new NormExpression(element1);
+    var norm2 = new NormExpression(element2);
+
+    assertThat(norm1).isEqualTo(norm2);
+    assertThat(norm1.hashCode()).hasSameHashCodeAs(norm2.hashCode());
+  }
+
+  @Test
+  void equals_returnsFalseWhenAttributesDiffer() {
+    var e1 = toElement(
+      """
+      <norms:norm-expression xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/"
+        created-by-zeitgrenze="false"
+        created-by-replacing-existing-expression="false">eli/bund/bgbl-1/2023/413/2023-12-29/1/deu</norms:norm-expression>
+      """
+    );
+
+    var e2 = toElement(
+      """
+      <norms:norm-expression xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/"
+        created-by-zeitgrenze="true"
+        created-by-replacing-existing-expression="false">eli/bund/bgbl-1/2023/413/2023-12-29/1/deu</norms:norm-expression>
+      """
+    );
+
+    var n1 = new NormExpression(e1);
+    var n2 = new NormExpression(e2);
+
+    assertThat(n1).isNotEqualTo(n2);
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/VerkuendungenControllerIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/VerkuendungenControllerIntegrationTest.java
@@ -765,7 +765,79 @@ class VerkuendungenControllerIntegrationTest extends BaseIntegrationTest {
         .andExpect(jsonPath("$[0].expressions[2].isCreated").value(true))
         .andExpect(jsonPath("$[0].expressions[2].isOrphan").value(true))
         .andExpect(jsonPath("$[0].expressions[2].createdBy").value("diese Verkündung"))
-        .andExpect(jsonPath("$[0].expressions[4]").doesNotExist())
+        .andExpect(jsonPath("$[0].expressions[3]").doesNotExist())
+        .andExpect(jsonPath("$[1]").doesNotExist());
+    }
+
+    @Test
+    void itShouldNotMarkedReplacingExpressionsAsOrphans() throws Exception {
+      Fixtures.loadAndSaveNormFixture(
+        dokumentRepository,
+        binaryFileRepository,
+        normManifestationRepository,
+        VerkuendungenControllerIntegrationTest.class,
+        "amending-law-for-vereinsgesetz-with-two-replacing-expressions",
+        NormPublishState.UNPUBLISHED
+      );
+
+      Fixtures.loadAndSaveNormFixture(
+        dokumentRepository,
+        binaryFileRepository,
+        normManifestationRepository,
+        VerkuendungenControllerIntegrationTest.class,
+        "vereinsgesetz-original-expression",
+        NormPublishState.UNPUBLISHED
+      );
+
+      // created-by-zeitgrenze="true" created-by-replacing-existing-expression="true"
+      Fixtures.loadAndSaveNormFixture(
+        dokumentRepository,
+        binaryFileRepository,
+        normManifestationRepository,
+        VerkuendungenControllerIntegrationTest.class,
+        "vereinsgesetz-2017-03-16-1",
+        NormPublishState.UNPUBLISHED
+      );
+
+      // created-by-zeitgrenze="false" created-by-replacing-existing-expression="true"
+      Fixtures.loadAndSaveNormFixture(
+        dokumentRepository,
+        binaryFileRepository,
+        normManifestationRepository,
+        VerkuendungenControllerIntegrationTest.class,
+        "vereinsgesetz-2024-05-30",
+        NormPublishState.UNPUBLISHED
+      );
+
+      mockMvc
+        .perform(
+          get(
+            "/api/v1/verkuendungen/eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/zielnormen/expressions/preview"
+          ).accept(MediaType.APPLICATION_JSON)
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].normWorkEli").value("eli/bund/bgbl-1/1964/s593"))
+        .andExpect(
+          jsonPath("$[0].title").value("Gesetz zur Regelung des öffentlichen Vereinsrechts")
+        )
+        .andExpect(jsonPath("$[0].shortTitle").value("Vereinsgesetz"))
+        .andExpect(
+          jsonPath("$[0].expressions[0].normExpressionEli").value(
+            "eli/bund/bgbl-1/1964/s593/2017-03-16/1/deu"
+          )
+        )
+        .andExpect(jsonPath("$[0].expressions[0].isGegenstandslos").value(false))
+        .andExpect(jsonPath("$[0].expressions[0].isCreated").value(true))
+        .andExpect(jsonPath("$[0].expressions[0].createdBy").value("diese Verkündung"))
+        .andExpect(
+          jsonPath("$[0].expressions[1].normExpressionEli").value(
+            "eli/bund/bgbl-1/1964/s593/2024-05-30/1/deu"
+          )
+        )
+        .andExpect(jsonPath("$[0].expressions[1].isGegenstandslos").value(false))
+        .andExpect(jsonPath("$[0].expressions[1].isCreated").value(true))
+        .andExpect(jsonPath("$[0].expressions[1].createdBy").value("System"))
+        .andExpect(jsonPath("$[0].expressions[2]").doesNotExist())
         .andExpect(jsonPath("$[1]").doesNotExist());
     }
   }

--- a/backend/src/test/resources/de/bund/digitalservice/ris/norms/application/service/ZeitgrenzeServiceTest/norm-with-several-zeitgrenzen/regelungstext-verkuendung-1.xml
+++ b/backend/src/test/resources/de/bund/digitalservice/ris/norms/application/service/ZeitgrenzeServiceTest/norm-with-several-zeitgrenzen/regelungstext-verkuendung-1.xml
@@ -174,7 +174,7 @@
                      <norms:geltungszeit id="gz-4" art="ausserkraft">2026-01-01</norms:geltungszeit>
                   </norms:geltungszeiten>
                   <norms:amended-norm-expressions>
-                     <norms:norm-expression>eli/bund/bgbl-1/1964/s593/2017-03-16/1/deu</norms:norm-expression>
+                     <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/1964/s593/2017-03-16/1/deu</norms:norm-expression>
                   </norms:amended-norm-expressions>
                </norms:legalDocML.de_metadaten>
             </ris:legalDocML.de_metadaten>

--- a/backend/src/test/resources/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/VerkuendungenControllerIntegrationTest/amending-law-for-vereinsgesetz-several-zielnormen-references-and-one-created/regelungstext-verkuendung-1.xml
+++ b/backend/src/test/resources/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/VerkuendungenControllerIntegrationTest/amending-law-for-vereinsgesetz-several-zielnormen-references-and-one-created/regelungstext-verkuendung-1.xml
@@ -193,7 +193,7 @@
                      </norms:zielnorm-reference>
                   </norms:zielnorm-references>
                   <norms:amended-norm-expressions>
-                     <norms:norm-expression>eli/bund/bgbl-1/1964/s593/2017-03-16/1/deu</norms:norm-expression>
+                     <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/1964/s593/2017-03-16/1/deu</norms:norm-expression>
                   </norms:amended-norm-expressions>
                </norms:legalDocML.de_metadaten>
             </ris:legalDocML.de_metadaten>
@@ -271,7 +271,7 @@
                                               href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-verkuendung-1">Vereinsgesetz vom
                                 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden
                                 ist</akn:affectedDocument>, wird wie folgt geändert:
-                            
+
                   </akn:listIntroduction>
                      <!-- Nummer 1 wurde entfernt -->
                      <!-- Nummer 2 -->

--- a/backend/src/test/resources/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/VerkuendungenControllerIntegrationTest/amending-law-for-vereinsgesetz-several-zielnormen-references-and-one-orphan-after-first-geltungszeit/regelungstext-verkuendung-1.xml
+++ b/backend/src/test/resources/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/VerkuendungenControllerIntegrationTest/amending-law-for-vereinsgesetz-several-zielnormen-references-and-one-orphan-after-first-geltungszeit/regelungstext-verkuendung-1.xml
@@ -186,7 +186,7 @@
                      </norms:zielnorm-reference>
                   </norms:zielnorm-references>
                   <norms:amended-norm-expressions>
-                     <norms:norm-expression>eli/bund/bgbl-1/1964/s593/2021-04-23/1/deu</norms:norm-expression>
+                     <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/1964/s593/2021-04-23/1/deu</norms:norm-expression>
                   </norms:amended-norm-expressions>
                </norms:legalDocML.de_metadaten>
             </ris:legalDocML.de_metadaten>
@@ -264,7 +264,7 @@
                                               href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom
                                 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden
                                 ist</akn:affectedDocument>, wird wie folgt geändert:
-                            
+
                   </akn:listIntroduction>
                      <!-- Nummer 1 wurde entfernt -->
                      <!-- Nummer 2 -->

--- a/backend/src/test/resources/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/VerkuendungenControllerIntegrationTest/amending-law-for-vereinsgesetz-several-zielnormen-references-and-one-orphan-before-first-geltungszeit/regelungstext-verkuendung-1.xml
+++ b/backend/src/test/resources/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/VerkuendungenControllerIntegrationTest/amending-law-for-vereinsgesetz-several-zielnormen-references-and-one-orphan-before-first-geltungszeit/regelungstext-verkuendung-1.xml
@@ -186,7 +186,7 @@
                      </norms:zielnorm-reference>
                   </norms:zielnorm-references>
                   <norms:amended-norm-expressions>
-                     <norms:norm-expression>eli/bund/bgbl-1/1964/s593/2017-03-16/1/deu</norms:norm-expression>
+                     <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/1964/s593/2017-03-16/1/deu</norms:norm-expression>
                   </norms:amended-norm-expressions>
                </norms:legalDocML.de_metadaten>
             </ris:legalDocML.de_metadaten>
@@ -264,7 +264,7 @@
                                               href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom
                                 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden
                                 ist</akn:affectedDocument>, wird wie folgt geändert:
-                            
+
                   </akn:listIntroduction>
                      <!-- Nummer 1 wurde entfernt -->
                      <!-- Nummer 2 -->

--- a/backend/src/test/resources/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/VerkuendungenControllerIntegrationTest/amending-law-for-vereinsgesetz-with-two-orphans/regelungstext-verkuendung-1.xml
+++ b/backend/src/test/resources/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/VerkuendungenControllerIntegrationTest/amending-law-for-vereinsgesetz-with-two-orphans/regelungstext-verkuendung-1.xml
@@ -175,8 +175,8 @@
                      </norms:zielnorm-reference>
                   </norms:zielnorm-references>
                   <norms:amended-norm-expressions>
-                     <norms:norm-expression>eli/bund/bgbl-1/1964/s593/2017-03-16/1/deu</norms:norm-expression>
-                     <norms:norm-expression>eli/bund/bgbl-1/1964/s593/2024-05-30/1/deu</norms:norm-expression>
+                     <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/1964/s593/2017-03-16/1/deu</norms:norm-expression>
+                     <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/1964/s593/2024-05-30/1/deu</norms:norm-expression>
                   </norms:amended-norm-expressions>
                </norms:legalDocML.de_metadaten>
             </ris:legalDocML.de_metadaten>
@@ -254,7 +254,7 @@
                                               href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom
                                 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden
                                 ist</akn:affectedDocument>, wird wie folgt geändert:
-                            
+
                   </akn:listIntroduction>
                      <!-- Nummer 1 wurde entfernt -->
                      <!-- Nummer 2 -->

--- a/backend/src/test/resources/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/VerkuendungenControllerIntegrationTest/amending-law-for-vereinsgesetz-with-two-replacing-expressions/rechtsetzungsdokument-1.xml
+++ b/backend/src/test/resources/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/VerkuendungenControllerIntegrationTest/amending-law-for-vereinsgesetz-with-two-replacing-expressions/rechtsetzungsdokument-1.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   This is a modified example from the LDML.de specification.
+-->
+<!--
+	##################################################################################
+	Projekt E-Gesetzgebung
+	Nicht-normative Exemplifikation für den Standard LegalDocML.de 1.6 (Dezember 2023)
+
+	2023 Copyright (C) 2021-2023 Bundesministerium des Innern und für Heimat,
+	Referat DG II 6, Maßnahmen Enterprise Resource Management und Elektronische
+	Verwaltungsarbeit
+
+	Veröffentlicht unter der Lizenz CC-BY-3.0 (Creative Commons Namensnennung 3.0)
+	##################################################################################
+-->
+<?xml-model href="/LegalDocML.de/1.8.1/schema/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.8.1/"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://Inhaltsdaten.LegalDocML.de/1.8.1/ /LegalDocML.de/1.8.1/schema/legalDocML.de-regelungstextverkuendungsfassung.xsd http://MetadatenBundesregierung.LegalDocML.de/1.8.1/ /LegalDocML.de/1.8.1/schema/legalDocML.de-metadaten-bundesregierung.xsd http://MetadatenRegelungstext.LegalDocML.de/1.8.1/ /LegalDocML.de/1.8.1/schema/legalDocML.de-metadaten-regelungstext.xsd http://MetadatenRIS.LegalDocML.de/1.8.1/ /LegalDocML.de/ris-norms-ldml-schema-extensions/1.8.1/legalDocML.de-metadaten-ris.xsd http://MetadatenMods.LegalDocML.de/1.8.1/ /LegalDocML.de/ris-norms-ldml-schema-extensions/1.8.1/norms-application-only-metadata.xsd">
+   <akn:documentCollection name="/akn/ontology/de/concept/documenttype/bund/rechtsetzungsdokument">
+      <akn:meta GUID="8ad6e5d2-d503-49b5-bb8b-cd5c506ce21c" eId="meta-n1">
+         <akn:identification eId="meta-n1_ident-n1"
+                             GUID="d50e4b53-2f0a-4151-b5ab-70bac60042fb"
+                             source="attributsemantik-noch-undefiniert">
+            <akn:FRBRWork eId="meta-n1_ident-n1_frbrwork-n1"
+                          GUID="1caf03be-a918-42d0-a52a-2ed7f118fa6b">
+               <akn:FRBRthis eId="meta-n1_ident-n1_frbrwork-n1_frbrthis-n1"
+                             GUID="da4d73b9-047f-462b-bfbe-7d9e6af9b38c"
+                             value="eli/bund/bgbl-1/2017/s419/rechtsetzungsdokument-1"/>
+               <akn:FRBRuri eId="meta-n1_ident-n1_frbrwork-n1_frbruri-n1"
+                            GUID="217707f7-94ff-4225-94e2-455eb6c2d6c9"
+                            value="eli/bund/bgbl-1/2017/s419"/>
+               <akn:FRBRalias eId="meta-n1_ident-n1_frbrwork-n1_frbralias-n1"
+                              GUID="d9dc4eed-fd5d-4469-9079-c6e1f60e8f6f"
+                              name="übergreifende-id"
+                              value="c53036e4-14ac-420f-b01a-bae05a0a9756"/>
+               <akn:FRBRdate eId="meta-n1_ident-n1_frbrwork-n1_frbrdate-n1"
+                             GUID="aac82214-8e7e-4b93-9dfb-4960eb6b27c1"
+                             date="2017-03-15"
+                             name="verkuendungsfassung-ausfertigungsdatum"/>
+               <akn:FRBRdate eId="meta-n1_ident-n1_frbrwork-n1_frbrdate-n2"
+                             GUID="243d1037-b75c-44b0-bd2b-b0ec9c90323f"
+                             date="2017-03-15"
+                             name="verkuendungsfassung-verkuendungsdatum"/>
+               <akn:FRBRauthor eId="meta-n1_ident-n1_frbrwork-n1_frbrauthor-n1"
+                               GUID="c869fe32-59e7-45ec-99f8-2c384e17f940"
+                               href="recht.bund.de/institution/bundesregierung"/>
+               <akn:FRBRcountry eId="meta-n1_ident-n1_frbrwork-n1_frbrcountry-n1"
+                                GUID="7276d753-7033-43bd-919a-83f8efbf2702"
+                                value="de"/>
+               <akn:FRBRnumber eId="meta-n1_ident-n1_frbrwork-n1_frbrnumber-n1"
+                               GUID="fff770b7-1752-4bd5-8162-218f6ba8d8c1"
+                               value="s419"/>
+               <akn:FRBRname eId="meta-n1_ident-n1_frbrwork-n1_frbrname-n1"
+                             GUID="b0197991-8d65-42a0-ae28-df7e76c462a5"
+                             value="bgbl-1"/>
+               <akn:FRBRsubtype eId="meta-n1_ident-n1_frbrwork-n1_frbrsubtype-n1"
+                                GUID="cd4ccdc6-f81f-4d68-8796-7567dd9c5cc2"
+                                value="rechtsetzungsdokument-1"/>
+            </akn:FRBRWork>
+            <akn:FRBRExpression eId="meta-n1_ident-n1_frbrexpression-n1"
+                                GUID="4499a080-dd15-4aa2-82c0-783b0eb0051c">
+               <akn:FRBRthis eId="meta-n1_ident-n1_frbrexpression-n1_frbrthis-n1"
+                             GUID="891cc730-5501-42fe-a7f3-8d234821109d"
+                             value="eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/rechtsetzungsdokument-1"/>
+               <akn:FRBRuri eId="meta-n1_ident-n1_frbrexpression-n1_frbruri-n1"
+                            GUID="aca76c2a-2b48-41eb-b63f-3a4f4c2a8ece"
+                            value="eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu"/>
+               <akn:FRBRalias eId="meta-n1_ident-n1_frbrexpression-n1_frbralias-n1"
+                              GUID="461628ec-1677-4624-af21-e0d3b67c0531"
+                              name="aktuelle-version-id"
+                              value="e47a5106-c153-4da4-8d94-8cc2ebf9b232"/>
+               <akn:FRBRalias eId="meta-n1_ident-n1_frbrexpression-n1_frbralias-n2"
+                              GUID="5a42d0ae-c228-4a9d-82b3-89f2279ceb77"
+                              name="nachfolgende-version-id"
+                              value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+               <akn:FRBRauthor eId="meta-n1_ident-n1_frbrexpression-n1_frbrauthor-n1"
+                               GUID="0ee19487-632c-4cdf-8c9c-0d3ddceb7a30"
+                               href="recht.bund.de/institution/bundesregierung"/>
+               <akn:FRBRdate eId="meta-n1_ident-n1_frbrexpression-n1_frbrdate-n1"
+                             GUID="066a9994-db00-4f62-b917-28b3389edbac"
+                             date="2017-03-15"
+                             name="verkuendung"/>
+               <akn:FRBRlanguage eId="meta-n1_ident-n1_frbrexpression-n1_frbrlanguage-n1"
+                                 GUID="7998e453-3ee5-4b7e-a1ae-cf241431eee1"
+                                 language="deu"/>
+               <akn:FRBRversionNumber eId="meta-n1_ident-n1_frbrexpression-n1_frbrversionnumber-n1"
+                                      GUID="35835917-5890-4a79-9bff-dff23d37b9ac"
+                                      value="1"/>
+            </akn:FRBRExpression>
+            <akn:FRBRManifestation eId="meta-n1_ident-n1_frbrmanifestation-n1"
+                                   GUID="c7492de2-d85a-4eab-8bf6-226376fafe10">
+               <akn:FRBRthis eId="meta-n1_ident-n1_frbrmanifestation-n1_frbrthis-n1"
+                             GUID="ab419ee1-2dca-4c80-afdc-673a9a7f5fd0"
+                             value="eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/2022-08-23/rechtsetzungsdokument-1.xml"/>
+               <akn:FRBRuri eId="meta-n1_ident-n1_frbrmanifestation-n1_frbruri-n1"
+                            GUID="bd94b5b6-d1db-4dd2-8765-a0efed6ee4d2"
+                            value="eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/2022-08-23/rechtsetzungsdokument-1.xml"/>
+               <akn:FRBRdate eId="meta-n1_ident-n1_frbrmanifestation-n1_frbrdate-n1"
+                             GUID="5414af8e-9994-4f22-adee-3d49e42d8301"
+                             date="2022-08-23"
+                             name="generierung"/>
+               <akn:FRBRauthor eId="meta-n1_ident-n1_frbrmanifestation-n1_frbrauthor-n1"
+                               GUID="0ea7b3dd-12dc-4568-b9e4-eceac5a9124c"
+                               href="recht.bund.de"/>
+               <akn:FRBRformat eId="meta-n1_ident-n1_frbrmanifestation-n1_frbrformat-n1"
+                               GUID="b6e7b39c-9792-4e0d-973d-3fbb282b9fa0"
+                               value="xml"/>
+            </akn:FRBRManifestation>
+         </akn:identification>
+         <akn:proprietary GUID="6ae41510-c979-4724-bcb7-84abed57d6da"
+                          source="attributsemantik-noch-undefiniert"
+                          eId="meta-n1_proprietary-n1">
+            <redok:legalDocML.de_metadaten xmlns:redok="http://MetadatenRechtsetzungsdokument.LegalDocML.de/1.8.1/">
+               <redok:initiant>bundesregierung</redok:initiant>
+               <redok:bearbeitendeInstitution>bundesregierung</redok:bearbeitendeInstitution>
+               <redok:fna>nicht-vorhanden</redok:fna>
+               <redok:gesta>nicht-vorhanden</redok:gesta>
+            </redok:legalDocML.de_metadaten>
+         </akn:proprietary>
+      </akn:meta>
+      <akn:collectionBody GUID="8b5149ba-acd1-4bb7-8b3e-ff8b70d161d8" eId="rdokhauptteil-n1">
+         <akn:component GUID="2de66313-4471-4a26-bc65-ab96afbe3aae"
+                        eId="rdokhauptteil-n1_tldokverweis-n1">
+            <akn:documentRef GUID="9fe1796e-73e7-4d65-af24-58f86b7b8d78"
+                             href="regelungstext-verkuendung-1.xml"
+                             showAs="/akn/ontology/de/concept/documenttype/bund/regelungstext-verkuendung"
+                             eId="rdokhauptteil-n1_tldokverweis-n1_verweis-n1"/>
+         </akn:component>
+      </akn:collectionBody>
+   </akn:documentCollection>
+</akn:akomaNtoso>

--- a/backend/src/test/resources/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/VerkuendungenControllerIntegrationTest/amending-law-for-vereinsgesetz-with-two-replacing-expressions/regelungstext-verkuendung-1.xml
+++ b/backend/src/test/resources/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/VerkuendungenControllerIntegrationTest/amending-law-for-vereinsgesetz-with-two-replacing-expressions/regelungstext-verkuendung-1.xml
@@ -41,7 +41,7 @@
                              date="2017-03-15"
                              name="verkuendungsfassung-ausfertigungsdatum"/>
                <akn:FRBRdate eId="meta-n1_ident-n1_frbrwork-n1_frbrdate-n2"
-                             GUID="3db64edd-1f5a-4e25-a004-a5fdcdd8bb10"
+                             GUID="f5d0c25b-ec40-42f6-9f74-efc229137eda"
                              date="2017-03-15"
                              name="verkuendungsfassung-verkuendungsdatum"/>
                <akn:FRBRauthor eId="meta-n1_ident-n1_frbrwork-n1_frbrauthor-n1"
@@ -139,7 +139,7 @@
                               href="#art-z1_abs-z_inhalt-n1_liste-n1_listenelem-n1_text-n1_ändbefehl-n1"/>
                   <akn:destination eId="meta-n1_analysis-n1_activemod-n1_textualmod-n1_destination-n1"
                                    GUID="83a4e169-ec57-4981-b191-84afe42130c8"
-                                   href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-verkuendung-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34.xml"/>
+                                   href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34.xml"/>
                   <akn:force eId="meta-n1_analysis-n1_activemod-n1_textualmod-n1_gelzeitnachw-n1"
                              GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9"
                              period="#meta-n1_geltzeiten-n1_geltungszeitgr-n1"/>
@@ -161,32 +161,22 @@
          <akn:proprietary eId="meta-n1_proprietary-n1"
                           GUID="fe419055-3201-41b1-b096-402eabcbe6a1"
                           source="attributsemantik-noch-undefiniert">
-            <regtxt:legalDocML.de_metadaten xmlns:regtxt="http://MetadatenRegelungstext.LegalDocML.de/1.8.1/">
-               <regtxt:typ>gesetz</regtxt:typ>
-               <regtxt:form>mantelform</regtxt:form>
-            </regtxt:legalDocML.de_metadaten>
             <ris:legalDocML.de_metadaten xmlns:ris="http://MetadatenRIS.LegalDocML.de/1.8.1/">
                <norms:legalDocML.de_metadaten xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/">
                   <norms:geltungszeiten>
-                     <norms:geltungszeit id="fe956ca1-d0d4-41d4-aea2-c1517bd92aed" art="inkraft">2017-03-16</norms:geltungszeit>
-                     <norms:geltungszeit id="3b6d5fc0-76e4-4428-9c6c-3ab824df3199" art="inkraft">2018-04-17</norms:geltungszeit>
+                     <norms:geltungszeit id="0c8d2c11-a70e-4e9d-97f8-0962abc31db8" art="inkraft">2017-03-16</norms:geltungszeit>
                   </norms:geltungszeiten>
                   <norms:zielnorm-references>
                      <norms:zielnorm-reference>
                         <norms:typ>Änderungsvorschrift</norms:typ>
-                        <norms:geltungszeit>fe956ca1-d0d4-41d4-aea2-c1517bd92aed</norms:geltungszeit>
-                        <norms:eid>hauptteil-1_art-1_abs-1_untergl-1_listenelem-1</norms:eid>
-                        <norms:zielnorm>eli/bund/bgbl-1/1964/s593</norms:zielnorm>
-                     </norms:zielnorm-reference>
-                     <norms:zielnorm-reference>
-                        <norms:typ>Änderungsvorschrift</norms:typ>
-                        <norms:geltungszeit>3b6d5fc0-76e4-4428-9c6c-3ab824df3199</norms:geltungszeit>
+                        <norms:geltungszeit>0c8d2c11-a70e-4e9d-97f8-0962abc31db8</norms:geltungszeit>
                         <norms:eid>hauptteil-1_art-1_abs-1_untergl-1_listenelem-2</norms:eid>
                         <norms:zielnorm>eli/bund/bgbl-1/1964/s593</norms:zielnorm>
                      </norms:zielnorm-reference>
                   </norms:zielnorm-references>
                   <norms:amended-norm-expressions>
-                     <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/1964/s593/2017-03-16/1/deu</norms:norm-expression>
+                     <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="true">eli/bund/bgbl-1/1964/s593/2017-03-16/1/deu</norms:norm-expression>
+                     <norms:norm-expression created-by-zeitgrenze="false" created-by-replacing-existing-expression="true">eli/bund/bgbl-1/1964/s593/2024-05-30/1/deu</norms:norm-expression>
                   </norms:amended-norm-expressions>
                </norms:legalDocML.de_metadaten>
             </ris:legalDocML.de_metadaten>
@@ -199,12 +189,16 @@
             <akn:p eId="einleitung-n1_doktitel-n1_text-n1"
                    GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
                <akn:docStage eId="einleitung-n1_doktitel-n1_text-n1_docstadium-n1"
-                             GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
+                             GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf
+                    </akn:docStage>
                <akn:docProponent eId="einleitung-n1_doktitel-n1_text-n1_docproponent-n1"
-                                 GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
-                        Innern</akn:docProponent>
+                                 GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8">des Bundesministeriums des
+                        Innern
+                    </akn:docProponent>
                <akn:docTitle eId="einleitung-n1_doktitel-n1_text-n1_doctitel-n1"
-                             GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
+                             GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur
+                        Änderung des Vereinsgesetzes
+                    </akn:docTitle>
             </akn:p>
          </akn:longTitle>
          <akn:block eId="einleitung-n1_block-n1"
@@ -213,7 +207,8 @@
             <akn:date eId="einleitung-n1_block-n1_datum-n1"
                       GUID="f20d437a-3058-4747-8b8b-9b1e06c17273"
                       refersTo="ausfertigung-datum"
-                      date="1900-01-01">Vom 01.01.1900</akn:date>
+                      date="1900-01-01">Vom 01.01.1900
+                </akn:date>
          </akn:block>
       </akn:preface>
       <!-- Eingangsformel -->
@@ -223,11 +218,13 @@
                       refersTo="eingangsformel"
                       name="attributsemantik-noch-undefiniert">
             <akn:p eId="präambel-n1_formel-n1_text-n1"
-                   GUID="7e0cf2ac-b45a-40b8-8369-c5013ada9f48"> Der <akn:organization eId="präambel-n1_formel-n1_text-n1_org-n1"
+                   GUID="7e0cf2ac-b45a-40b8-8369-c5013ada9f48">Der <akn:organization eId="präambel-n1_formel-n1_text-n1_org-n1"
                                  GUID="05004de4-44d4-4e59-a1ef-5912003a6f36"
                                  refersTo="attributsemantik-noch-undefiniert"
-                                 title="Bundestag">Bundestag</akn:organization> hat
-                    das folgende Gesetz beschlossen:</akn:p>
+                                 title="Bundestag">Bundestag
+                </akn:organization> hat
+                    das folgende Gesetz beschlossen:
+                </akn:p>
          </akn:formula>
       </akn:preamble>
       <akn:body eId="hauptteil-n1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
@@ -237,22 +234,27 @@
                       period="#meta-n1_geltzeiten-n1_geltungszeitgr-n1"
                       refersTo="hauptaenderung">
             <akn:num eId="art-z1_bezeichnung-n1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
-                    Artikel 1</akn:num>
-            <akn:heading eId="art-z1_überschrift-n1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+                    Artikel 1
+                </akn:num>
+            <akn:heading eId="art-z1_überschrift-n1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes
+                </akn:heading>
             <!-- Absatz (1) -->
             <akn:paragraph eId="art-z1_abs-z" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
                <akn:num eId="art-z1_abs-z_bezeichnung-n1"
                         GUID="ef3a32d2-df20-4978-914b-cd6288872208">
                     </akn:num>
-               <akn:content GUID="7fe2345e-ecbc-4650-8561-c36909c53b35"
+               <akn:content GUID="7d980381-f4ef-4c36-a118-f640f0e79ff8"
                             eId="art-z1_abs-z_inhalt-n1">
                   <akn:blockList eId="art-z1_abs-z_inhalt-n1_liste-n1"
                                  GUID="41675622-ed62-46e3-869f-94d99908b010">
                      <akn:listIntroduction eId="art-z1_abs-z_inhalt-n1_liste-n1_listeneing-n1"
                                            GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
-                      Das <akn:affectedDocument eId="art-z1_abs-z_inhalt-n1_liste-n1_listeneing-n1_bezugsdoc-n1"
+                     Das <akn:affectedDocument eId="art-z1_abs-z_inhalt-n1_liste-n1_listeneing-n1_bezugsdoc-n1"
                                               GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
-                                              href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-verkuendung-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:
+                                              href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1">Vereinsgesetz vom
+                                5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden
+                                ist</akn:affectedDocument>, wird wie folgt geändert:
+
                   </akn:listIntroduction>
                      <!-- Nummer 1 wurde entfernt -->
                      <!-- Nummer 2 -->
@@ -260,20 +262,26 @@
                                GUID="b5fa1383-f26a-4904-a638-f48711fbcf2d">
                         <akn:num eId="art-z1_abs-z_inhalt-n1_liste-n1_listenelem-n1_bezeichnung-n1"
                                  GUID="6f0f92b3-1a51-440c-9137-b44ab9d990ac">
-                                2.</akn:num>
+                                2.
+                            </akn:num>
                         <akn:p eId="art-z1_abs-z_inhalt-n1_liste-n1_listenelem-n1_text-n1"
                                GUID="db3fbe0f-b758-4cc4-b528-a723cacad94a">
                            <akn:mod eId="art-z1_abs-z_inhalt-n1_liste-n1_listenelem-n1_text-n1_ändbefehl-n1"
                                     GUID="148c2f06-6e33-4af8-9f4a-3da67c888510"
                                     refersTo="aenderungsbefehl-ersetzen">In <akn:ref eId="art-z1_abs-z_inhalt-n1_liste-n1_listenelem-n1_text-n1_ändbefehl-n1_ref-n1"
                                        GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206"
-                                       href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-verkuendung-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34.xml">§ 20 Absatz 1 Satz 2</akn:ref> wird die Angabe <akn:quotedText eId="art-z1_abs-z_inhalt-n1_liste-n1_listenelem-n1_text-n1_ändbefehl-n1_quottext-n1"
+                                       href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34.xml">
+                                        § 20 Absatz 1 Satz 2
+                                    </akn:ref> wird die Angabe <akn:quotedText eId="art-z1_abs-z_inhalt-n1_liste-n1_listenelem-n1_text-n1_ändbefehl-n1_quottext-n1"
                                               GUID="694459c4-ef66-4f87-bb78-a332054a2216"
                                               startQuote="„"
-                                              endQuote="“">§ 9 Abs. 1 Satz 2, Abs. 2</akn:quotedText> durch die Wörter <akn:quotedText eId="art-z1_abs-z_inhalt-n1_liste-n1_listenelem-n1_text-n1_ändbefehl-n1_quottext-n2"
+                                              endQuote="“">§ 9 Abs. 1 Satz 2, Abs. 2
+                                    </akn:quotedText> durch die Wörter <akn:quotedText eId="art-z1_abs-z_inhalt-n1_liste-n1_listenelem-n1_text-n1_ändbefehl-n1_quottext-n2"
                                               GUID="dd25bdb6-4ef4-4ef5-808c-27579b6ae196"
                                               startQuote="„"
-                                              endQuote="“">§ 9 Absatz 1 Satz 2, Absatz 2 oder 3</akn:quotedText> ersetzt.</akn:mod>
+                                              endQuote="“">§ 9 Absatz 1 Satz 2, Absatz 2 oder 3
+                                    </akn:quotedText> ersetzt.
+                                    </akn:mod>
                         </akn:p>
                      </akn:item>
                   </akn:blockList>
@@ -286,8 +294,10 @@
                       period="#meta-n1_geltzeiten-n1_geltungszeitgr-n1"
                       refersTo="geltungszeitregel">
             <akn:num eId="art-z3_bezeichnung-n1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
-                    Artikel 3</akn:num>
-            <akn:heading eId="art-z3_überschrift-n1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+                    Artikel 3
+                </akn:num>
+            <akn:heading eId="art-z3_überschrift-n1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten
+                </akn:heading>
             <!-- Absatz (1) -->
             <akn:paragraph eId="art-z3_abs-z" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
                <akn:num eId="art-z3_abs-z_bezeichnung-n1"
@@ -296,11 +306,13 @@
                <akn:content eId="art-z3_abs-z_inhalt-n1"
                             GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
                   <akn:p eId="art-z3_abs-z_inhalt-n1_text-n1"
-                         GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="art-z3_abs-z_inhalt-n1_text-n1_datum-n1"
+                         GUID="52406e40-b866-410c-b097-af69e6248f58">Dieses Gesetz tritt <akn:date eId="art-z3_abs-z_inhalt-n1_text-n1_datum-n1"
                                GUID="2ee89811-5368-46e0-acf8-a598506cc956"
                                date="2017-03-16"
                                refersTo="inkrafttreten-datum">am Tag
-                            nach der Verkündung</akn:date> in Kraft. </akn:p>
+                            nach der Verkündung
+                        </akn:date> in Kraft.
+                        </akn:p>
                </akn:content>
             </akn:paragraph>
          </akn:article>
@@ -312,7 +324,8 @@
                       name="attributsemantik-noch-undefiniert"
                       refersTo="schlussformel">
             <akn:p eId="schluss-n1_formel-n1_text-n1"
-                   GUID="1354658b-fdb7-46b4-96e2-e194b16ee103">Das vorstehende Gesetz ist hiermit verkündet.</akn:p>
+                   GUID="1354658b-fdb7-46b4-96e2-e194b16ee103">Das vorstehende Gesetz ist hiermit verkündet.
+                </akn:p>
          </akn:formula>
          <akn:blockContainer eId="schluss-n1_blockcontainer-n1"
                              GUID="35e11af5-ff7c-4422-af51-87cff3cc7ceb">
@@ -320,57 +333,67 @@
                    GUID="b55d6230-d71c-49d5-bf86-dab1db53ba6f">
                <akn:location eId="schluss-n1_blockcontainer-n1_text-n1_ort-n1"
                              GUID="19ffc7e1-add6-40a4-b9af-2f0927e46e9c"
-                             refersTo="attributsemantik-noch-undefiniert">Bonn</akn:location>, den <akn:date eId="schluss-n1_blockcontainer-n1_text-n1_datum-n1"
+                             refersTo="attributsemantik-noch-undefiniert">Bonn</akn:location>, den
+                    <akn:date eId="schluss-n1_blockcontainer-n1_text-n1_datum-n1"
                          GUID="34cf44aa-73a4-4dee-9827-4d890da7aac7"
                          refersTo="ausfertigung-datum"
-                         date="1964-08-05">5. August 1964</akn:date>
+                         date="1964-08-05">5. August 1964
+                    </akn:date>
             </akn:p>
-            <akn:p GUID="b21dcf6a-3dc0-4add-950d-344a06bae0d7"
+            <akn:p GUID="1cc3f2d2-608b-441e-a165-b75e4411c8f9"
                    eId="schluss-n1_blockcontainer-n1_text-n2">
                <akn:signature eId="schluss-n1_blockcontainer-n1_text-n2_signatur-n1"
                               GUID="b092cd1d-2f77-4fe6-a63d-5bcabeb410ad">
                   <akn:role eId="schluss-n1_blockcontainer-n1_text-n2_signatur-n1_fktbez-n1"
                             GUID="1cd9ff70-4004-48dc-8c76-7fb295852717"
-                            refersTo="attributsemantik-noch-undefiniert">Der Bundespräsident</akn:role>
+                            refersTo="attributsemantik-noch-undefiniert">Der Bundespräsident
+                    </akn:role>
                   <akn:person eId="schluss-n1_blockcontainer-n1_text-n2_signatur-n1_person-n1"
                               GUID="3d296b9f-6b7d-4c34-a091-23291a39917a"
-                              refersTo="attributsemantik-noch-undefiniert">Lübke</akn:person>
+                              refersTo="attributsemantik-noch-undefiniert">Lübke
+                    </akn:person>
                </akn:signature>
             </akn:p>
-            <akn:p GUID="7598fda7-4b76-4fd7-af4f-d77226c86640"
+            <akn:p GUID="e080439c-892a-48df-b742-bf0baf5ae112"
                    eId="schluss-n1_blockcontainer-n1_text-n3">
                <akn:signature eId="schluss-n1_blockcontainer-n1_text-n3_signatur-n1"
                               GUID="2c6c0dc9-32b6-46ee-a1fa-9b8a0bc7c193">
                   <akn:role eId="schluss-n1_blockcontainer-n1_text-n3_signatur-n1_fktbez-n1"
                             GUID="bea9417f-96d8-4a0b-a923-4541ed04b921"
-                            refersTo="attributsemantik-noch-undefiniert">Der Stellvertreter des Bundeskanzlers</akn:role>
+                            refersTo="attributsemantik-noch-undefiniert">Der Stellvertreter des Bundeskanzlers
+                    </akn:role>
                   <akn:person eId="schluss-n1_blockcontainer-n1_text-n3_signatur-n1_person-n1"
                               GUID="33105c66-afdb-4a8d-b397-59c357bf2713"
-                              refersTo="attributsemantik-noch-undefiniert">Mende</akn:person>
+                              refersTo="attributsemantik-noch-undefiniert">Mende
+                    </akn:person>
                </akn:signature>
             </akn:p>
-            <akn:p GUID="5614e06c-860c-447e-968f-876954ab1c0f"
+            <akn:p GUID="ac0e8224-9b32-46ce-963a-fe8e41eb21ff"
                    eId="schluss-n1_blockcontainer-n1_text-n4">
                <akn:signature eId="schluss-n1_blockcontainer-n1_text-n4_signatur-n1"
                               GUID="669a4ce1-2782-4623-8af7-83e7bcf0917a">
                   <akn:role eId="schluss-n1_blockcontainer-n1_text-n4_signatur-n1_fktbez-n1"
                             GUID="0732a41f-abe1-4774-b6c0-b4934082ca2c"
-                            refersTo="attributsemantik-noch-undefiniert">Der Bundesminister des Innern</akn:role>
+                            refersTo="attributsemantik-noch-undefiniert">Der Bundesminister des Innern
+                    </akn:role>
                   <akn:person eId="schluss-n1_blockcontainer-n1_text-n4_signatur-n1_person-n1"
                               GUID="a8095a73-f0f1-44ec-8c4e-92bc59ff44a7"
-                              refersTo="attributsemantik-noch-undefiniert">Hermann Höcherl</akn:person>
+                              refersTo="attributsemantik-noch-undefiniert">Hermann Höcherl
+                    </akn:person>
                </akn:signature>
             </akn:p>
-            <akn:p GUID="8b01eabf-470d-4c03-8041-77c513cd017b"
+            <akn:p GUID="6826fd98-b367-4d3d-84f0-8920b2f83919"
                    eId="schluss-n1_blockcontainer-n1_text-n5">
                <akn:signature eId="schluss-n1_blockcontainer-n1_text-n5_signatur-n1"
                               GUID="22a6ce3d-3ae9-4189-bfed-d544efe7e50b">
                   <akn:role eId="schluss-n1_blockcontainer-n1_text-n5_signatur-n1_fktbez-n1"
                             GUID="cacb2add-a766-4f2e-ac4a-7b437b226d0d"
-                            refersTo="attributsemantik-noch-undefiniert">Der Bundesminister der Justiz</akn:role>
+                            refersTo="attributsemantik-noch-undefiniert">Der Bundesminister der Justiz
+                    </akn:role>
                   <akn:person eId="schluss-n1_blockcontainer-n1_text-n5_signatur-n1_person-n1"
                               GUID="44bb454b-33df-4ee6-a29a-048d7b7f1148"
-                              refersTo="attributsemantik-noch-undefiniert">Bucher</akn:person>
+                              refersTo="attributsemantik-noch-undefiniert">Bucher
+                    </akn:person>
                </akn:signature>
             </akn:p>
          </akn:blockContainer>

--- a/backend/src/test/resources/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ZeitgrenzeControllerIntegrationTest/norm-with-only-unused-geltungszeit/regelungstext-verkuendung-1.xml
+++ b/backend/src/test/resources/de/bund/digitalservice/ris/norms/integration/adapter/input/restapi/ZeitgrenzeControllerIntegrationTest/norm-with-only-unused-geltungszeit/regelungstext-verkuendung-1.xml
@@ -171,7 +171,7 @@
                      <norms:geltungszeit id="gz-1" art="inkraft">2017-03-16</norms:geltungszeit>
                   </norms:geltungszeiten>
                   <norms:amended-norm-expressions>
-                     <norms:norm-expression>eli/bund/bgbl-1/1964/s593/2017-03-16/1/deu</norms:norm-expression>
+                     <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/1964/s593/2017-03-16/1/deu</norms:norm-expression>
                   </norms:amended-norm-expressions>
                </norms:legalDocML.de_metadaten>
             </ris:legalDocML.de_metadaten>

--- a/frontend/e2e/testData/aenderungsgesetz-abgabe/regelungstext-verkuendung-1.xml
+++ b/frontend/e2e/testData/aenderungsgesetz-abgabe/regelungstext-verkuendung-1.xml
@@ -186,8 +186,8 @@
                      </norms:zielnorm-reference>
                   </norms:zielnorm-references>
                   <norms:amended-norm-expressions>
-                     <norms:norm-expression>eli/bund/bgbl-1/1964/1234/1964-09-21/1/deu</norms:norm-expression>
-                     <norms:norm-expression>eli/bund/bgbl-1/1964/1234/2024-01-01/1/deu</norms:norm-expression>
+                     <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/1964/1234/1964-09-21/1/deu</norms:norm-expression>
+                     <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/1964/1234/2024-01-01/1/deu</norms:norm-expression>
                   </norms:amended-norm-expressions>
                </norms:legalDocML.de_metadaten>
             </ris:legalDocML.de_metadaten>

--- a/frontend/e2e/testData/aenderungsgesetz-with-amended-norm-expressions/regelungstext-verkuendung-1.xml
+++ b/frontend/e2e/testData/aenderungsgesetz-with-amended-norm-expressions/regelungstext-verkuendung-1.xml
@@ -186,8 +186,8 @@
                      </norms:zielnorm-reference>
                   </norms:zielnorm-references>
                   <norms:amended-norm-expressions>
-                     <norms:norm-expression>eli/bund/bgbl-1/1964/321/2017-03-16/1/deu</norms:norm-expression>
-                     <norms:norm-expression>eli/bund/bgbl-1/1964/321/2017-05-01/1/deu</norms:norm-expression>
+                     <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/1964/321/2017-03-16/1/deu</norms:norm-expression>
+                     <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/1964/321/2017-05-01/1/deu</norms:norm-expression>
                   </norms:amended-norm-expressions>
                </norms:legalDocML.de_metadaten>
             </ris:legalDocML.de_metadaten>

--- a/frontend/e2e/testData/aenderungsgesetz-with-orphaned-amended-norm-expressions/regelungstext-verkuendung-1.xml
+++ b/frontend/e2e/testData/aenderungsgesetz-with-orphaned-amended-norm-expressions/regelungstext-verkuendung-1.xml
@@ -175,9 +175,9 @@
                      </norms:zielnorm-reference>
                   </norms:zielnorm-references>
                   <norms:amended-norm-expressions>
-                     <norms:norm-expression>eli/bund/bgbl-1/1964/654/2017-01-01/1/deu</norms:norm-expression>
-                     <norms:norm-expression>eli/bund/bgbl-1/1964/654/2017-03-16/1/deu</norms:norm-expression>
-                     <norms:norm-expression>eli/bund/bgbl-1/1964/654/2017-05-01/1/deu</norms:norm-expression>
+                     <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/1964/654/2017-01-01/1/deu</norms:norm-expression>
+                     <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/1964/654/2017-03-16/1/deu</norms:norm-expression>
+                     <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/1964/654/2017-05-01/1/deu</norms:norm-expression>
                   </norms:amended-norm-expressions>
                </norms:legalDocML.de_metadaten>
             </ris:legalDocML.de_metadaten>


### PR DESCRIPTION
So important stuff:

- New domain entity `NormExpression` to represent now the node that has not only text content but got the two new mandatory attributes
- Domain entity `AmendedNormExpressions` does not implement `AbstractSet` anymore (nor it implements `AbstractCollection`) because all add/remove/etc operations are based solely on the expression eli and do not care about the attributes
- The important stuff is happening in the `NormService`:
   - No more separation between retrieving the expressions before the first geltungszeit and the ones after and including it. We just take all existing expressions and check if the point-in-time is before or after/including. Needed for identifying the possible orphans in the before part
   - Method strongly reduced in complexity by extracting into private helper methods, separating two main branches (`handleExistingExpression` and `handleGeltungszeit`)
   - When handling existing expressions we now also calculate if it was created by the system (so a replacing one) or not using the helper function `isSystemExpression`
   - When handling geltungszeiten, we now differentiate between retrieving an already previewed `SYSTEM` and a `THIS_VERKUENDUNG` expression. For the first we replace it with `THIS_VERKUENDUNG` and the second helps us to know if the expression had already been created (override.)