### PR TITLE
Disable two schematron rules

### DIFF
--- a/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/LdmlDeValidatorTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/norms/application/service/LdmlDeValidatorTest.java
@@ -256,5 +256,18 @@ class LdmlDeValidatorTest {
       // When // Then
       assertThatCode(() -> ldmlDeValidator.validateSchematron(norm)).doesNotThrowAnyException();
     }
+
+    @Test
+    void itHasNoSchematronErrorsBecauseWithinDisabledList() {
+      // Given
+      Norm norm = Fixtures.loadNormFromDisk(
+        LdmlDeValidatorTest.class,
+        "vereinsgesetz-disabled-rules",
+        true
+      );
+
+      // When // Then
+      assertThatCode(() -> ldmlDeValidator.validateSchematron(norm)).doesNotThrowAnyException();
+    }
   }
 }

--- a/backend/src/test/resources/de/bund/digitalservice/ris/norms/application/service/LdmlDeValidatorTest/vereinsgesetz-disabled-rules/rechtsetzungsdokument-1.xml
+++ b/backend/src/test/resources/de/bund/digitalservice/ris/norms/application/service/LdmlDeValidatorTest/vereinsgesetz-disabled-rules/rechtsetzungsdokument-1.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   This is a modified example from the LDML.de specification.
+-->
+<!--
+	##################################################################################
+	Projekt E-Gesetzgebung
+	Nicht-normative Exemplifikation für den Standard LegalDocML.de 1.6 (Dezember 2023)
+
+	2023 Copyright (C) 2021-2023 Bundesministerium des Innern und für Heimat,
+	Referat DG II 6, Maßnahmen Enterprise Resource Management und Elektronische
+	Verwaltungsarbeit
+
+	Veröffentlicht unter der Lizenz CC-BY-3.0 (Creative Commons Namensnennung 3.0)
+	##################################################################################
+-->
+<?xml-model href="/LegalDocML.de/1.8.1/schema/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.8.1/"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://Inhaltsdaten.LegalDocML.de/1.8.1/ /LegalDocML.de/1.8.1/schema/legalDocML.de-regelungstextverkuendungsfassung.xsd http://MetadatenBundesregierung.LegalDocML.de/1.8.1/ /LegalDocML.de/1.8.1/schema/legalDocML.de-metadaten-bundesregierung.xsd http://MetadatenRegelungstext.LegalDocML.de/1.8.1/ /LegalDocML.de/1.8.1/schema/legalDocML.de-metadaten-regelungstext.xsd http://MetadatenRIS.LegalDocML.de/1.8.1/ /LegalDocML.de/ris-norms-ldml-schema-extensions/1.8.1/legalDocML.de-metadaten-ris.xsd http://MetadatenMods.LegalDocML.de/1.8.1/ /LegalDocML.de/ris-norms-ldml-schema-extensions/1.8.1/norms-application-only-metadata.xsd">
+   <akn:documentCollection name="/akn/ontology/de/concept/documenttype/bund/rechtsetzungsdokument">
+      <akn:meta GUID="309bd4f6-72fe-45c5-a8d7-3b6f90e99b73" eId="meta-n1">
+         <akn:identification eId="meta-n1_ident-n1"
+                             GUID="62d112b3-8ca4-4094-9fe3-e1ca2b325d02"
+                             source="attributsemantik-noch-undefiniert">
+            <akn:FRBRWork eId="meta-n1_ident-n1_frbrwork-n1"
+                          GUID="4dd25350-701b-441b-97db-50d260694279">
+               <akn:FRBRthis eId="meta-n1_ident-n1_frbrwork-n1_frbrthis-n1"
+                             GUID="ac0ac716-7879-4c27-b545-3881d68594d4"
+                             value="eli/bund/bgbl-1/2017/s419/rechtsetzungsdokument-1"/>
+               <akn:FRBRuri eId="meta-n1_ident-n1_frbrwork-n1_frbruri-n1"
+                            GUID="f286a55a-5014-4a4c-833e-2d2770a6ee51"
+                            value="eli/bund/bgbl-1/2017/s419"/>
+               <akn:FRBRalias eId="meta-n1_ident-n1_frbrwork-n1_frbralias-n1"
+                              GUID="0a1be4f5-8e54-44b4-af54-2b7e4d37f540"
+                              name="übergreifende-id"
+                              value="c53036e4-14ac-420f-b01a-bae05a0a9756"/>
+               <akn:FRBRdate eId="meta-n1_ident-n1_frbrwork-n1_frbrdate-n1"
+                             GUID="b9671aa5-edd9-4e35-be3f-0f5f5f7f1689"
+                             date="2017-03-15"
+                             name="verkuendungsfassung-ausfertigungsdatum"/>
+               <akn:FRBRdate eId="meta-n1_ident-n1_frbrwork-n1_frbrdate-n2"
+                             GUID="6a9975d6-7e57-4dda-afa3-b5e7d53b6cca"
+                             date="2017-03-15"
+                             name="verkuendungsfassung-verkuendungsdatum"/>
+               <akn:FRBRauthor eId="meta-n1_ident-n1_frbrwork-n1_frbrauthor-n1"
+                               GUID="56f7946a-e0e8-44ca-b613-1e936b2a71fe"
+                               href="recht.bund.de/institution/bundesregierung"/>
+               <akn:FRBRcountry eId="meta-n1_ident-n1_frbrwork-n1_frbrcountry-n1"
+                                GUID="164a4ffc-a0af-4c06-931b-b9b038b66635"
+                                value="de"/>
+               <akn:FRBRnumber eId="meta-n1_ident-n1_frbrwork-n1_frbrnumber-n1"
+                               GUID="8c28697d-b927-4ed6-a646-0203532dffa1"
+                               value="s419"/>
+               <akn:FRBRname eId="meta-n1_ident-n1_frbrwork-n1_frbrname-n1"
+                             GUID="9c93a283-6251-43b3-b24d-4d69f3a00d0f"
+                             value="bgbl-1"/>
+               <akn:FRBRsubtype eId="meta-n1_ident-n1_frbrwork-n1_frbrsubtype-n1"
+                                GUID="6bf600d2-50aa-4477-b256-f4c0ea2ff348"
+                                value="rechtsetzungsdokument-1"/>
+            </akn:FRBRWork>
+            <akn:FRBRExpression eId="meta-n1_ident-n1_frbrexpression-n1"
+                                GUID="71b23682-f719-4493-8be8-969a2828a7c4">
+               <akn:FRBRthis eId="meta-n1_ident-n1_frbrexpression-n1_frbrthis-n1"
+                             GUID="efb0e716-cd4c-480f-854c-f8e115684834"
+                             value="eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/rechtsetzungsdokument-1"/>
+               <akn:FRBRuri eId="meta-n1_ident-n1_frbrexpression-n1_frbruri-n1"
+                            GUID="248b2378-8ebe-4006-964d-d9225443ac11"
+                            value="eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu"/>
+               <akn:FRBRalias eId="meta-n1_ident-n1_frbrexpression-n1_frbralias-n1"
+                              GUID="4e4bcc4e-646b-4f5d-918f-c8d0a589f8b4"
+                              name="aktuelle-version-id"
+                              value="e47a5106-c153-4da4-8d94-8cc2ebf9b232"/>
+               <akn:FRBRalias eId="meta-n1_ident-n1_frbrexpression-n1_frbralias-n2"
+                              GUID="8bb6800a-feee-4617-beb7-d382927eb230"
+                              name="nachfolgende-version-id"
+                              value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+               <akn:FRBRauthor eId="meta-n1_ident-n1_frbrexpression-n1_frbrauthor-n1"
+                               GUID="55fea7de-7908-428b-8c8f-879e03cb9e37"
+                               href="recht.bund.de/institution/bundesregierung"/>
+               <akn:FRBRdate eId="meta-n1_ident-n1_frbrexpression-n1_frbrdate-n1"
+                             GUID="78a31f84-8a2e-4ece-a108-5c7fd3b53422"
+                             date="2017-03-15"
+                             name="verkuendung"/>
+               <akn:FRBRlanguage eId="meta-n1_ident-n1_frbrexpression-n1_frbrlanguage-n1"
+                                 GUID="a4be9e53-961c-43ca-b58c-aeb4b14d7dd7"
+                                 language="deu"/>
+               <akn:FRBRversionNumber eId="meta-n1_ident-n1_frbrexpression-n1_frbrversionnumber-n1"
+                                      GUID="9e6d8097-021b-4bbc-b68d-02b8b316c8f2"
+                                      value="1"/>
+            </akn:FRBRExpression>
+            <akn:FRBRManifestation eId="meta-n1_ident-n1_frbrmanifestation-n1"
+                                   GUID="7ccaed34-f47b-4566-ab38-e4c3cfbfa35e">
+               <akn:FRBRthis eId="meta-n1_ident-n1_frbrmanifestation-n1_frbrthis-n1"
+                             GUID="7ced3f72-2ad7-44b3-947b-6013233945b6"
+                             value="eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/2022-08-23/rechtsetzungsdokument-1.xml"/>
+               <akn:FRBRuri eId="meta-n1_ident-n1_frbrmanifestation-n1_frbruri-n1"
+                            GUID="31272987-58a8-4b80-8671-c041713211ea"
+                            value="eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/2022-08-23/rechtsetzungsdokument-1.xml"/>
+               <akn:FRBRdate eId="meta-n1_ident-n1_frbrmanifestation-n1_frbrdate-n1"
+                             GUID="ecb6c16b-2df2-4975-b87f-3e98ed0f5ed7"
+                             date="2022-08-23"
+                             name="generierung"/>
+               <akn:FRBRauthor eId="meta-n1_ident-n1_frbrmanifestation-n1_frbrauthor-n1"
+                               GUID="28cafa5b-f49b-4714-84d1-60feb65f37e9"
+                               href="recht.bund.de"/>
+               <akn:FRBRformat eId="meta-n1_ident-n1_frbrmanifestation-n1_frbrformat-n1"
+                               GUID="95257d51-eaf3-46a0-93f2-f9bdda93965d"
+                               value="xml"/>
+            </akn:FRBRManifestation>
+         </akn:identification>
+         <akn:proprietary GUID="b1d0a5cb-c0e5-4ae6-ab33-f898347fb0e1"
+                          source="attributsemantik-noch-undefiniert"
+                          eId="meta-n1_proprietary-n1">
+            <redok:legalDocML.de_metadaten xmlns:redok="http://MetadatenRechtsetzungsdokument.LegalDocML.de/1.8.1/">
+               <redok:initiant>bundesregierung</redok:initiant>
+               <redok:bearbeitendeInstitution>bundesregierung</redok:bearbeitendeInstitution>
+               <redok:fna>nicht-vorhanden</redok:fna>
+               <redok:gesta>nicht-vorhanden</redok:gesta>
+            </redok:legalDocML.de_metadaten>
+            <breg:legalDocML.de_metadaten xmlns:breg="http://MetadatenBundesregierung.LegalDocML.de/1.8.1/">
+               <breg:federfuehrung>
+                  <breg:federfuehrend ab="2022-12-01" bis="unbestimmt">Bundesministerium des Innern und für Heimat</breg:federfuehrend>
+                  <breg:federfuehrend ab="2002-10-01" bis="2022-11-30">Bundesministerium der Justiz</breg:federfuehrend>
+               </breg:federfuehrung>
+            </breg:legalDocML.de_metadaten>
+         </akn:proprietary>
+      </akn:meta>
+      <akn:collectionBody GUID="119926af-9931-42a8-9415-e9fa5b8ea5a0" eId="rdokhauptteil-n1">
+         <akn:component GUID="25814878-4ada-4320-a470-8785648491b2"
+                        eId="rdokhauptteil-n1_tldokverweis-n1">
+            <akn:documentRef GUID="9347af12-9c74-4229-b549-a2384e240dad"
+                             href="regelungstext-verkuendung-1.xml"
+                             showAs="/akn/ontology/de/concept/documenttype/bund/regelungstext-verkuendung"
+                             eId="rdokhauptteil-n1_tldokverweis-n1_verweis-n1"/>
+         </akn:component>
+      </akn:collectionBody>
+   </akn:documentCollection>
+</akn:akomaNtoso>

--- a/backend/src/test/resources/de/bund/digitalservice/ris/norms/application/service/LdmlDeValidatorTest/vereinsgesetz-disabled-rules/regelungstext-verkuendung-1.xml
+++ b/backend/src/test/resources/de/bund/digitalservice/ris/norms/application/service/LdmlDeValidatorTest/vereinsgesetz-disabled-rules/regelungstext-verkuendung-1.xml
@@ -1,0 +1,365 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   This is a modified example from the LDML.de specification.
+-->
+<!--
+	##################################################################################
+	Projekt E-Gesetzgebung
+	Nicht-normative Exemplifikation für den Standard LegalDocML.de 1.6 (Dezember 2023)
+
+	2023 Copyright (C) 2021-2023 Bundesministerium des Innern und für Heimat,
+	Referat DG II 6, Maßnahmen Enterprise Resource Management und Elektronische
+	Verwaltungsarbeit
+
+	Veröffentlicht unter der Lizenz CC-BY-3.0 (Creative Commons Namensnennung 3.0)
+	##################################################################################
+-->
+<?xml-model href="/LegalDocML.de/1.8.1/schema/legalDocML.de.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<akn:akomaNtoso xmlns:akn="http://Inhaltsdaten.LegalDocML.de/1.8.1/"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://Inhaltsdaten.LegalDocML.de/1.8.1/ /LegalDocML.de/1.8.1/schema/legalDocML.de-regelungstextverkuendungsfassung.xsd http://MetadatenBundesregierung.LegalDocML.de/1.8.1/ /LegalDocML.de/1.8.1/schema/legalDocML.de-metadaten-bundesregierung.xsd http://MetadatenRegelungstext.LegalDocML.de/1.8.1/ /LegalDocML.de/1.8.1/schema/legalDocML.de-metadaten-regelungstext.xsd http://MetadatenRIS.LegalDocML.de/1.8.1/ /LegalDocML.de/ris-norms-ldml-schema-extensions/1.8.1/legalDocML.de-metadaten-ris.xsd http://MetadatenMods.LegalDocML.de/1.8.1/ /LegalDocML.de/ris-norms-ldml-schema-extensions/1.8.1/norms-application-only-metadata.xsd">
+   <akn:act name="/akn/ontology/de/concept/documenttype/bund/regelungstext-verkuendung">
+        <!-- Metadaten -->
+      <akn:meta eId="meta-n1" GUID="7e5837c8-b967-45be-924b-c95956c4aa94">
+         <akn:identification eId="meta-n1_ident-n1"
+                             GUID="be8ecb75-0f1a-4209-b3a4-17d55bdffb47"
+                             source="attributsemantik-noch-undefiniert">
+            <akn:FRBRWork eId="meta-n1_ident-n1_frbrwork-n1"
+                          GUID="d4f77434-7c1f-4496-917a-262a82a7070c">
+               <akn:FRBRthis eId="meta-n1_ident-n1_frbrwork-n1_frbrthis-n1"
+                             GUID="ad47b5be-0012-447a-90db-71438b38650e"
+                             value="eli/bund/bgbl-1/2017/s419/regelungstext-verkuendung-1"/>
+               <akn:FRBRuri eId="meta-n1_ident-n1_frbrwork-n1_frbruri-n1"
+                            GUID="a739e012-fe1d-4411-91b8-58e0de76fc28"
+                            value="eli/bund/bgbl-1/2017/s419"/>
+               <akn:FRBRalias eId="meta-n1_ident-n1_frbrwork-n1_frbralias-n1"
+                              GUID="42ae272d-4b4a-4d25-9965-79e76c741b5b"
+                              name="übergreifende-id"
+                              value="c53036e4-14ac-420f-b01a-bae05a0a9756"/>
+               <akn:FRBRdate eId="meta-n1_ident-n1_frbrwork-n1_frbrdate-n1"
+                             GUID="525ff48c-a66e-45f6-b036-884935f7ba7d"
+                             date="2017-03-15"
+                             name="verkuendungsfassung-ausfertigungsdatum"/>
+               <akn:FRBRdate eId="meta-n1_ident-n1_frbrwork-n1_frbrdate-n2"
+                             GUID="d9173375-8088-4792-ae3a-770097936b45"
+                             date="2017-03-15"
+                             name="verkuendungsfassung-verkuendungsdatum"/>
+               <akn:FRBRauthor eId="meta-n1_ident-n1_frbrwork-n1_frbrauthor-n1"
+                               GUID="27fa3047-26e1-4c59-8701-76dd34043d71"
+                               href="recht.bund.de/institution/bundesregierung"/>
+               <akn:FRBRcountry eId="meta-n1_ident-n1_frbrwork-n1_frbrcountry-n1"
+                                GUID="fa3d22d4-4f01-4486-9d45-c1edcf50729e"
+                                value="de"/>
+               <akn:FRBRnumber eId="meta-n1_ident-n1_frbrwork-n1_frbrnumber-n1"
+                               GUID="565c2f06-c2c9-4a27-aeb3-ca34199ce08c"
+                               value="s419"/>
+               <akn:FRBRname eId="meta-n1_ident-n1_frbrwork-n1_frbrname-n1"
+                             GUID="7219aecc-e1eb-49a1-abf5-bba8a8be721c"
+                             value="bgbl-1"/>
+               <akn:FRBRsubtype eId="meta-n1_ident-n1_frbrwork-n1_frbrsubtype-n1"
+                                GUID="c5bc9d46-575f-4808-90e8-a354a227d701"
+                                value="regelungstext-verkuendung-1"/>
+            </akn:FRBRWork>
+            <akn:FRBRExpression eId="meta-n1_ident-n1_frbrexpression-n1"
+                                GUID="4c69a6d2-8988-4581-bfa9-df9e8e24f321">
+               <akn:FRBRthis eId="meta-n1_ident-n1_frbrexpression-n1_frbrthis-n1"
+                             GUID="f3805314-bbb6-4def-b82b-8b7f0b126197"
+                             value="eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/regelungstext-verkuendung-1"/>
+               <akn:FRBRuri eId="meta-n1_ident-n1_frbrexpression-n1_frbruri-n1"
+                            GUID="5a2c4542-56cc-4c70-8b80-e2041b5b75e1"
+                            value="eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu"/>
+               <akn:FRBRalias eId="meta-n1_ident-n1_frbrexpression-n1_frbralias-n1"
+                              GUID="6c99101d-6bca-41ae-9794-250bd096fead"
+                              name="aktuelle-version-id"
+                              value="e47a5106-c153-4da4-8d94-8cc2ebf9b232"/>
+               <akn:FRBRalias eId="meta-n1_ident-n1_frbrexpression-n1_frbralias-n2"
+                              GUID="2c2df2b6-31ce-4876-9fbb-fe38102aeb37"
+                              name="nachfolgende-version-id"
+                              value="931577e5-66ba-48f5-a6eb-db40bcfd6b87"/>
+               <akn:FRBRauthor eId="meta-n1_ident-n1_frbrexpression-n1_frbrauthor-n1"
+                               GUID="9063f5e7-c3c5-4ab4-8e15-459b11d7a9f2"
+                               href="recht.bund.de/institution/bundesregierung"/>
+               <akn:FRBRdate eId="meta-n1_ident-n1_frbrexpression-n1_frbrdate-n1"
+                             GUID="1e8f33a8-d124-48c3-a864-7968701816ee"
+                             date="2017-03-15"
+                             name="verkuendung"/>
+               <akn:FRBRlanguage eId="meta-n1_ident-n1_frbrexpression-n1_frbrlanguage-n1"
+                                 GUID="9c61581b-ce24-4589-8db8-533262149b90"
+                                 language="deu"/>
+               <akn:FRBRversionNumber eId="meta-n1_ident-n1_frbrexpression-n1_frbrversionnumber-n1"
+                                      GUID="de475d52-7263-4c05-8014-e92a7785b784"
+                                      value="1"/>
+            </akn:FRBRExpression>
+            <akn:FRBRManifestation eId="meta-n1_ident-n1_frbrmanifestation-n1"
+                                   GUID="ea61dfec-d89c-442a-9f6d-cb65d8ed2dc3">
+               <akn:FRBRthis eId="meta-n1_ident-n1_frbrmanifestation-n1_frbrthis-n1"
+                             GUID="d74e4be8-c15d-4a9f-8ae6-781e522dc7a4"
+                             value="eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/2022-08-23/regelungstext-verkuendung-1.xml"/>
+               <akn:FRBRuri eId="meta-n1_ident-n1_frbrmanifestation-n1_frbruri-n1"
+                            GUID="6e12c94c-f206-4144-bedf-dcab30867f4c"
+                            value="eli/bund/bgbl-1/2017/s419/2017-03-15/1/deu/2022-08-23/regelungstext-verkuendung-1.xml"/>
+               <akn:FRBRdate eId="meta-n1_ident-n1_frbrmanifestation-n1_frbrdate-n1"
+                             GUID="791a8124-d12e-45e1-9c80-5f0438e4d046"
+                             date="2022-08-23"
+                             name="generierung"/>
+               <akn:FRBRauthor eId="meta-n1_ident-n1_frbrmanifestation-n1_frbrauthor-n1"
+                               GUID="f9d34cba-d819-4468-b6a7-4a3d76046a26"
+                               href="recht.bund.de"/>
+               <akn:FRBRformat eId="meta-n1_ident-n1_frbrmanifestation-n1_frbrformat-n1"
+                               GUID="dcf3aa47-de13-4ef6-9dce-1325a121fb4d"
+                               value="xml"/>
+            </akn:FRBRManifestation>
+         </akn:identification>
+         <akn:lifecycle eId="meta-n1_lebzykl-n1"
+                        GUID="4b31c2c4-6ecc-4f29-9f79-18149603114b"
+                        source="attributsemantik-noch-undefiniert">
+            <akn:eventRef eId="meta-n1_lebzykl-n1_ereignis-n1"
+                          GUID="44e782b4-63ae-4ef0-bb0d-53e42696dd06"
+                          date="2017-03-15"
+                          source="attributsemantik-noch-undefiniert"
+                          type="generation"
+                          refersTo="ausfertigung"/>
+            <akn:eventRef eId="meta-n1_lebzykl-n1_ereignis-n2"
+                          GUID="176435e5-1324-4718-b09a-ef4b63bcacf0"
+                          date="2017-03-16"
+                          source="attributsemantik-noch-undefiniert"
+                          type="generation"
+                          refersTo="inkrafttreten"/>
+         </akn:lifecycle>
+         <akn:analysis eId="meta-n1_analysis-n1"
+                       GUID="c0eb49c8-bf39-4a4a-b324-3b0feb88c1f1"
+                       source="attributsemantik-noch-undefiniert">
+            <akn:activeModifications eId="meta-n1_analysis-n1_activemod-n1"
+                                     GUID="cd241744-ace4-436c-a0e3-dc1ee8caf3ac">
+               <akn:textualMod eId="meta-n1_analysis-n1_activemod-n1_textualmod-n1"
+                               GUID="8992dd02-ab87-42e8-bee2-86b76f587f81"
+                               type="substitution">
+                  <akn:source eId="meta-n1_analysis-n1_activemod-n1_textualmod-n1_source-n1"
+                              GUID="7537d65c-2a3b-440c-80ec-257073b1d1d3"
+                              href="#art-z1_abs-z_untergl-n1_listenelem-n1_inhalt-n1_text-n1_ändbefehl-n1"/>
+                  <akn:destination eId="meta-n1_analysis-n1_activemod-n1_textualmod-n1_destination-n1"
+                                   GUID="83a4e169-ec57-4981-b191-84afe42130c8"
+                                   href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-verkuendung-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34.xml"/>
+                  <akn:force eId="meta-n1_analysis-n1_activemod-n1_textualmod-n1_gelzeitnachw-n1"
+                             GUID="9180eb9f-9da2-4fa4-b57f-803d4ddcdbc9"
+                             period="#meta-n1_geltzeiten-n1_geltungszeitgr-n1"/>
+               </akn:textualMod>
+            </akn:activeModifications>
+         </akn:analysis>
+         <akn:temporalData eId="meta-n1_geltzeiten-n1"
+                           GUID="82854d32-d922-43d7-ac8c-612c07219336"
+                           source="attributsemantik-noch-undefiniert">
+            <akn:temporalGroup eId="meta-n1_geltzeiten-n1_geltungszeitgr-n1"
+                               GUID="ac311ee1-33d3-4b9b-a974-776e55a88396">
+               <akn:timeInterval eId="meta-n1_geltzeiten-n1_geltungszeitgr-n1_gelzeitintervall-n1"
+                                 GUID="ca9f53aa-d374-4bec-aca3-fff4e3485179"
+                                 refersTo="geltungszeit"
+                                 start="#meta-n1_lebzykl-n1_ereignis-n2"/>
+            </akn:temporalGroup>
+         </akn:temporalData>
+         <!-- Diese Metadaten sind die Konstituenten für die Schematron-Validierung. -->
+         <akn:proprietary eId="meta-n1_proprietary-n1"
+                          GUID="fe419055-3201-41b1-b096-402eabcbe6a1"
+                          source="attributsemantik-noch-undefiniert">
+            <regtxt:legalDocML.de_metadaten xmlns:regtxt="http://MetadatenRegelungstext.LegalDocML.de/1.8.1/">
+               <regtxt:typ>verordnung</regtxt:typ>
+               <regtxt:form>mantelform</regtxt:form>
+            </regtxt:legalDocML.de_metadaten>
+            <ris:legalDocML.de_metadaten xmlns:ris="http://MetadatenRIS.LegalDocML.de/1.8.1/">
+               <norms:legalDocML.de_metadaten xmlns:norms="http://MetadatenMods.LegalDocML.de/1.8.1/">
+                  <norms:geltungszeiten>
+                     <norms:geltungszeit id="5e2f4f78-a0a1-4c55-9ef7-ad2821161915" art="inkraft">2017-03-16</norms:geltungszeit>
+                  </norms:geltungszeiten>
+                  <norms:zielnorm-references>
+                     <norms:zielnorm-reference>
+                        <norms:typ>Änderungsvorschrift</norms:typ>
+                        <norms:geltungszeit>5e2f4f78-a0a1-4c55-9ef7-ad2821161915</norms:geltungszeit>
+                        <norms:eid>art-z1_abs-z_untergl-n1_listenelem-n1</norms:eid>
+                        <norms:zielnorm>eli/bund/bgbl-1/1964/s593</norms:zielnorm>
+                     </norms:zielnorm-reference>
+                  </norms:zielnorm-references>
+                  <norms:amended-norm-expressions>
+                     <norms:norm-expression created-by-zeitgrenze="true" created-by-replacing-existing-expression="false">eli/bund/bgbl-1/1964/s593/2017-03-16/1/deu</norms:norm-expression>
+                  </norms:amended-norm-expressions>
+               </norms:legalDocML.de_metadaten>
+            </ris:legalDocML.de_metadaten>
+         </akn:proprietary>
+      </akn:meta>
+      <!-- Dokumentenkopf -->
+      <akn:preface eId="einleitung-n1" GUID="4554f060-e4ef-43a3-b71f-f30aa25769d6">
+         <akn:longTitle eId="einleitung-n1_doktitel-n1"
+                        GUID="185fcdbe-04f8-4b17-ac7c-2208c7f2f9df">
+            <akn:p eId="einleitung-n1_doktitel-n1_text-n1"
+                   GUID="a9694e02-330d-40e3-b0d1-50b2059f020c">
+               <akn:docStage eId="einleitung-n1_doktitel-n1_text-n1_docstadium-n1"
+                             GUID="884b29f7-584f-41e2-9329-d8780d33a3d7">Referentenentwurf</akn:docStage>
+               <akn:docProponent eId="einleitung-n1_doktitel-n1_text-n1_docproponent-n1"
+                                 GUID="20095250-c44a-45a5-b7e3-2b49366ff5a8"> des Bundesministeriums des
+                        Innern</akn:docProponent>
+               <akn:docTitle eId="einleitung-n1_doktitel-n1_text-n1_doctitel-n1"
+                             GUID="e08874b2-05a8-4d6e-9d78-7be24380c54b">Entwurf eines Zweiten Gesetzes zur Änderung des Vereinsgesetzes</akn:docTitle>
+            </akn:p>
+         </akn:longTitle>
+      </akn:preface>
+      <!-- Eingangsformel -->
+      <akn:preamble eId="präambel-n1" GUID="7eae9fd3-d601-40ba-a4a1-f9416d89e586">
+         <akn:formula eId="präambel-n1_formel-n1"
+                      GUID="a7bbd756-c50a-4944-8f64-49134e1166cc"
+                      refersTo="eingangsformel"
+                      name="attributsemantik-noch-undefiniert">
+            <akn:p eId="präambel-n1_formel-n1_text-n1"
+                   GUID="7e0cf2ac-b45a-40b8-8369-c5013ada9f48"> Der <akn:organization eId="präambel-n1_formel-n1_text-n1_org-n1"
+                                 GUID="05004de4-44d4-4e59-a1ef-5912003a6f36"
+                                 refersTo="attributsemantik-noch-undefiniert"
+                                 title="Bundestag">Bundestag</akn:organization> hat
+                    das folgende Gesetz beschlossen:</akn:p>
+         </akn:formula>
+      </akn:preamble>
+      <akn:body eId="hauptteil-n1" GUID="0B4A8E1F-65EF-4B7C-9E22-E83BA6B73CD8">
+            <!-- Artikel 1 : Hauptänderung -->
+         <akn:article eId="art-z1"
+                      GUID="cdbfc728-a070-42d9-ba2f-357945afef06"
+                      period="#meta-n1_geltzeiten-n1_geltungszeitgr-n1"
+                      refersTo="hauptaenderung">
+            <akn:num eId="art-z1_bezeichnung-n1" GUID="25a9acae-7463-4490-bc3f-8258b629d7e9">
+                    Artikel 1</akn:num>
+            <akn:heading eId="art-z1_überschrift-n1" GUID="92827aa8-8118-4207-9f93-589345f0bab6">Änderung des Vereinsgesetzes</akn:heading>
+            <!-- Absatz (1) -->
+            <akn:paragraph eId="art-z1_abs-z" GUID="48ead358-f901-41d3-a135-e372d5ef97b1">
+               <akn:num eId="art-z1_abs-z_bezeichnung-n1"
+                        GUID="ef3a32d2-df20-4978-914b-cd6288872208">
+                    </akn:num>
+               <akn:list eId="art-z1_abs-z_untergl-n1"
+                         GUID="41675622-ed62-46e3-869f-94d99908b010">
+                  <akn:intro eId="art-z1_abs-z_untergl-n1_intro-n1"
+                             GUID="5d6fc824-7926-43b4-b243-b0096da183f9">
+                     <akn:p eId="art-z1_abs-z_untergl-n1_intro-n1_text-n1"
+                            GUID="04879ca1-994b-4eb2-b59b-032e528d9ce5"> Das <akn:affectedDocument eId="art-z1_abs-z_untergl-n1_intro-n1_text-n1_bezugsdoc-n1"
+                                                                                                   GUID="88b3b9f3-e4a8-49c6-9320-b5b42150bcc5"
+                                                                                                   href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-verkuendung-1">Vereinsgesetz vom 5. August 1964 (BGBl. I S. 593), das zuletzt durch … geändert worden ist</akn:affectedDocument>, wird wie folgt geändert:</akn:p>
+                  </akn:intro>
+                 <!-- Nummer 1 wurde entfernt -->
+                 <!-- Nummer 2 -->
+                 <akn:point eId="art-z1_abs-z_untergl-n1_listenelem-n1"
+                            GUID="b5fa1383-f26a-4904-a638-f48711fbcf2d">
+                     <akn:num eId="art-z1_abs-z_untergl-n1_listenelem-n1_bezeichnung-n1"
+                              GUID="6f0f92b3-1a51-440c-9137-b44ab9d990ac">
+                                2.</akn:num>
+                     <akn:content eId="art-z1_abs-z_untergl-n1_listenelem-n1_inhalt-n1"
+                                  GUID="6cb14ab5-3a7f-45f4-9e85-00ac2fb0fe5e">
+                        <akn:p eId="art-z1_abs-z_untergl-n1_listenelem-n1_inhalt-n1_text-n1"
+                               GUID="db3fbe0f-b758-4cc4-b528-a723cacad94a">
+                           <akn:mod eId="art-z1_abs-z_untergl-n1_listenelem-n1_inhalt-n1_text-n1_ändbefehl-n1"
+                                    GUID="148c2f06-6e33-4af8-9f4a-3da67c888510"
+                                    refersTo="aenderungsbefehl-ersetzen">In <akn:ref eId="art-z1_abs-z_untergl-n1_listenelem-n1_inhalt-n1_text-n1_ändbefehl-n1_ref-n1"
+                                                                                     GUID="61d3036a-d7d9-4fa5-b181-c3345caa3206"
+                                                                                     href="eli/bund/bgbl-1/1964/s593/1964-08-05/1/deu/regelungstext-verkuendung-1/hauptteil-1_art-1_abs-1_untergl-1_listenelem-2_inhalt-1_text-1/9-34.xml">§ 20 Absatz 1 Satz 2</akn:ref> wird die Angabe <akn:quotedText eId="art-z1_abs-z_untergl-n1_listenelem-n1_inhalt-n1_text-n1_ändbefehl-n1_quottext-n1"
+                                                                                            GUID="694459c4-ef66-4f87-bb78-a332054a2216"
+                                                                                            startQuote="„"
+                                                                                            endQuote="“">§ 9 Abs. 1 Satz 2, Abs. 2</akn:quotedText> durch die Wörter <akn:quotedText eId="art-z1_abs-z_untergl-n1_listenelem-n1_inhalt-n1_text-n1_ändbefehl-n1_quottext-n2"
+                                                                                            GUID="dd25bdb6-4ef4-4ef5-808c-27579b6ae196"
+                                                                                            startQuote="„"
+                                                                                            endQuote="“">§ 9 Absatz 1 Satz 2, Absatz 2 oder 3</akn:quotedText> ersetzt.</akn:mod>
+                        </akn:p>
+                     </akn:content>
+                  </akn:point>
+               </akn:list>
+            </akn:paragraph>
+         </akn:article>
+         <!-- Artikel 3: Geltungszeitregel-->
+         <akn:article eId="art-z3"
+                      GUID="aaae12b5-0c74-4e51-a286-d6051ff5d21b"
+                      period="#meta-n1_geltzeiten-n1_geltungszeitgr-n1"
+                      refersTo="geltungszeitregel">
+            <akn:num eId="art-z3_bezeichnung-n1" GUID="1bc12642-f00c-4b55-8388-5e8870e6e706">
+                    Artikel 3</akn:num>
+            <akn:heading eId="art-z3_überschrift-n1" GUID="59a7dc28-e095-4da6-ba78-278a0d69a3fd">Inkrafttreten</akn:heading>
+            <!-- Absatz (1) -->
+            <akn:paragraph eId="art-z3_abs-z" GUID="0b1590b0-8945-44a0-bf44-ebfb7d8c3bd8">
+               <akn:num eId="art-z3_abs-z_bezeichnung-n1"
+                        GUID="c46a1cbc-f823-4a18-9b0c-0f131244a58e">
+                    </akn:num>
+               <akn:content eId="art-z3_abs-z_inhalt-n1"
+                            GUID="3e004e1f-f1bc-42a7-8042-2c1d77df81aa">
+                  <akn:p eId="art-z3_abs-z_inhalt-n1_text-n1"
+                         GUID="52406e40-b866-410c-b097-af69e6248f58"> Dieses Gesetz tritt <akn:date eId="art-z3_abs-z_inhalt-n1_text-n1_datum-n1"
+                               GUID="2ee89811-5368-46e0-acf8-a598506cc956"
+                               date="2017-03-16"
+                               refersTo="inkrafttreten-datum">am Tag
+                            nach der Verkündung</akn:date> in Kraft. </akn:p>
+               </akn:content>
+            </akn:paragraph>
+         </akn:article>
+      </akn:body>
+      <!-- Schluss -->
+      <akn:conclusions eId="schluss-n1" GUID="5814d07a-3869-489d-b03e-239304e841cb">
+         <akn:formula eId="schluss-n1_formel-n1"
+                      GUID="a269a1a9-e8ca-471a-a9d4-ce61e9af05aa"
+                      name="attributsemantik-noch-undefiniert"
+                      refersTo="schlussformel">
+            <akn:p eId="schluss-n1_formel-n1_text-n1"
+                   GUID="1354658b-fdb7-46b4-96e2-e194b16ee103">Das vorstehende Gesetz ist hiermit verkündet.</akn:p>
+         </akn:formula>
+         <akn:blockContainer eId="schluss-n1_blockcontainer-n1"
+                             GUID="35e11af5-ff7c-4422-af51-87cff3cc7ceb">
+            <akn:p eId="schluss-n1_blockcontainer-n1_text-n1"
+                   GUID="b55d6230-d71c-49d5-bf86-dab1db53ba6f">
+               <akn:location eId="schluss-n1_blockcontainer-n1_text-n1_ort-n1"
+                             GUID="19ffc7e1-add6-40a4-b9af-2f0927e46e9c"
+                             refersTo="attributsemantik-noch-undefiniert">Bonn</akn:location>, den <akn:date eId="schluss-n1_blockcontainer-n1_text-n1_datum-n1"
+                         GUID="34cf44aa-73a4-4dee-9827-4d890da7aac7"
+                         refersTo="ausfertigung-datum"
+                         date="1964-08-05">5. August 1964</akn:date>
+            </akn:p>
+            <akn:p GUID="d28457d3-8c25-4baf-b599-87bcc05fd480"
+                   eId="schluss-n1_blockcontainer-n1_text-n2">
+               <akn:signature eId="schluss-n1_blockcontainer-n1_text-n2_signatur-n1"
+                              GUID="b092cd1d-2f77-4fe6-a63d-5bcabeb410ad">
+                  <akn:role eId="schluss-n1_blockcontainer-n1_text-n2_signatur-n1_fktbez-n1"
+                            GUID="1cd9ff70-4004-48dc-8c76-7fb295852717"
+                            refersTo="attributsemantik-noch-undefiniert">Der Bundespräsident</akn:role>
+                  <akn:person eId="schluss-n1_blockcontainer-n1_text-n2_signatur-n1_person-n1"
+                              GUID="3d296b9f-6b7d-4c34-a091-23291a39917a"
+                              refersTo="attributsemantik-noch-undefiniert">Lübke</akn:person>
+               </akn:signature>
+            </akn:p>
+            <akn:p GUID="c9227602-3964-4989-93a7-f8aed79de2ee"
+                   eId="schluss-n1_blockcontainer-n1_text-n3">
+               <akn:signature eId="schluss-n1_blockcontainer-n1_text-n3_signatur-n1"
+                              GUID="2c6c0dc9-32b6-46ee-a1fa-9b8a0bc7c193">
+                  <akn:role eId="schluss-n1_blockcontainer-n1_text-n3_signatur-n1_fktbez-n1"
+                            GUID="bea9417f-96d8-4a0b-a923-4541ed04b921"
+                            refersTo="attributsemantik-noch-undefiniert">Der Stellvertreter des Bundeskanzlers</akn:role>
+                  <akn:person eId="schluss-n1_blockcontainer-n1_text-n3_signatur-n1_person-n1"
+                              GUID="33105c66-afdb-4a8d-b397-59c357bf2713"
+                              refersTo="attributsemantik-noch-undefiniert">Mende</akn:person>
+               </akn:signature>
+            </akn:p>
+            <akn:p GUID="32060b74-649e-4746-a41a-12c6de9135de"
+                   eId="schluss-n1_blockcontainer-n1_text-n4">
+               <akn:signature eId="schluss-n1_blockcontainer-n1_text-n4_signatur-n1"
+                              GUID="669a4ce1-2782-4623-8af7-83e7bcf0917a">
+                  <akn:role eId="schluss-n1_blockcontainer-n1_text-n4_signatur-n1_fktbez-n1"
+                            GUID="0732a41f-abe1-4774-b6c0-b4934082ca2c"
+                            refersTo="attributsemantik-noch-undefiniert">Der Bundesminister des Innern</akn:role>
+                  <akn:person eId="schluss-n1_blockcontainer-n1_text-n4_signatur-n1_person-n1"
+                              GUID="a8095a73-f0f1-44ec-8c4e-92bc59ff44a7"
+                              refersTo="attributsemantik-noch-undefiniert">Hermann Höcherl</akn:person>
+               </akn:signature>
+            </akn:p>
+            <akn:p GUID="4e6c9af2-48d5-4341-afd2-5befa4a68106"
+                   eId="schluss-n1_blockcontainer-n1_text-n5">
+               <akn:signature eId="schluss-n1_blockcontainer-n1_text-n5_signatur-n1"
+                              GUID="22a6ce3d-3ae9-4189-bfed-d544efe7e50b">
+                  <akn:role eId="schluss-n1_blockcontainer-n1_text-n5_signatur-n1_fktbez-n1"
+                            GUID="cacb2add-a766-4f2e-ac4a-7b437b226d0d"
+                            refersTo="attributsemantik-noch-undefiniert">Der Bundesminister der Justiz</akn:role>
+                  <akn:person eId="schluss-n1_blockcontainer-n1_text-n5_signatur-n1_person-n1"
+                              GUID="44bb454b-33df-4ee6-a29a-048d7b7f1148"
+                              refersTo="attributsemantik-noch-undefiniert">Bucher</akn:person>
+               </akn:signature>
+            </akn:p>
+         </akn:blockContainer>
+      </akn:conclusions>
+   </akn:act>
+</akn:akomaNtoso>


### PR DESCRIPTION
Instead of commenting out the rules in the sch file, I decided to have a list of disabled rules in our `LdmlValidator` class because:

- More visible than in the sch file
- We can differentiate more easily which rules were already disabled within the standard (currently 4) and which ones are disabled by us
- We don't need to take care of our disabled rules when we do another LDML.de upgrade